### PR TITLE
feat(health_connector_core,health_connector_hc_android,health_connector_hk_iod)!: Standardize and synchronize error codes across platforms

### DIFF
--- a/examples/health_connector_toolbox/lib/src/features/aggregate_health_data/pages/aggregate_health_data_page.dart
+++ b/examples/health_connector_toolbox/lib/src/features/aggregate_health_data/pages/aggregate_health_data_page.dart
@@ -657,8 +657,7 @@ class _AggregateHealthDataPageState
         return;
       }
 
-      final message =
-          e.code == HealthConnectorErrorCode.unsupportedHealthPlatformApi
+      final message = e.code == HealthConnectorErrorCode.unsupportedOperation
           ? AppTexts.readPermissionDenied
           : e.message;
       showAppSnackBar(context, SnackBarType.error, message);

--- a/examples/health_connector_toolbox/lib/src/features/permissions/pages/permissions_page.dart
+++ b/examples/health_connector_toolbox/lib/src/features/permissions/pages/permissions_page.dart
@@ -431,8 +431,7 @@ final class PermissionsPage extends StatelessWidget {
       if (!context.mounted) {
         return;
       }
-      final message =
-          e.code == HealthConnectorErrorCode.unsupportedHealthPlatformApi
+      final message = e.code == HealthConnectorErrorCode.unsupportedOperation
           ? '${AppTexts.failedToRequestPermissions} ${e.message}'
           : e.message;
       showAppSnackBar(context, SnackBarType.error, message);

--- a/examples/health_connector_toolbox/lib/src/features/read_health_records/pages/read_health_records_page.dart
+++ b/examples/health_connector_toolbox/lib/src/features/read_health_records/pages/read_health_records_page.dart
@@ -443,8 +443,7 @@ class _ReadHealthRecordsPageState
         return;
       }
 
-      final message =
-          e.code == HealthConnectorErrorCode.unsupportedHealthPlatformApi
+      final message = e.code == HealthConnectorErrorCode.unsupportedOperation
           ? AppTexts.readPermissionDenied
           : e.message;
       showAppSnackBar(context, SnackBarType.error, message);
@@ -519,8 +518,7 @@ class _ReadHealthRecordsPageState
         return;
       }
 
-      final message =
-          e.code == HealthConnectorErrorCode.unsupportedHealthPlatformApi
+      final message = e.code == HealthConnectorErrorCode.unsupportedOperation
           ? AppTexts.readPermissionDenied
           : e.message;
       showAppSnackBar(context, SnackBarType.error, message);

--- a/examples/health_connector_toolbox/lib/src/features/write_health_record/pages/write_health_record_form_page.dart
+++ b/examples/health_connector_toolbox/lib/src/features/write_health_record/pages/write_health_record_form_page.dart
@@ -582,7 +582,7 @@ class _WriteHealthRecordFormPageState extends State<WriteHealthRecordFormPage> {
   }
 
   String _getErrorMessage(HealthConnectorException e) {
-    if (e.code == HealthConnectorErrorCode.unsupportedHealthPlatformApi) {
+    if (e.code == HealthConnectorErrorCode.unsupportedOperation) {
       return switch (widget.dataType) {
         StepsHealthDataType() => AppTexts.writePermissionDeniedSteps,
         WeightHealthDataType() => AppTexts.writePermissionDeniedWeight,

--- a/packages/health_connector/example/lib/main.dart
+++ b/packages/health_connector/example/lib/main.dart
@@ -285,7 +285,7 @@ class _ExampleAppHomePageState extends State<ExampleAppHomePage> {
       if (!mounted) {
         return;
       }
-      if (e.code == HealthConnectorErrorCode.unsupportedHealthPlatformApi) {
+      if (e.code == HealthConnectorErrorCode.unsupportedOperation) {
         _showError(
           'getGrantedPermissions is only available on Health Connect. '
           'HealthKit does not allow querying granted permissions.',
@@ -329,7 +329,7 @@ class _ExampleAppHomePageState extends State<ExampleAppHomePage> {
       if (!mounted) {
         return;
       }
-      if (e.code == HealthConnectorErrorCode.unsupportedHealthPlatformApi) {
+      if (e.code == HealthConnectorErrorCode.unsupportedOperation) {
         _showError(
           'revokeAllPermissions is only available on Health Connect. '
           'On iOS, users must revoke permissions manually in Settings.',

--- a/packages/health_connector/lib/src/health_connector.dart
+++ b/packages/health_connector/lib/src/health_connector.dart
@@ -64,10 +64,10 @@ final class HealthConnector {
   /// ## Throws
   ///
   /// - [HealthConnectorException] with
-  ///   [HealthConnectorErrorCode.healthPlatformUnavailable]
+  ///   [HealthConnectorErrorCode.healthProviderUnavailable]
   ///   if Health platform is unavailable on this device.
   /// - [HealthConnectorException] with
-  ///   [HealthConnectorErrorCode.installationOrUpdateRequired]
+  ///   [HealthConnectorErrorCode.healthProviderNotInstalledOrUpdateRequired]
   ///   if Health platform installation or update is required.
   /// - [HealthConnectorException] with [HealthConnectorErrorCode.unknown]
   ///   if an unexpected error occurs
@@ -94,7 +94,7 @@ final class HealthConnector {
         );
 
         throw HealthConnectorException(
-          HealthConnectorErrorCode.healthPlatformUnavailable,
+          HealthConnectorErrorCode.healthProviderUnavailable,
           '$healthPlatform is not available.',
         );
       case HealthPlatformStatus.installationOrUpdateRequired:
@@ -107,7 +107,7 @@ final class HealthConnector {
         );
 
         throw HealthConnectorException(
-          HealthConnectorErrorCode.installationOrUpdateRequired,
+          HealthConnectorErrorCode.healthProviderNotInstalledOrUpdateRequired,
           '$healthPlatform needs installation or update.',
         );
       case HealthPlatformStatus.available:
@@ -221,7 +221,7 @@ final class HealthConnector {
   /// ## Throws
   ///
   /// - [HealthConnectorException] with
-  ///   [HealthConnectorErrorCode.invalidPlatformConfiguration] if
+  ///   [HealthConnectorErrorCode.invalidConfiguration] if
   ///    required permissions are missing from platform configuration
   /// - [HealthConnectorException] with [HealthConnectorErrorCode.unknown]
   ///   if unexpected error occurs
@@ -314,7 +314,7 @@ final class HealthConnector {
   /// ## Throws
   ///
   /// - [HealthConnectorException] with
-  ///   [HealthConnectorErrorCode.unsupportedHealthPlatformApi] if
+  ///   [HealthConnectorErrorCode.unsupportedOperation] if
   ///   this API is not supported on the current platform
   /// - [HealthConnectorException] if the platform request fails or
   ///   returns invalid data
@@ -364,7 +364,7 @@ final class HealthConnector {
         );
 
         throw const HealthConnectorException(
-          HealthConnectorErrorCode.unsupportedHealthPlatformApi,
+          HealthConnectorErrorCode.unsupportedOperation,
           'getGrantedPermissions is only available on Health Connect. ',
         );
       case HealthPlatform.healthConnect:
@@ -401,7 +401,7 @@ final class HealthConnector {
   /// ## Throws
   ///
   /// - [HealthConnectorException] with
-  ///   [HealthConnectorErrorCode.unsupportedHealthPlatformApi] if this API is
+  ///   [HealthConnectorErrorCode.unsupportedOperation] if this API is
   ///   not supported on the current platform
   /// - [HealthConnectorException] if the platform request fails
   ///
@@ -442,7 +442,7 @@ final class HealthConnector {
         );
 
         throw const HealthConnectorException(
-          HealthConnectorErrorCode.unsupportedHealthPlatformApi,
+          HealthConnectorErrorCode.unsupportedOperation,
           'revokeAllPermissions is only available on Health Connect. ',
         );
       case HealthPlatform.healthConnect:
@@ -487,7 +487,7 @@ final class HealthConnector {
   /// ## Throws
   ///
   /// - [HealthConnectorException] with
-  ///   [HealthConnectorErrorCode.invalidPlatformConfiguration] if
+  ///   [HealthConnectorErrorCode.invalidConfiguration] if
   ///   required feature permissions are missing from platform configuration
   /// - [HealthConnectorException] if unable to query feature status
   ///
@@ -584,7 +584,7 @@ final class HealthConnector {
   ///
   /// ## Throws
   ///
-  /// - [HealthConnectorException] with [HealthConnectorErrorCode.securityError]
+  /// - [HealthConnectorException] with [HealthConnectorErrorCode.notAuthorized]
   ///   if read permission has not been granted
   /// - [HealthConnectorException] with [HealthConnectorErrorCode.unknown]
   ///   if an unexpected error occurs
@@ -669,7 +669,7 @@ final class HealthConnector {
   ///
   /// ## Throws
   ///
-  /// - [HealthConnectorException] with [HealthConnectorErrorCode.securityError]
+  /// - [HealthConnectorException] with [HealthConnectorErrorCode.notAuthorized]
   ///   if read permission has not been granted
   /// - [HealthConnectorException] with [HealthConnectorErrorCode.unknown]
   ///   if an unexpected error occurs
@@ -744,7 +744,7 @@ final class HealthConnector {
   ///
   /// ## Throws
   ///
-  /// - [HealthConnectorException] with [HealthConnectorErrorCode.securityError]
+  /// - [HealthConnectorException] with [HealthConnectorErrorCode.notAuthorized]
   ///   if write permission has not been granted
   /// - [HealthConnectorException] with
   ///   [HealthConnectorErrorCode.invalidArgument] if the record ID is not
@@ -844,7 +844,7 @@ final class HealthConnector {
   /// ## Throws
   ///
   /// - [HealthConnectorException] with
-  ///   [HealthConnectorErrorCode.securityError] if write permission has not
+  ///   [HealthConnectorErrorCode.notAuthorized] if write permission has not
   ///   been granted
   /// - [HealthConnectorException] with
   ///   [HealthConnectorErrorCode.invalidArgument] if any record ID is not
@@ -958,7 +958,7 @@ final class HealthConnector {
   ///
   /// ## Throws
   ///
-  /// - [HealthConnectorException] with [HealthConnectorErrorCode.securityError]
+  /// - [HealthConnectorException] with [HealthConnectorErrorCode.notAuthorized]
   ///   if read permission has not been granted
   /// - [HealthConnectorException] with [HealthConnectorErrorCode.unknown]
   ///   if an unexpected error occurs
@@ -1036,9 +1036,9 @@ final class HealthConnector {
   /// - [HealthConnectorException] with
   ///   [HealthConnectorErrorCode.invalidArgument] if
   ///   [endTime] before [startTime]
-  /// - [HealthConnectorException] with [HealthConnectorErrorCode.securityError]
+  /// - [HealthConnectorException] with [HealthConnectorErrorCode.notAuthorized]
   ///   if delete/write permission has not been granted
-  /// - [HealthConnectorException] with [HealthConnectorErrorCode.securityError]
+  /// - [HealthConnectorException] with [HealthConnectorErrorCode.notAuthorized]
   ///   if attempting to delete records not created by this app
   /// - [HealthConnectorException] with [HealthConnectorErrorCode.unknown]
   ///   if an unexpected error occurs
@@ -1121,12 +1121,12 @@ final class HealthConnector {
   ///
   /// ## Throws
   ///
-  /// - [HealthConnectorException] with [HealthConnectorErrorCode.securityError]
+  /// - [HealthConnectorException] with [HealthConnectorErrorCode.notAuthorized]
   ///   if delete/write permission has not been granted
   /// - [HealthConnectorException] with
   ///   [HealthConnectorErrorCode.invalidArgument] if
   ///   any record ID is [HealthRecordId.none]
-  /// - [HealthConnectorException] with [HealthConnectorErrorCode.securityError]
+  /// - [HealthConnectorException] with [HealthConnectorErrorCode.notAuthorized]
   ///   if attempting to delete records not created by this app
   /// - [HealthConnectorException] with [HealthConnectorErrorCode.unknown]
   ///   if an unexpected error occurs
@@ -1230,9 +1230,9 @@ final class HealthConnector {
   /// - [HealthConnectorException] with
   ///   [HealthConnectorErrorCode.invalidArgument] if the record ID is
   ///   [HealthRecordId.none] or invalid
-  /// - [HealthConnectorException] with [HealthConnectorErrorCode.securityError]
+  /// - [HealthConnectorException] with [HealthConnectorErrorCode.notAuthorized]
   ///   if write/delete permission has not been granted
-  /// - [HealthConnectorException] with [HealthConnectorErrorCode.securityError]
+  /// - [HealthConnectorException] with [HealthConnectorErrorCode.notAuthorized]
   ///   if attempting to update a record not created by this app
   /// - [HealthConnectorException] with [HealthConnectorErrorCode.unknown]
   ///   if an unexpected error occurs

--- a/packages/health_connector_core/lib/src/annotations/since.dart
+++ b/packages/health_connector_core/lib/src/annotations/since.dart
@@ -33,3 +33,4 @@ const sinceV1_1_0 = Since('1.1.0');
 const sinceV1_2_0 = Since('1.2.0');
 const sinceV1_3_0 = Since('1.3.0');
 const sinceV1_4_0 = Since('1.4.0');
+const sinceV2_0_0 = Since('2.0.0');

--- a/packages/health_connector_core/lib/src/annotations/supported_on.dart
+++ b/packages/health_connector_core/lib/src/annotations/supported_on.dart
@@ -14,7 +14,7 @@ import 'package:meta/meta.dart' show immutable, internal;
 ///
 /// When the annotated API is called on an unsupported platform, the annotated
 /// API should throw a [HealthConnectorException] with
-/// [HealthConnectorErrorCode.unsupportedHealthPlatformApi].
+/// [HealthConnectorErrorCode.unsupportedOperation].
 ///
 /// ## Example
 ///

--- a/packages/health_connector_core/lib/src/models/exceptions/health_connector_error_code.dart
+++ b/packages/health_connector_core/lib/src/models/exceptions/health_connector_error_code.dart
@@ -1,5 +1,5 @@
 import 'package:health_connector_core/src/annotations/annotations.dart'
-    show sinceV1_0_0;
+    show sinceV1_0_0, sinceV2_0_0;
 import 'package:health_connector_core/src/models/exceptions/health_connector_exception.dart'
     show HealthConnectorException;
 
@@ -8,60 +8,125 @@ import 'package:health_connector_core/src/models/exceptions/health_connector_exc
 /// These codes help identify the specific type of error that occurred.
 @sinceV1_0_0
 enum HealthConnectorErrorCode {
-  /// Unknown or unspecified error.
-  unknown('UNKNOWN'),
-
-  /// Health platform app installation or update is required.
-  installationOrUpdateRequired('INSTALLATION_OR_UPDATE_REQUIRED'),
-
-  /// Health platform is unavailable on this device.
-  healthPlatformUnavailable('HEALTH_PLATFORM_UNAVAILABLE'),
-
-  /// Failed to parse data from the platform.
+  /// The health provider needs to be installed or updated.
   ///
-  /// This can occur when the platform returns malformed data or when
-  /// the JSON structure doesn't match the expected format.
-  parsingError('PARSING_ERROR'),
-
-  /// Attempted to use platform APIs or features that are not supported
-  /// on the current health platform.
+  /// **Platform:** Android only (iOS Apple Health is pre-installed)
   ///
-  /// This typically indicates a developer error where plugin API are being
-  /// requested that aren't available on the current health platform.
-  unsupportedHealthPlatformApi('UNSUPPORTED_HEALTH_PLATFORM_API'),
-
-  /// Platform configuration is missing or invalid.
+  /// **Causes:**
+  /// - Health Connect app is not installed.
+  /// - Health Connect app is outdated and requires an update.
   ///
-  /// This indicates platform-specific configuration is not properly set up.
-  invalidPlatformConfiguration('INVALID_PLATFORM_CONFIGURATION'),
+  /// **Action:**
+  /// - Prompt the user to install or update Health Connect from the Play Store.
+  /// - Provide a direct link.
+  healthProviderNotInstalledOrUpdateRequired(
+    'HEALTH_PROVIDER_NOT_INSTALLED_OR_UPDATE_REQUIRED',
+  ),
 
-  /// Security/permission error occurred.
+  /// The health provider is unavailable on this device.
   ///
-  /// This error occurs when a request is made without proper permissions
-  /// or when access is denied by the health platform.
-  securityError('SECURITY_ERROR'),
-
-  /// I/O error occurred during data operations.
-  ioError('IO_ERROR'),
-
-  /// Remote/IPC communication error occurred.
+  /// **Causes:**
+  /// - Device does not support health API (Android < SDK 28, unsupported iPad).
+  /// - Enterprise policy (MDM) or parental controls block access.
+  /// - Health service is explicitly disabled by the system.
+  /// - Device is in a restricted profile (Android work profile).
   ///
-  /// This error occurs when inter-process communication (IPC) with the health
-  /// platform service fails.
+  /// **Action:**
+  /// - Inform the user that health features are not available on their device.
+  /// - Gracefully disable health-related functionality.
+  healthProviderUnavailable('HEALTH_PROVIDER_UNAVAILABLE'),
+
+  /// Attempted to use an API not supported by the current platform or version.
+  ///
+  /// **Causes:**
+  /// - Calling an Android-specific API on iOS (or vice versa).
+  /// - Requesting a data type unsupported by the current SDK version.
+  ///
+  /// **Action:**
+  /// - Check platform/version before calling the API.
+  /// - This error should not occur in production if properly guarded.
+  unsupportedOperation('UNSUPPORTED_OPERATION'),
+
+  /// Missing or invalid app configuration.
+  ///
+  /// **Causes:**
+  /// - Android: Missing permissions in `AndroidManifest.xml`.
+  /// - Android: Missing Play Console health data declarations.
+  /// - iOS: Missing HealthKit entitlement in Signing & Capabilities.
+  /// - iOS: Missing usage description keys in `Info.plist`.
+  ///
+  /// **Action:**
+  /// - Check build logs and fix the app configuration.
+  /// - This error should not occur in production if properly configured.
+  invalidConfiguration('INVALID_CONFIGURATION'),
+
+  /// Invalid argument provided to the API.
+  ///
+  /// **Causes:**
+  /// - `startTime` is after `endTime`.
+  /// - Value out of valid range (e.g., negative step count).
+  /// - Record ID does not exist (delete/update operations).
+  ///
+  /// **Action:**
+  /// - Validate inputs before calling the plugin.
+  /// - Refresh local record ID cache before delete/update operations.
+  invalidArgument('INVALID_ARGUMENT'),
+
+  /// Access to health data was denied or not yet authorized.
+  ///
+  /// **Causes:**
+  /// - Permissions have not been requested yet.
+  /// - User denied permissions in the system dialog.
+  /// - Permissions were revoked via system settings.
+  ///
+  /// **Action:**
+  /// - If not yet requested: Trigger the permission request flow.
+  /// - If denied: Explain why the feature needs access and
+  ///   guide user to settings.
+  /// - Respect user choice; avoid repeated prompting.
+  notAuthorized('NOT_AUTHORIZED'),
+
+  /// A transient I/O or communication error occurred.
+  ///
+  /// **Causes:**
+  /// - Temporary disk I/O failure.
+  /// - Inter-process communication (IPC) interrupted.
+  /// - Background service temporarily unreachable.
+  /// - Too many read/write operations in a short time window (Android only).
+  ///
+  /// **Action:**
+  /// - Retry with exponential backoff (e.g., 1s → 2s → 4s, max 30s).
+  /// - These issues typically resolve quickly without user intervention.
   remoteError('REMOTE_ERROR'),
 
-  /// Invalid argument provided to the operation.
+  /// User cancelled the operation.
   ///
-  /// This error occurs when invalid parameters are passed to an operation.
-  /// For example:
-  /// - Invalid record IDs
-  /// - Invalid time ranges
-  /// - Invalid data types or values
-  /// - Missing required parameters
-  invalidArgument('INVALID_ARGUMENT');
+  /// **Causes:**
+  /// - User dismissed the permission dialog without making a choice.
+  /// - User cancelled an in-progress action.
+  ///
+  /// **Action:**
+  /// - Respect the user's choice; do not immediately re-prompt.
+  /// - Continue app flow without health features if appropriate.
+  /// - This is not an error condition requiring user notification.
+  @sinceV2_0_0
+  userCancelled('USER_CANCELLED'),
+
+  /// An unknown or unexpected error occurred.
+  ///
+  /// **Causes:**
+  /// - Unmapped native error code.
+  /// - Internal platform bug.
+  /// - New error type from SDK update.
+  ///
+  /// **Action:**
+  /// - Log the full error details for investigation.
+  /// - Show a generic "Something went wrong" message to the user.
+  /// - Report to crash analytics.
+  unknown('UNKNOWN');
 
   const HealthConnectorErrorCode(this.code);
 
-  /// The error code string.
+  /// The string representation of the error code.
   final String code;
 }

--- a/packages/health_connector_hc_android/android/src/main/kotlin/com/phamtunglam/health_connector_hc_android/HealthConnectorClient.kt
+++ b/packages/health_connector_hc_android/android/src/main/kotlin/com/phamtunglam/health_connector_hc_android/HealthConnectorClient.kt
@@ -108,9 +108,10 @@ internal class HealthConnectorClient private constructor(
                         "due to SDK version too low or running in a profile mode",
                     exception = e,
                 )
-                throw HealthConnectorErrorCodeDto.INSTALLATION_OR_UPDATE_REQUIRED.toError(
-                    details = e.message,
-                )
+                throw HealthConnectorErrorCodeDto
+                    .HEALTH_PROVIDER_NOT_INSTALLED_OR_UPDATE_REQUIRED.toError(
+                        details = e.message,
+                    )
             } catch (e: IllegalStateException) {
                 HealthConnectorLogger.error(
                     tag = TAG,
@@ -119,7 +120,7 @@ internal class HealthConnectorClient private constructor(
                     message = "Failed to create Health Connect client due to service not available",
                     exception = e,
                 )
-                throw HealthConnectorErrorCodeDto.HEALTH_PLATFORM_UNAVAILABLE.toError(
+                throw HealthConnectorErrorCodeDto.HEALTH_PROVIDER_UNAVAILABLE.toError(
                     details = e.message,
                 )
             }
@@ -206,7 +207,7 @@ internal class HealthConnectorClient private constructor(
                 ),
                 exception = e,
             )
-            throw HealthConnectorErrorCodeDto.INVALID_PLATFORM_CONFIGURATION.toError(
+            throw HealthConnectorErrorCodeDto.INVALID_CONFIGURATION.toError(
                 details = e.message,
             )
         } catch (e: RuntimeException) {
@@ -278,7 +279,7 @@ internal class HealthConnectorClient private constructor(
                 context = mapOf("feature" to feature),
                 exception = e,
             )
-            throw HealthConnectorErrorCodeDto.INVALID_PLATFORM_CONFIGURATION.toError(
+            throw HealthConnectorErrorCodeDto.INVALID_CONFIGURATION.toError(
                 details = e.message,
             )
         } catch (e: RuntimeException) {
@@ -348,7 +349,7 @@ internal class HealthConnectorClient private constructor(
                 context = mapOf("request" to request),
                 exception = e,
             )
-            throw HealthConnectorErrorCodeDto.SECURITY_ERROR.toError(
+            throw HealthConnectorErrorCodeDto.NOT_AUTHORIZED.toError(
                 details = "Permission access denied while processing $request: " +
                     (e.message ?: "Access denied"),
             )
@@ -449,7 +450,7 @@ internal class HealthConnectorClient private constructor(
                 context = mapOf("request" to request),
                 exception = e,
             )
-            throw HealthConnectorErrorCodeDto.SECURITY_ERROR.toError(
+            throw HealthConnectorErrorCodeDto.NOT_AUTHORIZED.toError(
                 details = "Permission access denied while processing $request: " +
                     (e.message ?: "Access denied"),
             )
@@ -516,7 +517,7 @@ internal class HealthConnectorClient private constructor(
                 context = mapOf("request" to request),
                 exception = e,
             )
-            throw HealthConnectorErrorCodeDto.SECURITY_ERROR.toError(
+            throw HealthConnectorErrorCodeDto.NOT_AUTHORIZED.toError(
                 details = "Permission access denied while processing $request: " +
                     (e.message ?: "Access denied"),
             )
@@ -583,7 +584,7 @@ internal class HealthConnectorClient private constructor(
                 context = mapOf("request" to request),
                 exception = e,
             )
-            throw HealthConnectorErrorCodeDto.SECURITY_ERROR.toError(
+            throw HealthConnectorErrorCodeDto.NOT_AUTHORIZED.toError(
                 details = "Permission access denied while processing $request: " +
                     (e.message ?: "Access denied"),
             )
@@ -667,7 +668,7 @@ internal class HealthConnectorClient private constructor(
                 context = mapOf("request" to request),
                 exception = e,
             )
-            throw HealthConnectorErrorCodeDto.SECURITY_ERROR.toError(
+            throw HealthConnectorErrorCodeDto.NOT_AUTHORIZED.toError(
                 details = "Permission access denied while processing $request: " +
                     (e.message ?: "Access denied"),
             )
@@ -838,7 +839,7 @@ internal class HealthConnectorClient private constructor(
                 context = mapOf("request" to request),
                 exception = e,
             )
-            throw HealthConnectorErrorCodeDto.UNSUPPORTED_HEALTH_PLATFORM_API.toError(
+            throw HealthConnectorErrorCodeDto.UNSUPPORTED_OPERATION.toError(
                 details = "Unsupported aggregation metric for Oxygen Saturation: " +
                     (e.message ?: "Operation not supported"),
             )
@@ -863,7 +864,7 @@ internal class HealthConnectorClient private constructor(
                 context = mapOf("request" to request),
                 exception = e,
             )
-            throw HealthConnectorErrorCodeDto.SECURITY_ERROR.toError(
+            throw HealthConnectorErrorCodeDto.NOT_AUTHORIZED.toError(
                 details = "Permission access denied while processing $request: " +
                     (e.message ?: "Access denied"),
             )
@@ -1034,7 +1035,7 @@ internal class HealthConnectorClient private constructor(
                 context = mapOf("request" to request),
                 exception = e,
             )
-            throw HealthConnectorErrorCodeDto.UNSUPPORTED_HEALTH_PLATFORM_API.toError(
+            throw HealthConnectorErrorCodeDto.UNSUPPORTED_OPERATION.toError(
                 details = "Unsupported aggregation metric for Respiratory Rate: " +
                     (e.message ?: "Operation not supported"),
             )
@@ -1059,7 +1060,7 @@ internal class HealthConnectorClient private constructor(
                 context = mapOf("request" to request),
                 exception = e,
             )
-            throw HealthConnectorErrorCodeDto.SECURITY_ERROR.toError(
+            throw HealthConnectorErrorCodeDto.NOT_AUTHORIZED.toError(
                 details = "Permission access denied while processing $request: " +
                     (e.message ?: "Access denied"),
             )
@@ -1229,7 +1230,7 @@ internal class HealthConnectorClient private constructor(
                 context = mapOf("request" to request),
                 exception = e,
             )
-            throw HealthConnectorErrorCodeDto.UNSUPPORTED_HEALTH_PLATFORM_API.toError(
+            throw HealthConnectorErrorCodeDto.UNSUPPORTED_OPERATION.toError(
                 details = "Unsupported aggregation metric for VO2Max: " +
                     (e.message ?: "Operation not supported"),
             )
@@ -1254,7 +1255,7 @@ internal class HealthConnectorClient private constructor(
                 context = mapOf("request" to request),
                 exception = e,
             )
-            throw HealthConnectorErrorCodeDto.SECURITY_ERROR.toError(
+            throw HealthConnectorErrorCodeDto.NOT_AUTHORIZED.toError(
                 details = "Permission access denied while processing $request: " +
                     (e.message ?: "Access denied"),
             )
@@ -1425,7 +1426,7 @@ internal class HealthConnectorClient private constructor(
                 context = mapOf("request" to request),
                 exception = e,
             )
-            throw HealthConnectorErrorCodeDto.UNSUPPORTED_HEALTH_PLATFORM_API.toError(
+            throw HealthConnectorErrorCodeDto.UNSUPPORTED_OPERATION.toError(
                 details = "Unsupported aggregation metric for Blood Glucose: " +
                     (e.message ?: "Operation not supported"),
             )
@@ -1450,7 +1451,7 @@ internal class HealthConnectorClient private constructor(
                 context = mapOf("request" to request),
                 exception = e,
             )
-            throw HealthConnectorErrorCodeDto.SECURITY_ERROR.toError(
+            throw HealthConnectorErrorCodeDto.NOT_AUTHORIZED.toError(
                 details = "Permission access denied while processing $request: " +
                     (e.message ?: "Access denied"),
             )
@@ -1564,7 +1565,7 @@ internal class HealthConnectorClient private constructor(
                 context = mapOf("request" to request),
                 exception = e,
             )
-            throw HealthConnectorErrorCodeDto.UNSUPPORTED_HEALTH_PLATFORM_API.toError(
+            throw HealthConnectorErrorCodeDto.UNSUPPORTED_OPERATION.toError(
                 details = "Unsupported aggregation metric for ${request.dataType}: " +
                     (e.message ?: "Operation not supported"),
             )
@@ -1601,7 +1602,7 @@ internal class HealthConnectorClient private constructor(
                 context = mapOf("request" to request),
                 exception = e,
             )
-            throw HealthConnectorErrorCodeDto.SECURITY_ERROR.toError(
+            throw HealthConnectorErrorCodeDto.NOT_AUTHORIZED.toError(
                 details = "Permission access denied while processing $request: " +
                     (e.message ?: "Access denied"),
             )
@@ -1665,7 +1666,7 @@ internal class HealthConnectorClient private constructor(
                 context = mapOf("request" to request),
                 exception = e,
             )
-            throw HealthConnectorErrorCodeDto.SECURITY_ERROR.toError(
+            throw HealthConnectorErrorCodeDto.NOT_AUTHORIZED.toError(
                 details = "Permission access denied while processing $request: " +
                     (e.message ?: "Access denied"),
             )
@@ -1736,7 +1737,7 @@ internal class HealthConnectorClient private constructor(
                 context = mapOf("request" to request),
                 exception = e,
             )
-            throw HealthConnectorErrorCodeDto.SECURITY_ERROR.toError(
+            throw HealthConnectorErrorCodeDto.NOT_AUTHORIZED.toError(
                 details = "Permission access denied while processing $request: " +
                     (e.message ?: "Access denied"),
             )

--- a/packages/health_connector_hc_android/android/src/main/kotlin/com/phamtunglam/health_connector_hc_android/HealthConnectorHCAndroidPlugin.kt
+++ b/packages/health_connector_hc_android/android/src/main/kotlin/com/phamtunglam/health_connector_hc_android/HealthConnectorHCAndroidPlugin.kt
@@ -218,7 +218,7 @@ class HealthConnectorHCAndroidPlugin :
                     complete(
                         callback,
                         Result.failure(
-                            HealthConnectorErrorCodeDto.INVALID_PLATFORM_CONFIGURATION.toError(
+                            HealthConnectorErrorCodeDto.INVALID_CONFIGURATION.toError(
                                 details = "Activity is unavailable. " +
                                     "The app may be in the background or " +
                                     "activity has been destroyed.",

--- a/packages/health_connector_hc_android/android/src/main/kotlin/com/phamtunglam/health_connector_hc_android/mappers/HealthConnectorErrorMappers.kt
+++ b/packages/health_connector_hc_android/android/src/main/kotlin/com/phamtunglam/health_connector_hc_android/mappers/HealthConnectorErrorMappers.kt
@@ -16,26 +16,32 @@ import com.phamtunglam.health_connector_hc_android.pigeon.HealthConnectorErrorDt
  */
 internal fun HealthConnectorErrorCodeDto.toError(details: Any? = null): HealthConnectorErrorDto {
     val message = when (this) {
-        HealthConnectorErrorCodeDto.INSTALLATION_OR_UPDATE_REQUIRED ->
+        HealthConnectorErrorCodeDto.HEALTH_PROVIDER_NOT_INSTALLED_OR_UPDATE_REQUIRED ->
             "Health Connect is required to be installed or updated"
 
-        HealthConnectorErrorCodeDto.HEALTH_PLATFORM_UNAVAILABLE ->
+        HealthConnectorErrorCodeDto.HEALTH_PROVIDER_UNAVAILABLE ->
             "Health Connect is unavailable"
 
-        HealthConnectorErrorCodeDto.INVALID_PLATFORM_CONFIGURATION ->
+        HealthConnectorErrorCodeDto.INVALID_CONFIGURATION ->
             "Invalid platform configuration"
 
         HealthConnectorErrorCodeDto.UNKNOWN ->
             "An unknown error occurred"
 
-        HealthConnectorErrorCodeDto.SECURITY_ERROR ->
+        HealthConnectorErrorCodeDto.NOT_AUTHORIZED ->
             "Security/permission error: Access denied or insufficient permissions"
 
         HealthConnectorErrorCodeDto.INVALID_ARGUMENT ->
             "Invalid argument: Input validation failed"
 
-        HealthConnectorErrorCodeDto.UNSUPPORTED_HEALTH_PLATFORM_API ->
+        HealthConnectorErrorCodeDto.UNSUPPORTED_OPERATION ->
             "Unsupported health platform API"
+
+        HealthConnectorErrorCodeDto.REMOTE_ERROR ->
+            "A transient I/O or communication error occurred"
+
+        HealthConnectorErrorCodeDto.USER_CANCELLED ->
+            "User cancelled the operation"
     }
     return HealthConnectorErrorDto(name, message, details)
 }

--- a/packages/health_connector_hc_android/android/src/main/kotlin/com/phamtunglam/health_connector_hc_android/pigeon/HealthConnectorHCAndroidApi.g.kt
+++ b/packages/health_connector_hc_android/android/src/main/kotlin/com/phamtunglam/health_connector_hc_android/pigeon/HealthConnectorHCAndroidApi.g.kt
@@ -95,22 +95,26 @@ class HealthConnectorErrorDto (
 /** Error codes that native platforms can use when throwing error. */
 enum class HealthConnectorErrorCodeDto(val raw: Int) {
   /** Health Connect installation or update is required. */
-  INSTALLATION_OR_UPDATE_REQUIRED(0),
+  HEALTH_PROVIDER_NOT_INSTALLED_OR_UPDATE_REQUIRED(0),
   /** Health platform is unavailable on this device. */
-  HEALTH_PLATFORM_UNAVAILABLE(1),
+  HEALTH_PROVIDER_UNAVAILABLE(1),
   /** Invalid platform configuration detected. */
-  INVALID_PLATFORM_CONFIGURATION(2),
+  INVALID_CONFIGURATION(2),
   /** Invalid argument or input validation error. */
   INVALID_ARGUMENT(3),
   /**
    * Attempted to use platform APIs or features that are not supported
    * on the current health platform.
    */
-  UNSUPPORTED_HEALTH_PLATFORM_API(4),
+  UNSUPPORTED_OPERATION(4),
   /** Unknown or unspecified error. */
   UNKNOWN(5),
   /** Security/permission error occurred. */
-  SECURITY_ERROR(6);
+  NOT_AUTHORIZED(6),
+  /** A transient I/O or communication error occurred. */
+  REMOTE_ERROR(7),
+  /** User cancelled the operation. */
+  USER_CANCELLED(8);
 
   companion object {
     fun ofRaw(raw: Int): HealthConnectorErrorCodeDto? {

--- a/packages/health_connector_hc_android/lib/src/health_connector_hc_client.dart
+++ b/packages/health_connector_hc_android/lib/src/health_connector_hc_client.dart
@@ -24,7 +24,7 @@ import 'package:health_connector_core/health_connector_core.dart'
         PermissionListExtension,
         sinceV1_0_0,
         internalUse;
-import 'package:health_connector_hc_android/src/mappers/error_code_mappers.dart';
+import 'package:health_connector_hc_android/src/mappers/health_connector_error_code_mappers.dart';
 import 'package:health_connector_hc_android/src/mappers/health_data_type_mappers.dart';
 import 'package:health_connector_hc_android/src/mappers/health_platform_feature_mappers.dart';
 import 'package:health_connector_hc_android/src/mappers/health_record_mapper.dart';

--- a/packages/health_connector_hc_android/lib/src/mappers/health_connector_error_code_mappers.dart
+++ b/packages/health_connector_hc_android/lib/src/mappers/health_connector_error_code_mappers.dart
@@ -1,7 +1,7 @@
 import 'package:flutter/services.dart' show PlatformException;
 import 'package:health_connector_core/health_connector_core.dart'
     show HealthConnectorErrorCode, sinceV1_0_0;
-import 'package:health_connector_hk_ios/src/pigeon/health_connector_platform_api.g.dart'
+import 'package:health_connector_hc_android/src/pigeon/health_connector_hc_android_api.g.dart'
     show HealthConnectorErrorCodeDto;
 import 'package:meta/meta.dart' show internal;
 
@@ -13,16 +13,24 @@ extension HealthConnectorErrorCodeDtoToDomain on HealthConnectorErrorCodeDto {
     switch (this) {
       case HealthConnectorErrorCodeDto.unknown:
         return HealthConnectorErrorCode.unknown;
-      case HealthConnectorErrorCodeDto.healthPlatformUnavailable:
-        return HealthConnectorErrorCode.healthPlatformUnavailable;
-      case HealthConnectorErrorCodeDto.unsupportedHealthPlatformApi:
-        return HealthConnectorErrorCode.unsupportedHealthPlatformApi;
-      case HealthConnectorErrorCodeDto.invalidPlatformConfiguration:
-        return HealthConnectorErrorCode.invalidPlatformConfiguration;
+      case HealthConnectorErrorCodeDto
+          .healthProviderNotInstalledOrUpdateRequired:
+        return HealthConnectorErrorCode
+            .healthProviderNotInstalledOrUpdateRequired;
+      case HealthConnectorErrorCodeDto.healthProviderUnavailable:
+        return HealthConnectorErrorCode.healthProviderUnavailable;
+      case HealthConnectorErrorCodeDto.unsupportedOperation:
+        return HealthConnectorErrorCode.unsupportedOperation;
+      case HealthConnectorErrorCodeDto.invalidConfiguration:
+        return HealthConnectorErrorCode.invalidConfiguration;
       case HealthConnectorErrorCodeDto.invalidArgument:
         return HealthConnectorErrorCode.invalidArgument;
-      case HealthConnectorErrorCodeDto.securityError:
-        return HealthConnectorErrorCode.securityError;
+      case HealthConnectorErrorCodeDto.notAuthorized:
+        return HealthConnectorErrorCode.notAuthorized;
+      case HealthConnectorErrorCodeDto.remoteError:
+        return HealthConnectorErrorCode.remoteError;
+      case HealthConnectorErrorCodeDto.userCancelled:
+        return HealthConnectorErrorCode.userCancelled;
     }
   }
 }

--- a/packages/health_connector_hc_android/lib/src/pigeon/health_connector_hc_android_api.g.dart
+++ b/packages/health_connector_hc_android/lib/src/pigeon/health_connector_hc_android_api.g.dart
@@ -50,26 +50,32 @@ bool _deepEquals(Object? a, Object? b) {
 /// Error codes that native platforms can use when throwing error.
 enum HealthConnectorErrorCodeDto {
   /// Health Connect installation or update is required.
-  installationOrUpdateRequired,
+  healthProviderNotInstalledOrUpdateRequired,
 
   /// Health platform is unavailable on this device.
-  healthPlatformUnavailable,
+  healthProviderUnavailable,
 
   /// Invalid platform configuration detected.
-  invalidPlatformConfiguration,
+  invalidConfiguration,
 
   /// Invalid argument or input validation error.
   invalidArgument,
 
   /// Attempted to use platform APIs or features that are not supported
   /// on the current health platform.
-  unsupportedHealthPlatformApi,
+  unsupportedOperation,
 
   /// Unknown or unspecified error.
   unknown,
 
   /// Security/permission error occurred.
-  securityError,
+  notAuthorized,
+
+  /// A transient I/O or communication error occurred.
+  remoteError,
+
+  /// User cancelled the operation.
+  userCancelled,
 }
 
 /// Represents the status of the health platform on the device.

--- a/packages/health_connector_hc_android/pigeons/health_connector_hc_android_api.dart
+++ b/packages/health_connector_hc_android/pigeons/health_connector_hc_android_api.dart
@@ -21,26 +21,32 @@ import 'package:pigeon/pigeon.dart';
 /// Error codes that native platforms can use when throwing error.
 enum HealthConnectorErrorCodeDto {
   /// Health Connect installation or update is required.
-  installationOrUpdateRequired,
+  healthProviderNotInstalledOrUpdateRequired,
 
   /// Health platform is unavailable on this device.
-  healthPlatformUnavailable,
+  healthProviderUnavailable,
 
   /// Invalid platform configuration detected.
-  invalidPlatformConfiguration,
+  invalidConfiguration,
 
   /// Invalid argument or input validation error.
   invalidArgument,
 
   /// Attempted to use platform APIs or features that are not supported
   /// on the current health platform.
-  unsupportedHealthPlatformApi,
+  unsupportedOperation,
 
   /// Unknown or unspecified error.
   unknown,
 
   /// Security/permission error occurred.
-  securityError,
+  notAuthorized,
+
+  /// A transient I/O or communication error occurred.
+  remoteError,
+
+  /// User cancelled the operation.
+  userCancelled,
 }
 
 /// Represents the status of the health platform on the device.

--- a/packages/health_connector_hk_ios/ios/health_connector_hk_ios/Sources/health_connector_hk_ios/HealthConnectorClient.swift
+++ b/packages/health_connector_hk_ios/ios/health_connector_hk_ios/Sources/health_connector_hk_ios/HealthConnectorClient.swift
@@ -37,7 +37,7 @@ class HealthConnectorClient {
             let hkErrorCode = HKError.Code(rawValue: error.code)
             switch hkErrorCode {
             case .errorAuthorizationDenied:
-                return HealthConnectorErrors.securityError(
+                return HealthConnectorErrors.notAuthorized(
                     message: error.localizedDescription,
                     details: error.localizedDescription
                 )
@@ -47,7 +47,7 @@ class HealthConnectorClient {
                     details: error.localizedDescription
                 )
             case .errorHealthDataUnavailable, .errorDatabaseInaccessible:
-                return HealthConnectorErrors.healthPlatformUnavailable(
+                return HealthConnectorErrors.healthProviderUnavailable(
                     message: error.localizedDescription,
                     details: error.localizedDescription
                 )
@@ -82,7 +82,7 @@ class HealthConnectorClient {
                 phase: "failed",
                 message: "HealthKit is not available on this device"
             )
-            throw HealthConnectorErrors.healthPlatformUnavailable(
+            throw HealthConnectorErrors.healthProviderUnavailable(
                 message: nil,
                 details: nil
             )

--- a/packages/health_connector_hk_ios/ios/health_connector_hk_ios/Sources/health_connector_hk_ios/HealthConnectorHkIosPlugin.swift
+++ b/packages/health_connector_hk_ios/ios/health_connector_hk_ios/Sources/health_connector_hk_ios/HealthConnectorHkIosPlugin.swift
@@ -57,7 +57,7 @@ public class HealthConnectorHkIosPlugin: NSObject, FlutterPlugin, HealthConnecto
                 }
 
                 guard let client = healthClient else {
-                    throw HealthConnectorErrors.healthPlatformUnavailable()
+                    throw HealthConnectorErrors.healthProviderUnavailable()
                 }
 
                 let healthDataResults = try await client
@@ -117,7 +117,7 @@ public class HealthConnectorHkIosPlugin: NSObject, FlutterPlugin, HealthConnecto
                 }
 
                 guard let client = healthClient else {
-                    throw HealthConnectorErrors.healthPlatformUnavailable()
+                    throw HealthConnectorErrors.healthProviderUnavailable()
                 }
 
                 let result = try await client.readRecord(request: request)
@@ -171,7 +171,7 @@ public class HealthConnectorHkIosPlugin: NSObject, FlutterPlugin, HealthConnecto
                 }
 
                 guard let client = healthClient else {
-                    throw HealthConnectorErrors.healthPlatformUnavailable()
+                    throw HealthConnectorErrors.healthProviderUnavailable()
                 }
 
                 let result = try await client.readRecords(request: request)
@@ -225,7 +225,7 @@ public class HealthConnectorHkIosPlugin: NSObject, FlutterPlugin, HealthConnecto
                 }
 
                 guard let client = healthClient else {
-                    throw HealthConnectorErrors.healthPlatformUnavailable()
+                    throw HealthConnectorErrors.healthProviderUnavailable()
                 }
 
                 let result = try await client.writeRecord(request: request)
@@ -279,7 +279,7 @@ public class HealthConnectorHkIosPlugin: NSObject, FlutterPlugin, HealthConnecto
                 }
 
                 guard let client = healthClient else {
-                    throw HealthConnectorErrors.healthPlatformUnavailable()
+                    throw HealthConnectorErrors.healthProviderUnavailable()
                 }
 
                 let result = try await client.writeRecords(request: request)
@@ -333,7 +333,7 @@ public class HealthConnectorHkIosPlugin: NSObject, FlutterPlugin, HealthConnecto
                 }
 
                 guard let client = healthClient else {
-                    throw HealthConnectorErrors.healthPlatformUnavailable()
+                    throw HealthConnectorErrors.healthProviderUnavailable()
                 }
 
                 let result = try await client.updateRecord(request: request)
@@ -387,7 +387,7 @@ public class HealthConnectorHkIosPlugin: NSObject, FlutterPlugin, HealthConnecto
                 }
 
                 guard let client = healthClient else {
-                    throw HealthConnectorErrors.healthPlatformUnavailable()
+                    throw HealthConnectorErrors.healthProviderUnavailable()
                 }
 
                 let result = try await client.aggregate(request: request)
@@ -443,7 +443,7 @@ public class HealthConnectorHkIosPlugin: NSObject, FlutterPlugin, HealthConnecto
                 }
 
                 guard let client = healthClient else {
-                    throw HealthConnectorErrors.healthPlatformUnavailable()
+                    throw HealthConnectorErrors.healthProviderUnavailable()
                 }
 
                 try await client.deleteRecordsByIds(request: request)
@@ -497,7 +497,7 @@ public class HealthConnectorHkIosPlugin: NSObject, FlutterPlugin, HealthConnecto
                 }
 
                 guard let client = healthClient else {
-                    throw HealthConnectorErrors.healthPlatformUnavailable()
+                    throw HealthConnectorErrors.healthProviderUnavailable()
                 }
 
                 try await client.deleteRecordsByTimeRange(request: request)

--- a/packages/health_connector_hk_ios/ios/health_connector_hk_ios/Sources/health_connector_hk_ios/mappers/HealthConnectorErrorMappers.swift
+++ b/packages/health_connector_hk_ios/ios/health_connector_hk_ios/Sources/health_connector_hk_ios/mappers/HealthConnectorErrorMappers.swift
@@ -11,16 +11,20 @@ extension HealthConnectorErrorCodeDto {
         switch self {
         case .unknown:
             "UNKNOWN"
-        case .healthPlatformUnavailable:
-            "HEALTH_PLATFORM_UNAVAILABLE"
-        case .unsupportedHealthPlatformApi:
-            "UNSUPPORTED_HEALTH_PLATFORM_API"
-        case .invalidPlatformConfiguration:
-            "INVALID_PLATFORM_CONFIGURATION"
+        case .healthProviderUnavailable:
+            "HEALTH_PROVIDER_UNAVAILABLE"
+        case .unsupportedOperation:
+            "UNSUPPORTED_OPERATION"
+        case .invalidConfiguration:
+            "INVALID_CONFIGURATION"
         case .invalidArgument:
             "INVALID_ARGUMENT"
-        case .securityError:
-            "SECURITY_ERROR"
+        case .notAuthorized:
+            "NOT_AUTHORIZED"
+        case .remoteError:
+            "REMOTE_ERROR"
+        case .userCancelled:
+            "USER_CANCELLED"
         }
     }
 }
@@ -29,20 +33,24 @@ extension HealthConnectorErrorCodeDto {
  * Creates a [HealthConnectorError] from this error code with the appropriate message.
  */
 extension HealthConnectorErrorCodeDto {
-    func toError(details: Any? = nil) -> HealthConnectorError {
+    func toError(details: Sendable? = nil) -> HealthConnectorError {
         let message = switch self {
-        case .healthPlatformUnavailable:
+        case .healthProviderUnavailable:
             "HealthKit is unavailable"
-        case .invalidPlatformConfiguration:
+        case .invalidConfiguration:
             "Invalid platform configuration"
         case .unknown:
             "An unknown error occurred"
-        case .securityError:
+        case .notAuthorized:
             "Security/permission error: Access denied or insufficient permissions"
         case .invalidArgument:
             "Invalid argument: Input validation failed"
-        case .unsupportedHealthPlatformApi:
+        case .unsupportedOperation:
             "Unsupported health platform API"
+        case .remoteError:
+            "A transient I/O or communication error occurred"
+        case .userCancelled:
+            "User cancelled the operation"
         }
         return HealthConnectorError(code: stringValue, message: message, details: details)
     }
@@ -55,9 +63,9 @@ enum HealthConnectorErrors {
     /**
      * Creates a `HealthConnectorError` indicating that HealthKit is unavailable on the device.
      */
-    static func healthPlatformUnavailable(message: String? = nil, details: Sendable? = nil) -> HealthConnectorError {
+    static func healthProviderUnavailable(message: String? = nil, details: Sendable? = nil) -> HealthConnectorError {
         HealthConnectorError(
-            code: HealthConnectorErrorCodeDto.healthPlatformUnavailable.stringValue,
+            code: HealthConnectorErrorCodeDto.healthProviderUnavailable.stringValue,
             message: "HealthKit is unavailable\(getMessageOrEmpty(message))",
             details: details
         )
@@ -78,9 +86,9 @@ enum HealthConnectorErrors {
      * Creates a `HealthConnectorError` indicating that the requested API or feature is not
      * supported on iOS HealthKit.
      */
-    static func unsupportedHealthPlatformApi(message: String? = nil, details: Sendable? = nil) -> HealthConnectorError {
+    static func unsupportedOperation(message: String? = nil, details: Sendable? = nil) -> HealthConnectorError {
         HealthConnectorError(
-            code: HealthConnectorErrorCodeDto.unsupportedHealthPlatformApi.stringValue,
+            code: HealthConnectorErrorCodeDto.unsupportedOperation.stringValue,
             message: "Unsupported health platform API\(getMessageOrEmpty(message))",
             details: details
         )
@@ -90,9 +98,9 @@ enum HealthConnectorErrors {
      * Creates a `HealthConnectorError` for invalid platform configuration issues, f.e. missing
      * required permissions in Info.plist.
      */
-    static func invalidPlatformConfiguration(message: String? = nil, details: Sendable? = nil) -> HealthConnectorError {
+    static func invalidConfiguration(message: String? = nil, details: Sendable? = nil) -> HealthConnectorError {
         HealthConnectorError(
-            code: HealthConnectorErrorCodeDto.invalidPlatformConfiguration.stringValue,
+            code: HealthConnectorErrorCodeDto.invalidConfiguration.stringValue,
             message: "Invalid platform configuration\(getMessageOrEmpty(message))",
             details: details
         )
@@ -114,9 +122,9 @@ enum HealthConnectorErrors {
      *
      * This error maps to `HKError.errorAuthorizationDenied` on iOS.
      */
-    static func securityError(message: String? = nil, details: Sendable? = nil) -> HealthConnectorError {
+    static func notAuthorized(message: String? = nil, details: Sendable? = nil) -> HealthConnectorError {
         HealthConnectorError(
-            code: HealthConnectorErrorCodeDto.securityError.stringValue,
+            code: HealthConnectorErrorCodeDto.notAuthorized.stringValue,
             message: "Security error: Permission denied or insufficient access\(getMessageOrEmpty(message))",
             details: details
         )

--- a/packages/health_connector_hk_ios/ios/health_connector_hk_ios/Sources/health_connector_hk_ios/pigeon/HealthConnectorPlatformApi.g.swift
+++ b/packages/health_connector_hk_ios/ios/health_connector_hk_ios/Sources/health_connector_hk_ios/pigeon/HealthConnectorPlatformApi.g.swift
@@ -146,18 +146,22 @@ func deepHashHealthConnectorPlatformApi(value: Any?, hasher: inout Hasher) {
 /// Error codes that native platforms can use when throwing error.
 public enum HealthConnectorErrorCodeDto: Int {
   /// Health platform is unavailable on this device.
-  case healthPlatformUnavailable = 0
+  case healthProviderUnavailable = 0
   /// Invalid platform configuration detected.
-  case invalidPlatformConfiguration = 1
+  case invalidConfiguration = 1
   /// Invalid argument or input validation error.
   case invalidArgument = 2
   /// Attempted to use platform APIs that are not supported on
   /// the current health platform.
-  case unsupportedHealthPlatformApi = 3
+  case unsupportedOperation = 3
   /// Unknown or unspecified error.
   case unknown = 4
   /// Security/permission error occurred.
-  case securityError = 5
+  case notAuthorized = 5
+  /// A transient I/O or communication error occurred.
+  case remoteError = 6
+  /// User cancelled the operation.
+  case userCancelled = 7
 }
 
 /// Represents the status of the health platform on the device.

--- a/packages/health_connector_hk_ios/lib/src/health_connector_hk_client.dart
+++ b/packages/health_connector_hk_ios/lib/src/health_connector_hk_client.dart
@@ -21,7 +21,7 @@ import 'package:health_connector_core/health_connector_core.dart'
         PermissionListExtension,
         sinceV1_0_0,
         internalUse;
-import 'package:health_connector_hk_ios/src/mappers/error_code_mappers.dart';
+import 'package:health_connector_hk_ios/src/mappers/health_connector_error_code_mappers.dart';
 import 'package:health_connector_hk_ios/src/mappers/health_data_type_mappers.dart';
 import 'package:health_connector_hk_ios/src/mappers/health_record_mapper.dart';
 import 'package:health_connector_hk_ios/src/mappers/health_record_mappers/health_record_id_mappers.dart';

--- a/packages/health_connector_hk_ios/lib/src/mappers/health_connector_error_code_mappers.dart
+++ b/packages/health_connector_hk_ios/lib/src/mappers/health_connector_error_code_mappers.dart
@@ -1,7 +1,7 @@
 import 'package:flutter/services.dart' show PlatformException;
 import 'package:health_connector_core/health_connector_core.dart'
     show HealthConnectorErrorCode, sinceV1_0_0;
-import 'package:health_connector_hc_android/src/pigeon/health_connector_hc_android_api.g.dart'
+import 'package:health_connector_hk_ios/src/pigeon/health_connector_platform_api.g.dart'
     show HealthConnectorErrorCodeDto;
 import 'package:meta/meta.dart' show internal;
 
@@ -13,18 +13,20 @@ extension HealthConnectorErrorCodeDtoToDomain on HealthConnectorErrorCodeDto {
     switch (this) {
       case HealthConnectorErrorCodeDto.unknown:
         return HealthConnectorErrorCode.unknown;
-      case HealthConnectorErrorCodeDto.installationOrUpdateRequired:
-        return HealthConnectorErrorCode.installationOrUpdateRequired;
-      case HealthConnectorErrorCodeDto.healthPlatformUnavailable:
-        return HealthConnectorErrorCode.healthPlatformUnavailable;
-      case HealthConnectorErrorCodeDto.unsupportedHealthPlatformApi:
-        return HealthConnectorErrorCode.unsupportedHealthPlatformApi;
-      case HealthConnectorErrorCodeDto.invalidPlatformConfiguration:
-        return HealthConnectorErrorCode.invalidPlatformConfiguration;
+      case HealthConnectorErrorCodeDto.healthProviderUnavailable:
+        return HealthConnectorErrorCode.healthProviderUnavailable;
+      case HealthConnectorErrorCodeDto.unsupportedOperation:
+        return HealthConnectorErrorCode.unsupportedOperation;
+      case HealthConnectorErrorCodeDto.invalidConfiguration:
+        return HealthConnectorErrorCode.invalidConfiguration;
       case HealthConnectorErrorCodeDto.invalidArgument:
         return HealthConnectorErrorCode.invalidArgument;
-      case HealthConnectorErrorCodeDto.securityError:
-        return HealthConnectorErrorCode.securityError;
+      case HealthConnectorErrorCodeDto.notAuthorized:
+        return HealthConnectorErrorCode.notAuthorized;
+      case HealthConnectorErrorCodeDto.remoteError:
+        return HealthConnectorErrorCode.remoteError;
+      case HealthConnectorErrorCodeDto.userCancelled:
+        return HealthConnectorErrorCode.userCancelled;
     }
   }
 }

--- a/packages/health_connector_hk_ios/lib/src/pigeon/health_connector_platform_api.g.dart
+++ b/packages/health_connector_hk_ios/lib/src/pigeon/health_connector_platform_api.g.dart
@@ -51,23 +51,29 @@ bool _deepEquals(Object? a, Object? b) {
 /// Error codes that native platforms can use when throwing error.
 enum HealthConnectorErrorCodeDto {
   /// Health platform is unavailable on this device.
-  healthPlatformUnavailable,
+  healthProviderUnavailable,
 
   /// Invalid platform configuration detected.
-  invalidPlatformConfiguration,
+  invalidConfiguration,
 
   /// Invalid argument or input validation error.
   invalidArgument,
 
   /// Attempted to use platform APIs that are not supported on
   /// the current health platform.
-  unsupportedHealthPlatformApi,
+  unsupportedOperation,
 
   /// Unknown or unspecified error.
   unknown,
 
   /// Security/permission error occurred.
-  securityError,
+  notAuthorized,
+
+  /// A transient I/O or communication error occurred.
+  remoteError,
+
+  /// User cancelled the operation.
+  userCancelled,
 }
 
 /// Represents the status of the health platform on the device.

--- a/packages/health_connector_hk_ios/pigeons/health_connector_platform_api.dart
+++ b/packages/health_connector_hk_ios/pigeons/health_connector_platform_api.dart
@@ -18,23 +18,29 @@ import 'package:pigeon/pigeon.dart';
 /// Error codes that native platforms can use when throwing error.
 enum HealthConnectorErrorCodeDto {
   /// Health platform is unavailable on this device.
-  healthPlatformUnavailable,
+  healthProviderUnavailable,
 
   /// Invalid platform configuration detected.
-  invalidPlatformConfiguration,
+  invalidConfiguration,
 
   /// Invalid argument or input validation error.
   invalidArgument,
 
   /// Attempted to use platform APIs that are not supported on
   /// the current health platform.
-  unsupportedHealthPlatformApi,
+  unsupportedOperation,
 
   /// Unknown or unspecified error.
   unknown,
 
   /// Security/permission error occurred.
-  securityError,
+  notAuthorized,
+
+  /// A transient I/O or communication error occurred.
+  remoteError,
+
+  /// User cancelled the operation.
+  userCancelled,
 }
 
 /// Represents the status of the health platform on the device.


### PR DESCRIPTION
### **User description**
- Renames error code values in `health_connector_core` to be better aligned with the domain (e.g., `securityError` -> `notAuthorized`, `healthPlatformUnavailable` -> `healthProviderUnavailable`).
- Updates Pigeon definitions for Android and iOS to match the new core error codes.
- Adds support for `userCancelled` error codes.
- Updates Android and iOS error code mappings.

BREAKING CHANGE: The `HealthConnectorErrorCode` enum has been significantly renamed. Old values like `securityError`, `healthPlatformUnavailable`, and `installationOrUpdateRequired` are removed and replaced with `notAuthorized`, `healthProviderUnavailable`, and `healthProviderNotInstalledOrUpdateRequired` respectively. New `userCancelled` error code was added. Any error handling logic relying on specific enum names must be updated.


___

### **PR Type**
Enhancement, Documentation


___

### **Description**
- Standardizes error code naming across platforms for better domain alignment
  - `securityError` → `notAuthorized`
  - `healthPlatformUnavailable` → `healthProviderUnavailable`
  - `installationOrUpdateRequired` → `healthProviderNotInstalledOrUpdateRequired`
  - `unsupportedHealthPlatformApi` → `unsupportedOperation`
  - `invalidPlatformConfiguration` → `invalidConfiguration`

- Adds new `userCancelled` error code with `@sinceV2_0_0` annotation

- Adds `remoteError` code for transient I/O and communication failures

- Enhances error code documentation with detailed causes and recommended actions

- Updates all platform implementations (Dart, Kotlin, Swift) and Pigeon definitions

- Renames error mapper files for consistency across Android and iOS packages


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Old Error Codes<br/>securityError<br/>healthPlatformUnavailable<br/>unsupportedHealthPlatformApi"] -->|"Rename & Align"| B["New Error Codes<br/>notAuthorized<br/>healthProviderUnavailable<br/>unsupportedOperation"]
  B -->|"Update Mappers"| C["Android<br/>Kotlin Implementation"]
  B -->|"Update Mappers"| D["iOS<br/>Swift Implementation"]
  B -->|"Update Pigeon"| E["Pigeon Definitions<br/>Android & iOS"]
  B -->|"Add Documentation"| F["Enhanced Error Docs<br/>Causes & Actions"]
  G["New Codes<br/>userCancelled<br/>remoteError"] -->|"Add Support"| C
  G -->|"Add Support"| D
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><details><summary>23 files</summary><table>
<tr>
  <td><strong>health_connector_error_code.dart</strong><dd><code>Comprehensive error code refactoring with enhanced documentation</code></dd></td>
  <td><a href="https://github.com/fam-tung-lam/health_connector/pull/34/files#diff-2f2194d283e40700c656db3fbdbd74ec459ac8d66b6abb1c91410221cb37d36d">+105/-40</a></td>

</tr>

<tr>
  <td><strong>since.dart</strong><dd><code>Add version 2.0.0 annotation constant</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/fam-tung-lam/health_connector/pull/34/files#diff-b7730b71358a0b35e832764dd21e745a98c16ce42707376ba09d7ba0399e5b6b">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>health_connector_hc_android_api.dart</strong><dd><code>Rename error codes in Pigeon definition for Android</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/fam-tung-lam/health_connector/pull/34/files#diff-94b53bdf5324682c4271d77979aab294e56468fa03aed4e47f457cb47037cbf9">+11/-5</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>health_connector_hc_android_api.g.dart</strong><dd><code>Update generated Pigeon code with new error codes</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/fam-tung-lam/health_connector/pull/34/files#diff-d756b64a1ed711851582d2a643d79e51d3b0456b5558db0d3352196bb92d9fcc">+11/-5</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>health_connector_error_code_mappers.dart</strong><dd><code>Update error code mapping logic for Android platform</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/fam-tung-lam/health_connector/pull/34/files#diff-997791b3472ef580c220be82adecfffec90a06ee782142a19408be50148fd8f7">+16/-10</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>health_connector_hc_client.dart</strong><dd><code>Rename error mapper import file for consistency</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/fam-tung-lam/health_connector/pull/34/files#diff-a120bdcd1518727307fa1df040f2c1b2d9e37fd032c21f81c5670f5a76d26ed6">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>HealthConnectorHCAndroidApi.g.kt</strong><dd><code>Update generated Kotlin code with new error codes</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/fam-tung-lam/health_connector/pull/34/files#diff-e6f9aac35ab0f3a96117362ead91b0ee359674294103ce3b59a72675da86b028">+9/-5</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>HealthConnectorErrorMappers.kt</strong><dd><code>Update error message mapping for new error codes</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/fam-tung-lam/health_connector/pull/34/files#diff-ea978f5bb0865850e78d1914ec9c7a9209bd39bcf2550af229e2e393abb01633">+11/-5</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>HealthConnectorClient.kt</strong><dd><code>Update error code usage throughout Android client</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/fam-tung-lam/health_connector/pull/34/files#diff-ad31ca5ffb54a1dccd985fd236c8328c8c9c1e372e881727fe17d8dc60b56e2d">+24/-23</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>HealthConnectorHCAndroidPlugin.kt</strong><dd><code>Update error code reference in plugin implementation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/fam-tung-lam/health_connector/pull/34/files#diff-d12ef408900b74499ec89a26a23b12a1b53cd24657c1403ed5ea77fcda65155c">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>health_connector_platform_api.dart</strong><dd><code>Rename error codes in Pigeon definition for iOS</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/fam-tung-lam/health_connector/pull/34/files#diff-bd70880d9151e33820a65ebe97efc5b100aa03bb3c0129eaf9fdbbab3e09e1b8">+10/-4</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>health_connector_platform_api.g.dart</strong><dd><code>Update generated Pigeon code with new error codes</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/fam-tung-lam/health_connector/pull/34/files#diff-230d776da0359b47c38d72b88a8b0a114fd1d6d5cf09e99a18fbeb577b5a1b04">+10/-4</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>health_connector_error_code_mappers.dart</strong><dd><code>Update error code mapping logic for iOS platform</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/fam-tung-lam/health_connector/pull/34/files#diff-00ad0cf411ee8749de76fd86806ce1026b19d107ee0068162ac818c420cf2d4f">+12/-8</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>health_connector_hk_client.dart</strong><dd><code>Rename error mapper import file for consistency</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/fam-tung-lam/health_connector/pull/34/files#diff-02bc71965d968ac39ac3fe030036e2ade416f2e655d8db6451b93a93fa180137">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>HealthConnectorPlatformApi.g.swift</strong><dd><code>Update generated Swift code with new error codes</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/fam-tung-lam/health_connector/pull/34/files#diff-d404fd0601d2ab071c2c77d6d4d7d1c2f04d05df60fa2c1abe4ee5e7f21530d3">+8/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>HealthConnectorErrorMappers.swift</strong><dd><code>Update error code mapping and message generation for iOS</code>&nbsp; </dd></td>
  <td><a href="https://github.com/fam-tung-lam/health_connector/pull/34/files#diff-510015eacd0d1e239b191f8f88fbba510810b2f6b8c12f14b0e362f1b31f7847">+29/-21</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>HealthConnectorClient.swift</strong><dd><code>Update error code usage throughout iOS client</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/fam-tung-lam/health_connector/pull/34/files#diff-7ba7a6730c323361114ecfcd6fd7f2c783b62de742fd417e2b020ed14ed961fb">+3/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>HealthConnectorHkIosPlugin.swift</strong><dd><code>Update error code references in iOS plugin implementation</code></dd></td>
  <td><a href="https://github.com/fam-tung-lam/health_connector/pull/34/files#diff-d32ef736d1ea3139ea58944d56d32e3219003e2c8e29d8ff9d8913cf829611f5">+9/-9</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>aggregate_health_data_page.dart</strong><dd><code>Update error code reference in example app</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/fam-tung-lam/health_connector/pull/34/files#diff-a900ddbcebeb134dc83eeea8b4cd65841bd82c112a25c5c3338ebc0f899ade74">+1/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>permissions_page.dart</strong><dd><code>Update error code reference in example app</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/fam-tung-lam/health_connector/pull/34/files#diff-072fd6144dd5788f8537f5011b4f30fb71fb9c44443e19307387082a4c583420">+1/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>read_health_records_page.dart</strong><dd><code>Update error code references in example app</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/fam-tung-lam/health_connector/pull/34/files#diff-7f48e2c0326e5a9589ee3441bd08560e0a206bb394c1918c6ef0bea7013930f7">+2/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>write_health_record_form_page.dart</strong><dd><code>Update error code reference in example app</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/fam-tung-lam/health_connector/pull/34/files#diff-44252a75f0d550a07ae10a2b7c91d2fe8d448d7445ff92c4da73fcab587fd2d0">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>main.dart</strong><dd><code>Update error code references in example app</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/fam-tung-lam/health_connector/pull/34/files#diff-bf11050e89e9b435ace8fb89b3d59368ac888f38f4771df8ef570b7a4e1b4fe7">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Documentation</strong></td><td><details><summary>2 files</summary><table>
<tr>
  <td><strong>supported_on.dart</strong><dd><code>Update documentation to reference new error code name</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/fam-tung-lam/health_connector/pull/34/files#diff-f5ef02843ade9641f6a881a7a0e17dc8093d6d562eef167d774b4fba267fa51a">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>health_connector.dart</strong><dd><code>Update documentation references to new error codes</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/fam-tung-lam/health_connector/pull/34/files#diff-a7c3b4728d2f5d7620a681bac605cc57250cad25ec594cc421f1eed837b56cb6">+21/-21</a>&nbsp; </td>

</tr>
</table></details></td></tr></tbody></table>

</details>

___

