### PR TITLE
fix(health_connector_hc_android,health_connector_hk_ios): Prevent infinite recursion in nutrient record mappers

### DIFF
--- a/packages/health_connector_hc_android/lib/src/mappers/health_record_mapper.dart
+++ b/packages/health_connector_hc_android/lib/src/mappers/health_record_mapper.dart
@@ -14,14 +14,46 @@ import 'package:health_connector_core/health_connector_core.dart'
         HeightRecord,
         HydrationRecord,
         LeanBodyMassRecord,
-        NutrientHealthRecord,
         NutritionRecord,
         SleepSessionRecord,
         SleepStageRecord,
         StepRecord,
         SystolicBloodPressureRecord,
         WeightRecord,
-        WheelchairPushesRecord;
+        WheelchairPushesRecord,
+        PhosphorusNutrientRecord,
+        EnergyNutrientRecord,
+        CaffeineNutrientRecord,
+        ProteinNutrientRecord,
+        TotalCarbohydrateNutrientRecord,
+        TotalFatNutrientRecord,
+        SaturatedFatNutrientRecord,
+        MonounsaturatedFatNutrientRecord,
+        PolyunsaturatedFatNutrientRecord,
+        CholesterolNutrientRecord,
+        DietaryFiberNutrientRecord,
+        SugarNutrientRecord,
+        VitaminANutrientRecord,
+        VitaminB6NutrientRecord,
+        VitaminB12NutrientRecord,
+        VitaminCNutrientRecord,
+        VitaminDNutrientRecord,
+        VitaminENutrientRecord,
+        VitaminKNutrientRecord,
+        ThiaminNutrientRecord,
+        RiboflavinNutrientRecord,
+        NiacinNutrientRecord,
+        FolateNutrientRecord,
+        BiotinNutrientRecord,
+        PantothenicAcidNutrientRecord,
+        CalciumNutrientRecord,
+        IronNutrientRecord,
+        MagnesiumNutrientRecord,
+        ManganeseNutrientRecord,
+        PotassiumNutrientRecord,
+        SeleniumNutrientRecord,
+        SodiumNutrientRecord,
+        ZincNutrientRecord;
 import 'package:health_connector_hc_android/src/mappers/health_record_mappers/health_record_mappers.dart';
 import 'package:health_connector_hc_android/src/pigeon/health_connector_platform_api.g.dart'
     show
@@ -74,7 +106,71 @@ extension HealthRecordToDto on HealthRecord {
         return record.toDto();
       case final SleepSessionRecord record:
         return record.toDto();
-      case final NutrientHealthRecord record:
+      case final EnergyNutrientRecord record:
+        return record.toDto();
+      case final CaffeineNutrientRecord record:
+        return record.toDto();
+      case final ProteinNutrientRecord record:
+        return record.toDto();
+      case final TotalCarbohydrateNutrientRecord record:
+        return record.toDto();
+      case final TotalFatNutrientRecord record:
+        return record.toDto();
+      case final SaturatedFatNutrientRecord record:
+        return record.toDto();
+      case final MonounsaturatedFatNutrientRecord record:
+        return record.toDto();
+      case final PolyunsaturatedFatNutrientRecord record:
+        return record.toDto();
+      case final CholesterolNutrientRecord record:
+        return record.toDto();
+      case final DietaryFiberNutrientRecord record:
+        return record.toDto();
+      case final SugarNutrientRecord record:
+        return record.toDto();
+      case final VitaminANutrientRecord record:
+        return record.toDto();
+      case final VitaminB6NutrientRecord record:
+        return record.toDto();
+      case final VitaminB12NutrientRecord record:
+        return record.toDto();
+      case final VitaminCNutrientRecord record:
+        return record.toDto();
+      case final VitaminDNutrientRecord record:
+        return record.toDto();
+      case final VitaminENutrientRecord record:
+        return record.toDto();
+      case final VitaminKNutrientRecord record:
+        return record.toDto();
+      case final ThiaminNutrientRecord record:
+        return record.toDto();
+      case final RiboflavinNutrientRecord record:
+        return record.toDto();
+      case final NiacinNutrientRecord record:
+        return record.toDto();
+      case final FolateNutrientRecord record:
+        return record.toDto();
+      case final BiotinNutrientRecord record:
+        return record.toDto();
+      case final PantothenicAcidNutrientRecord record:
+        return record.toDto();
+      case final CalciumNutrientRecord record:
+        return record.toDto();
+      case final IronNutrientRecord record:
+        return record.toDto();
+      case final MagnesiumNutrientRecord record:
+        return record.toDto();
+      case final ManganeseNutrientRecord record:
+        return record.toDto();
+      case final PhosphorusNutrientRecord record:
+        return record.toDto();
+      case final PotassiumNutrientRecord record:
+        return record.toDto();
+      case final SeleniumNutrientRecord record:
+        return record.toDto();
+      case final SodiumNutrientRecord record:
+        return record.toDto();
+      case final ZincNutrientRecord record:
         return record.toDto();
       case final NutritionRecord record:
         return record.toDto();

--- a/packages/health_connector_hk_ios/lib/src/mappers/health_record_mapper.dart
+++ b/packages/health_connector_hk_ios/lib/src/mappers/health_record_mapper.dart
@@ -1,26 +1,58 @@
 import 'package:health_connector_core/health_connector_core.dart'
     show
         ActiveCaloriesBurnedRecord,
+        BiotinNutrientRecord,
         BloodPressureRecord,
         BodyFatPercentageRecord,
         BodyTemperatureRecord,
+        CaffeineNutrientRecord,
+        CalciumNutrientRecord,
+        CholesterolNutrientRecord,
+        DietaryFiberNutrientRecord,
         DiastolicBloodPressureRecord,
         DistanceRecord,
+        EnergyNutrientRecord,
         FloorsClimbedRecord,
+        FolateNutrientRecord,
         HealthRecord,
         HeartRateMeasurementRecord,
         HeartRateSeriesRecord,
         HeightRecord,
         HydrationRecord,
+        IronNutrientRecord,
         LeanBodyMassRecord,
+        MagnesiumNutrientRecord,
+        ManganeseNutrientRecord,
+        MonounsaturatedFatNutrientRecord,
+        NiacinNutrientRecord,
         NutritionRecord,
+        PantothenicAcidNutrientRecord,
+        PhosphorusNutrientRecord,
+        PolyunsaturatedFatNutrientRecord,
+        PotassiumNutrientRecord,
+        ProteinNutrientRecord,
+        RiboflavinNutrientRecord,
+        SaturatedFatNutrientRecord,
+        SeleniumNutrientRecord,
         SleepSessionRecord,
         SleepStageRecord,
+        SodiumNutrientRecord,
         StepRecord,
+        SugarNutrientRecord,
         SystolicBloodPressureRecord,
+        ThiaminNutrientRecord,
+        TotalCarbohydrateNutrientRecord,
+        TotalFatNutrientRecord,
+        VitaminANutrientRecord,
+        VitaminB12NutrientRecord,
+        VitaminB6NutrientRecord,
+        VitaminCNutrientRecord,
+        VitaminDNutrientRecord,
+        VitaminENutrientRecord,
+        VitaminKNutrientRecord,
         WeightRecord,
         WheelchairPushesRecord,
-        NutrientHealthRecord;
+        ZincNutrientRecord;
 import 'package:health_connector_hk_ios/src/mappers/health_record_mappers/health_record_mappers.dart';
 import 'package:health_connector_hk_ios/src/pigeon/health_connector_platform_api.g.dart'
     show
@@ -110,7 +142,71 @@ extension HealthRecordToDto on HealthRecord {
         return record.toDto();
       case final NutritionRecord record:
         return record.toDto();
-      case final NutrientHealthRecord record:
+      case final EnergyNutrientRecord record:
+        return record.toDto();
+      case final CaffeineNutrientRecord record:
+        return record.toDto();
+      case final ProteinNutrientRecord record:
+        return record.toDto();
+      case final TotalCarbohydrateNutrientRecord record:
+        return record.toDto();
+      case final TotalFatNutrientRecord record:
+        return record.toDto();
+      case final SaturatedFatNutrientRecord record:
+        return record.toDto();
+      case final MonounsaturatedFatNutrientRecord record:
+        return record.toDto();
+      case final PolyunsaturatedFatNutrientRecord record:
+        return record.toDto();
+      case final CholesterolNutrientRecord record:
+        return record.toDto();
+      case final DietaryFiberNutrientRecord record:
+        return record.toDto();
+      case final SugarNutrientRecord record:
+        return record.toDto();
+      case final VitaminANutrientRecord record:
+        return record.toDto();
+      case final VitaminB6NutrientRecord record:
+        return record.toDto();
+      case final VitaminB12NutrientRecord record:
+        return record.toDto();
+      case final VitaminCNutrientRecord record:
+        return record.toDto();
+      case final VitaminDNutrientRecord record:
+        return record.toDto();
+      case final VitaminENutrientRecord record:
+        return record.toDto();
+      case final VitaminKNutrientRecord record:
+        return record.toDto();
+      case final ThiaminNutrientRecord record:
+        return record.toDto();
+      case final RiboflavinNutrientRecord record:
+        return record.toDto();
+      case final NiacinNutrientRecord record:
+        return record.toDto();
+      case final FolateNutrientRecord record:
+        return record.toDto();
+      case final BiotinNutrientRecord record:
+        return record.toDto();
+      case final PantothenicAcidNutrientRecord record:
+        return record.toDto();
+      case final CalciumNutrientRecord record:
+        return record.toDto();
+      case final IronNutrientRecord record:
+        return record.toDto();
+      case final MagnesiumNutrientRecord record:
+        return record.toDto();
+      case final ManganeseNutrientRecord record:
+        return record.toDto();
+      case final PhosphorusNutrientRecord record:
+        return record.toDto();
+      case final PotassiumNutrientRecord record:
+        return record.toDto();
+      case final SeleniumNutrientRecord record:
+        return record.toDto();
+      case final SodiumNutrientRecord record:
+        return record.toDto();
+      case final ZincNutrientRecord record:
         return record.toDto();
       case final BloodPressureRecord record:
         return record.toDto();


### PR DESCRIPTION
### **User description**
The sealed class `NutrientHealthRecord` was causing infinite recursion when its `toDto()` method was called, as it would resolve back to `HealthRecordToDto.toDto()` extension method.

Caused by separating health record mapper files for each health record type in GIT commits:
- e72390d255423fb4a59af2d11c7921a43ef02daf
- a5763c3750648a8c76f4519de43821c311e615af

Replaced catch-all `NutrientHealthRecord` case with individual cases for each concrete subtype to prevent stack overflow when converting nutrient records to DTOs.


___

### **PR Type**
Bug fix


___

### **Description**
- Replace generic `NutrientHealthRecord` case with 32 specific nutrient record types

- Prevent infinite recursion in `toDto()` extension method calls

- Add explicit imports for all concrete nutrient record subtypes

- Apply fix to both Android and iOS health connector packages


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Generic NutrientHealthRecord case"] -->|causes infinite recursion| B["toDto() extension method"]
  B -->|resolves back to| A
  C["32 specific nutrient record cases"] -->|direct mapping| D["Individual toDto() methods"]
  D -->|no recursion| E["DTO conversion complete"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>health_record_mapper.dart</strong><dd><code>Replace generic nutrient record with specific types</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/health_connector_hc_android/lib/src/mappers/health_record_mapper.dart

<ul><li>Removed generic <code>NutrientHealthRecord</code> import and case statement<br> <li> Added 32 specific nutrient record type imports (Energy, Caffeine, <br>Protein, Vitamins, Minerals, etc.)<br> <li> Replaced single catch-all case with 32 individual pattern matching <br>cases<br> <li> Each case directly calls the concrete type's <code>toDto()</code> method</ul>


</details>


  </td>
  <td><a href="https://github.com/fam-tung-lam/health_connector/pull/22/files#diff-4a60d19e8ecf3ee0dc56018254f6b05949146a86a49809d3c73536b84f0505d0">+99/-3</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>health_record_mapper.dart</strong><dd><code>Replace generic nutrient record with specific types</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/health_connector_hk_ios/lib/src/mappers/health_record_mapper.dart

<ul><li>Removed generic <code>NutrientHealthRecord</code> import and case statement<br> <li> Added 32 specific nutrient record type imports in alphabetical order<br> <li> Replaced single catch-all case with 32 individual pattern matching <br>cases<br> <li> Each case directly calls the concrete type's <code>toDto()</code> method</ul>


</details>


  </td>
  <td><a href="https://github.com/fam-tung-lam/health_connector/pull/22/files#diff-e70caaaef533eba517f09158a99e095f57371faecd7726c9f212b417a446c0a1">+98/-2</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

