### PR TITLE
fix(health_connector_hk_ios): Request auth for correlation component types not correlation itself

### DIFF
--- a/packages/health_connector_hk_ios/ios/health_connector_hk_ios/Sources/health_connector_hk_ios/HealthConnectorClient.swift
+++ b/packages/health_connector_hk_ios/ios/health_connector_hk_ios/Sources/health_connector_hk_ios/HealthConnectorClient.swift
@@ -303,14 +303,16 @@ internal class HealthConnectorClient {
             var typesToWrite = Set<HKSampleType>()
 
             for permission in healthDataPermissions {
-                let objectType = permission.toHealthKitObjectType()
+                let objectTypes = permission.toHealthKitObjectTypes()
 
-                switch permission.accessType {
-                case .read:
-                    typesToRead.insert(objectType)
-                case .write:
-                    if let sampleType = objectType as? HKSampleType {
-                        typesToWrite.insert(sampleType)
+                for objectType in objectTypes {
+                    switch permission.accessType {
+                    case .read:
+                        typesToRead.insert(objectType)
+                    case .write:
+                        if let sampleType = objectType as? HKSampleType {
+                            typesToWrite.insert(sampleType)
+                        }
                     }
                 }
             }
@@ -321,7 +323,7 @@ internal class HealthConnectorClient {
             // Create permission request results by checking authorization status
             let results = healthDataPermissions.map {
                 permissionDto -> HealthDataPermissionRequestResultDto in
-                let objectType = permissionDto.toHealthKitObjectType()
+                let objectTypes = permissionDto.toHealthKitObjectTypes()
                 let status: PermissionStatusDto
 
                 switch permissionDto.accessType {
@@ -330,20 +332,24 @@ internal class HealthConnectorClient {
                     status = .unknown
 
                 case .write:
-                    if let sampleType = objectType as? HKSampleType {
-                        let authStatus = store.authorizationStatus(for: sampleType)
-                        switch authStatus {
-                        case .sharingAuthorized:
+                    // Check authorization status for all object types
+                    let sampleTypes = objectTypes.compactMap { $0 as? HKSampleType }
+                    
+                    if sampleTypes.isEmpty {
+                        status = .unknown
+                    } else {
+                        let authStatuses = sampleTypes.map { store.authorizationStatus(for: $0) }
+                        
+                        let allAuthorized = authStatuses.allSatisfy { $0 == .sharingAuthorized }
+                        let allDenied = authStatuses.allSatisfy { $0 == .sharingDenied }
+                        
+                        if allAuthorized {
                             status = .granted
-                        case .sharingDenied:
+                        } else if allDenied {
                             status = .denied
-                        case .notDetermined:
-                            status = .unknown
-                        @unknown default:
+                        } else {
                             status = .unknown
                         }
-                    } else {
-                        status = .unknown
                     }
                 }
 

--- a/packages/health_connector_hk_ios/ios/health_connector_hk_ios/Sources/health_connector_hk_ios/mappers/PermissionMappers.swift
+++ b/packages/health_connector_hk_ios/ios/health_connector_hk_ios/Sources/health_connector_hk_ios/mappers/PermissionMappers.swift
@@ -3,138 +3,175 @@ import HealthKit
 
 /**
  * Extension to convert `HealthDataPermissionDto` to HealthKit types.
- *
- * This extension provides utility methods to map Pigeon DTOs to their corresponding
- * HealthKit types for use with the HealthKit SDK.
  */
 extension HealthDataPermissionDto {
     /**
-     * Converts this permission DTO to a HealthKit `HKObjectType`.
+     * Converts this permission DTO to a list of HealthKit `HKObjectType`.
      *
-     * ## HealthKit Object Types
      * HealthKit uses different object types for different health data:
      * - Quantity types: For data that can be measured (e.g., steps, heart rate)
      * - Category types: For data that falls into categories (e.g., sleep analysis)
      * - Characteristic types: For unchanging data (e.g., blood type, biological sex)
      *
-     * - Returns: The corresponding `HKObjectType` for this health data permission.
-     *            Currently supports:
-     *            - `.steps` → `HKQuantityType.quantityType(forIdentifier: .stepCount)`
-     *            - `.weight` → `HKQuantityType.quantityType(forIdentifier: .bodyMass)`
+     * - Returns: A list of corresponding `HKObjectType` for this health data permission.
+     *            For simple types, returns a single-element array.
+     *            For correlation types, returns the correlation type plus all component types.
      */
-    func toHealthKitObjectType() -> HKObjectType {
+    func toHealthKitObjectTypes() -> [HKObjectType] {
         switch self.healthDataType {
         case .activeCaloriesBurned:
-            return HKQuantityType.quantityType(forIdentifier: .activeEnergyBurned)!
+            return [HKQuantityType.quantityType(forIdentifier: .activeEnergyBurned)!]
         case .distance:
-            return HKQuantityType.quantityType(forIdentifier: .distanceWalkingRunning)!
+            return [HKQuantityType.quantityType(forIdentifier: .distanceWalkingRunning)!]
         case .floorsClimbed:
-            return HKQuantityType.quantityType(forIdentifier: .flightsClimbed)!
+            return [HKQuantityType.quantityType(forIdentifier: .flightsClimbed)!]
         case .height:
-            return HKQuantityType.quantityType(forIdentifier: .height)!
+            return [HKQuantityType.quantityType(forIdentifier: .height)!]
         case .hydration:
-            return HKQuantityType.quantityType(forIdentifier: .dietaryWater)!
+            return [HKQuantityType.quantityType(forIdentifier: .dietaryWater)!]
         case .leanBodyMass:
-            return HKQuantityType.quantityType(forIdentifier: .leanBodyMass)!
+            return [HKQuantityType.quantityType(forIdentifier: .leanBodyMass)!]
         case .bodyFatPercentage:
-            return HKQuantityType.quantityType(forIdentifier: .bodyFatPercentage)!
+            return [HKQuantityType.quantityType(forIdentifier: .bodyFatPercentage)!]
         case .bodyTemperature:
-            return HKQuantityType.quantityType(forIdentifier: .bodyTemperature)!
+            return [HKQuantityType.quantityType(forIdentifier: .bodyTemperature)!]
         case .steps:
-            return HKQuantityType.quantityType(forIdentifier: .stepCount)!
+            return [HKQuantityType.quantityType(forIdentifier: .stepCount)!]
         case .weight:
-            return HKQuantityType.quantityType(forIdentifier: .bodyMass)!
+            return [HKQuantityType.quantityType(forIdentifier: .bodyMass)!]
         case .wheelchairPushes:
-            return HKQuantityType.quantityType(forIdentifier: .pushCount)!
+            return [HKQuantityType.quantityType(forIdentifier: .pushCount)!]
         case .heartRateMeasurementRecord:
-            return HKQuantityType.quantityType(forIdentifier: .heartRate)!
+            return [HKQuantityType.quantityType(forIdentifier: .heartRate)!]
         case .sleepStageRecord:
-            // Sleep stages use HKCategoryType, not HKQuantityType
-            return HKCategoryType.categoryType(forIdentifier: .sleepAnalysis)!
+            return [HKCategoryType.categoryType(forIdentifier: .sleepAnalysis)!]
 
         // MARK: Nutrients
 
         case .energyNutrient:
-            return HKQuantityType.quantityType(forIdentifier: .dietaryEnergyConsumed)!
+            return [HKQuantityType.quantityType(forIdentifier: .dietaryEnergyConsumed)!]
         case .caffeine:
-            return HKQuantityType.quantityType(forIdentifier: .dietaryCaffeine)!
-
+            return [HKQuantityType.quantityType(forIdentifier: .dietaryCaffeine)!]
         case .protein:
-            return HKQuantityType.quantityType(forIdentifier: .dietaryProtein)!
+            return [HKQuantityType.quantityType(forIdentifier: .dietaryProtein)!]
         case .totalCarbohydrate:
-            return HKQuantityType.quantityType(forIdentifier: .dietaryCarbohydrates)!
+            return [HKQuantityType.quantityType(forIdentifier: .dietaryCarbohydrates)!]
         case .totalFat:
-            return HKQuantityType.quantityType(forIdentifier: .dietaryFatTotal)!
+            return [HKQuantityType.quantityType(forIdentifier: .dietaryFatTotal)!]
         case .saturatedFat:
-            return HKQuantityType.quantityType(forIdentifier: .dietaryFatSaturated)!
+            return [HKQuantityType.quantityType(forIdentifier: .dietaryFatSaturated)!]
         case .monounsaturatedFat:
-            return HKQuantityType.quantityType(forIdentifier: .dietaryFatMonounsaturated)!
+            return [HKQuantityType.quantityType(forIdentifier: .dietaryFatMonounsaturated)!]
         case .polyunsaturatedFat:
-            return HKQuantityType.quantityType(forIdentifier: .dietaryFatPolyunsaturated)!
+            return [HKQuantityType.quantityType(forIdentifier: .dietaryFatPolyunsaturated)!]
         case .cholesterol:
-            return HKQuantityType.quantityType(forIdentifier: .dietaryCholesterol)!
+            return [HKQuantityType.quantityType(forIdentifier: .dietaryCholesterol)!]
         case .dietaryFiber:
-            return HKQuantityType.quantityType(forIdentifier: .dietaryFiber)!
+            return [HKQuantityType.quantityType(forIdentifier: .dietaryFiber)!]
         case .sugar:
-            return HKQuantityType.quantityType(forIdentifier: .dietarySugar)!
-
+            return [HKQuantityType.quantityType(forIdentifier: .dietarySugar)!]
         case .vitaminA:
-            return HKQuantityType.quantityType(forIdentifier: .dietaryVitaminA)!
+            return [HKQuantityType.quantityType(forIdentifier: .dietaryVitaminA)!]
         case .vitaminB6:
-            return HKQuantityType.quantityType(forIdentifier: .dietaryVitaminB6)!
+            return [HKQuantityType.quantityType(forIdentifier: .dietaryVitaminB6)!]
         case .vitaminB12:
-            return HKQuantityType.quantityType(forIdentifier: .dietaryVitaminB12)!
+            return [HKQuantityType.quantityType(forIdentifier: .dietaryVitaminB12)!]
         case .vitaminC:
-            return HKQuantityType.quantityType(forIdentifier: .dietaryVitaminC)!
+            return [HKQuantityType.quantityType(forIdentifier: .dietaryVitaminC)!]
         case .vitaminD:
-            return HKQuantityType.quantityType(forIdentifier: .dietaryVitaminD)!
+            return [HKQuantityType.quantityType(forIdentifier: .dietaryVitaminD)!]
         case .vitaminE:
-            return HKQuantityType.quantityType(forIdentifier: .dietaryVitaminE)!
+            return [HKQuantityType.quantityType(forIdentifier: .dietaryVitaminE)!]
         case .vitaminK:
-            return HKQuantityType.quantityType(forIdentifier: .dietaryVitaminK)!
+            return [HKQuantityType.quantityType(forIdentifier: .dietaryVitaminK)!]
         case .thiamin:
-            return HKQuantityType.quantityType(forIdentifier: .dietaryThiamin)!
+            return [HKQuantityType.quantityType(forIdentifier: .dietaryThiamin)!]
         case .riboflavin:
-            return HKQuantityType.quantityType(forIdentifier: .dietaryRiboflavin)!
+            return [HKQuantityType.quantityType(forIdentifier: .dietaryRiboflavin)!]
         case .niacin:
-            return HKQuantityType.quantityType(forIdentifier: .dietaryNiacin)!
+            return [HKQuantityType.quantityType(forIdentifier: .dietaryNiacin)!]
         case .folate:
-            return HKQuantityType.quantityType(forIdentifier: .dietaryFolate)!
+            return [HKQuantityType.quantityType(forIdentifier: .dietaryFolate)!]
         case .biotin:
-            return HKQuantityType.quantityType(forIdentifier: .dietaryBiotin)!
+            return [HKQuantityType.quantityType(forIdentifier: .dietaryBiotin)!]
         case .pantothenicAcid:
-            return HKQuantityType.quantityType(forIdentifier: .dietaryPantothenicAcid)!
-
+            return [HKQuantityType.quantityType(forIdentifier: .dietaryPantothenicAcid)!]
         case .calcium:
-            return HKQuantityType.quantityType(forIdentifier: .dietaryCalcium)!
+            return [HKQuantityType.quantityType(forIdentifier: .dietaryCalcium)!]
         case .iron:
-            return HKQuantityType.quantityType(forIdentifier: .dietaryIron)!
+            return [HKQuantityType.quantityType(forIdentifier: .dietaryIron)!]
         case .magnesium:
-            return HKQuantityType.quantityType(forIdentifier: .dietaryMagnesium)!
+            return [HKQuantityType.quantityType(forIdentifier: .dietaryMagnesium)!]
         case .manganese:
-            return HKQuantityType.quantityType(forIdentifier: .dietaryManganese)!
+            return [HKQuantityType.quantityType(forIdentifier: .dietaryManganese)!]
         case .phosphorus:
-            return HKQuantityType.quantityType(forIdentifier: .dietaryPhosphorus)!
+            return [HKQuantityType.quantityType(forIdentifier: .dietaryPhosphorus)!]
         case .potassium:
-            return HKQuantityType.quantityType(forIdentifier: .dietaryPotassium)!
+            return [HKQuantityType.quantityType(forIdentifier: .dietaryPotassium)!]
         case .selenium:
-            return HKQuantityType.quantityType(forIdentifier: .dietarySelenium)!
+            return [HKQuantityType.quantityType(forIdentifier: .dietarySelenium)!]
         case .sodium:
-            return HKQuantityType.quantityType(forIdentifier: .dietarySodium)!
+            return [HKQuantityType.quantityType(forIdentifier: .dietarySodium)!]
         case .zinc:
-            return HKQuantityType.quantityType(forIdentifier: .dietaryZinc)!
+            return [HKQuantityType.quantityType(forIdentifier: .dietaryZinc)!]
 
         // MARK: Correlation Types
+
         case .nutrition:
-            // Nutrition is a correlation type (HKCorrelation.food)
-            return HKCorrelationType.correlationType(forIdentifier: .food)!
+            // Nutrition is a correlation type (HKCorrelation.food) but HealthKit requires
+            // requesting permissions for the individual quantity types, not the correlation type itself
+            return [
+                // Energy & Other
+                HKQuantityType.quantityType(forIdentifier: .dietaryEnergyConsumed)!,
+                HKQuantityType.quantityType(forIdentifier: .dietaryCaffeine)!,
+                // Macronutrients
+                HKQuantityType.quantityType(forIdentifier: .dietaryProtein)!,
+                HKQuantityType.quantityType(forIdentifier: .dietaryCarbohydrates)!,
+                HKQuantityType.quantityType(forIdentifier: .dietaryFatTotal)!,
+                HKQuantityType.quantityType(forIdentifier: .dietaryFatSaturated)!,
+                HKQuantityType.quantityType(forIdentifier: .dietaryFatMonounsaturated)!,
+                HKQuantityType.quantityType(forIdentifier: .dietaryFatPolyunsaturated)!,
+                HKQuantityType.quantityType(forIdentifier: .dietaryCholesterol)!,
+                HKQuantityType.quantityType(forIdentifier: .dietaryFiber)!,
+                HKQuantityType.quantityType(forIdentifier: .dietarySugar)!,
+                // Vitamins
+                HKQuantityType.quantityType(forIdentifier: .dietaryVitaminA)!,
+                HKQuantityType.quantityType(forIdentifier: .dietaryVitaminB6)!,
+                HKQuantityType.quantityType(forIdentifier: .dietaryVitaminB12)!,
+                HKQuantityType.quantityType(forIdentifier: .dietaryVitaminC)!,
+                HKQuantityType.quantityType(forIdentifier: .dietaryVitaminD)!,
+                HKQuantityType.quantityType(forIdentifier: .dietaryVitaminE)!,
+                HKQuantityType.quantityType(forIdentifier: .dietaryVitaminK)!,
+                HKQuantityType.quantityType(forIdentifier: .dietaryThiamin)!,
+                HKQuantityType.quantityType(forIdentifier: .dietaryRiboflavin)!,
+                HKQuantityType.quantityType(forIdentifier: .dietaryNiacin)!,
+                HKQuantityType.quantityType(forIdentifier: .dietaryFolate)!,
+                HKQuantityType.quantityType(forIdentifier: .dietaryBiotin)!,
+                HKQuantityType.quantityType(forIdentifier: .dietaryPantothenicAcid)!,
+                // Minerals
+                HKQuantityType.quantityType(forIdentifier: .dietaryCalcium)!,
+                HKQuantityType.quantityType(forIdentifier: .dietaryIron)!,
+                HKQuantityType.quantityType(forIdentifier: .dietaryMagnesium)!,
+                HKQuantityType.quantityType(forIdentifier: .dietaryManganese)!,
+                HKQuantityType.quantityType(forIdentifier: .dietaryPhosphorus)!,
+                HKQuantityType.quantityType(forIdentifier: .dietaryPotassium)!,
+                HKQuantityType.quantityType(forIdentifier: .dietarySelenium)!,
+                HKQuantityType.quantityType(forIdentifier: .dietarySodium)!,
+                HKQuantityType.quantityType(forIdentifier: .dietaryZinc)!,
+                // Water
+                HKQuantityType.quantityType(forIdentifier: .dietaryWater)!,
+            ]
         case .bloodPressure:
-            // Blood pressure is a correlation type (HKCorrelation.bloodPressure)
-            return HKCorrelationType.correlationType(forIdentifier: .bloodPressure)!
+            // Blood pressure is a correlation type (HKCorrelation.bloodPressure) but HealthKit requires
+            // requesting permissions for the individual quantity types, not the correlation type itself
+            return [
+                HKQuantityType.quantityType(forIdentifier: .bloodPressureSystolic)!,
+                HKQuantityType.quantityType(forIdentifier: .bloodPressureDiastolic)!,
+            ]
         case .systolicBloodPressure:
-            return HKQuantityType.quantityType(forIdentifier: .bloodPressureSystolic)!
+            return [HKQuantityType.quantityType(forIdentifier: .bloodPressureSystolic)!]
         case .diastolicBloodPressure:
-            return HKQuantityType.quantityType(forIdentifier: .bloodPressureDiastolic)!
+            return [HKQuantityType.quantityType(forIdentifier: .bloodPressureDiastolic)!]
         }
     }
 }


### PR DESCRIPTION
### **User description**
HealthKit requires requesting authorization for individual component types (e.g., systolic/diastolic for blood pressure, individual nutrients for nutrition) rather than the correlation type itself.

Updated permission mappers to return component quantity types for `.nutrition` and `.bloodPressure` correlation types.


___

### **PR Type**
Bug fix


___

### **Description**
- Changed permission mapper to return component types for correlation types

- Nutrition correlation now returns all individual nutrient quantity types

- Blood pressure correlation now returns systolic and diastolic quantity types

- Updated authorization request logic to handle multiple object types per permission

- Fixed authorization status checking to aggregate results across component types


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Permission DTO"] -->|toHealthKitObjectTypes| B["Array of HKObjectType"]
  B -->|Correlation Type| C["Component Types"]
  C -->|Nutrition| D["All Nutrient Types"]
  C -->|Blood Pressure| E["Systolic + Diastolic"]
  B -->|Simple Type| F["Single Type Array"]
  D -->|Request Auth| G["HealthKit Authorization"]
  E -->|Request Auth| G
  F -->|Request Auth| G
  G -->|Check Status| H["Aggregate Results"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>HealthConnectorClient.swift</strong><dd><code>Update authorization handling for multiple object types</code>&nbsp; &nbsp; </dd></summary>
<hr>

packages/health_connector_hk_ios/ios/health_connector_hk_ios/Sources/health_connector_hk_ios/HealthConnectorClient.swift

<ul><li>Changed <code>toHealthKitObjectType()</code> to <code>toHealthKitObjectTypes()</code> to handle <br>multiple types per permission<br> <li> Updated permission processing loop to iterate over returned object <br>types array<br> <li> Modified authorization status checking to aggregate results across <br>multiple sample types<br> <li> Implemented logic to determine overall permission status based on all <br>component types</ul>


</details>


  </td>
  <td><a href="https://github.com/fam-tung-lam/health_connector/pull/20/files#diff-7ba7a6730c323361114ecfcd6fd7f2c783b62de742fd417e2b020ed14ed961fb">+25/-19</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>PermissionMappers.swift</strong><dd><code>Map correlation types to component quantity types</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/health_connector_hk_ios/ios/health_connector_hk_ios/Sources/health_connector_hk_ios/mappers/PermissionMappers.swift

<ul><li>Renamed <code>toHealthKitObjectType()</code> to <code>toHealthKitObjectTypes()</code> returning <br>array instead of single type<br> <li> Updated all simple health data types to return single-element arrays<br> <li> Expanded <code>.nutrition</code> correlation type to return all individual nutrient <br>quantity types instead of correlation type<br> <li> Expanded <code>.bloodPressure</code> correlation type to return systolic and <br>diastolic quantity types instead of correlation type<br> <li> Updated documentation to reflect component type authorization <br>requirement</ul>


</details>


  </td>
  <td><a href="https://github.com/fam-tung-lam/health_connector/pull/20/files#diff-426eaaec7b48b08c16fdb8f53512597d2569b054086367af6f9d0f1d0b4015c6">+103/-66</a></td>

</tr>
</table></td></tr></tbody></table>

</details>

___

