### PR TITLE
fix(health_connector_hk_ios): Map blood pressure types to corresponding HealthKit types

### DIFF
--- a/packages/health_connector_hk_ios/ios/health_connector_hk_ios/Sources/health_connector_hk_ios/HealthConnectorClient.swift
+++ b/packages/health_connector_hk_ios/ios/health_connector_hk_ios/Sources/health_connector_hk_ios/HealthConnectorClient.swift
@@ -73,6 +73,12 @@ internal class HealthConnectorClient {
             return .leanBodyMass
         case is HeartRateMeasurementRecordDto:
             return .heartRateMeasurementRecord
+        case is BloodPressureRecordDto:
+            return .bloodPressure
+        case is SystolicBloodPressureRecordDto:
+            return .systolicBloodPressure
+        case is DiastolicBloodPressureRecordDto:
+            return .diastolicBloodPressure
         case is SleepStageRecordDto:
             return .sleepStageRecord
         // Energy & Other Nutrients


### PR DESCRIPTION
### **PR Type**
Bug fix


___

### **Description**
- Add mapping for blood pressure record types to HealthKit

- Support systolic and diastolic blood pressure records

- Enable writing blood pressure data to HealthKit


___

### Diagram Walkthrough


```mermaid
flowchart LR
  BP["Blood Pressure Records"] --> BPR["BloodPressureRecordDto"]
  BP --> SBP["SystolicBloodPressureRecordDto"]
  BP --> DBP["DiastolicBloodPressureRecordDto"]
  BPR -- "maps to" --> HK1[".bloodPressure"]
  SBP -- "maps to" --> HK2[".systolicBloodPressure"]
  DBP -- "maps to" --> HK3[".diastolicBloodPressure"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>HealthConnectorClient.swift</strong><dd><code>Add blood pressure record type mappings</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/health_connector_hk_ios/ios/health_connector_hk_ios/Sources/health_connector_hk_ios/HealthConnectorClient.swift

<ul><li>Added three new case statements for blood pressure record types<br> <li> Maps <code>BloodPressureRecordDto</code> to <code>.bloodPressure</code> HealthKit type<br> <li> Maps <code>SystolicBloodPressureRecordDto</code> to <code>.systolicBloodPressure</code> <br>HealthKit type<br> <li> Maps <code>DiastolicBloodPressureRecordDto</code> to <code>.diastolicBloodPressure</code> <br>HealthKit type</ul>


</details>


  </td>
  <td><a href="https://github.com/fam-tung-lam/health_connector/pull/15/files#diff-7ba7a6730c323361114ecfcd6fd7f2c783b62de742fd417e2b020ed14ed961fb">+6/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

