### PR TITLE
chore(health_connector,health_connector_logger,health_connector_hc_android,health_connector_hk_ios): Remove obsolete `phase` data from log messages

### DIFF
--- a/packages/health_connector/lib/src/health_connector.dart
+++ b/packages/health_connector/lib/src/health_connector.dart
@@ -92,7 +92,6 @@ final class HealthConnector {
         HealthConnectorLogger.error(
           _tag,
           operation: 'create',
-          phase: 'failed',
           message: 'Health platform unavailable',
           context: {'platform': healthPlatform.name},
         );
@@ -105,7 +104,6 @@ final class HealthConnector {
         HealthConnectorLogger.warning(
           _tag,
           operation: 'create',
-          phase: 'failed',
           message: 'Health platform installation or update required',
           context: {'platform': healthPlatform.name},
         );
@@ -118,7 +116,6 @@ final class HealthConnector {
         HealthConnectorLogger.info(
           _tag,
           operation: 'create',
-          phase: 'succeeded',
           message: 'HealthConnector created successfully',
           context: {'platform': healthPlatform.name},
         );
@@ -182,7 +179,6 @@ final class HealthConnector {
     HealthConnectorLogger.debug(
       _tag,
       operation: 'getHealthPlatformStatus',
-      phase: 'entry',
       message: 'Checking health platform status',
     );
 
@@ -200,7 +196,6 @@ final class HealthConnector {
       HealthConnectorLogger.info(
         _tag,
         operation: 'getHealthPlatformStatus',
-        phase: 'succeeded',
         message: 'Health platform status retrieved',
         context: {'status': status.name},
       );
@@ -210,7 +205,6 @@ final class HealthConnector {
       HealthConnectorLogger.error(
         _tag,
         operation: 'getHealthPlatformStatus',
-        phase: 'failed',
         message: 'Failed to get health platform status',
         exception: e,
         stackTrace: st,
@@ -272,7 +266,6 @@ final class HealthConnector {
     HealthConnectorLogger.debug(
       tag,
       operation: 'requestPermissions',
-      phase: 'entry',
       message: 'Requesting permissions',
       context: {'permissions': permissions},
     );
@@ -287,7 +280,6 @@ final class HealthConnector {
       HealthConnectorLogger.info(
         tag,
         operation: 'requestPermissions',
-        phase: 'succeeded',
         message: 'Permissions requested successfully',
         context: {'results': results},
       );
@@ -297,7 +289,6 @@ final class HealthConnector {
       HealthConnectorLogger.error(
         tag,
         operation: 'requestPermissions',
-        phase: 'failed',
         message: 'Failed to request permissions',
         exception: e,
         stackTrace: st,
@@ -356,7 +347,6 @@ final class HealthConnector {
     HealthConnectorLogger.debug(
       tag,
       operation: 'getGrantedPermissions',
-      phase: 'entry',
       message: 'Getting granted permissions',
     );
 
@@ -365,7 +355,6 @@ final class HealthConnector {
         HealthConnectorLogger.error(
           tag,
           operation: 'getGrantedPermissions',
-          phase: 'failed',
           message: 'getGrantedPermissions is only available on Health Connect',
           context: {'current_health_platform': _healthPlatform.name},
         );
@@ -382,7 +371,6 @@ final class HealthConnector {
           HealthConnectorLogger.info(
             tag,
             operation: 'getGrantedPermissions',
-            phase: 'succeeded',
             message: 'Granted permissions retrieved',
             context: {'permissions': permissions},
           );
@@ -392,7 +380,6 @@ final class HealthConnector {
           HealthConnectorLogger.error(
             tag,
             operation: 'getGrantedPermissions',
-            phase: 'failed',
             message: 'Failed to get granted permissions',
             exception: e,
             stackTrace: st,
@@ -434,7 +421,6 @@ final class HealthConnector {
     HealthConnectorLogger.debug(
       tag,
       operation: 'revokeAllPermissions',
-      phase: 'entry',
       message: 'Revoking all permissions',
     );
 
@@ -443,7 +429,6 @@ final class HealthConnector {
         HealthConnectorLogger.error(
           tag,
           operation: 'revokeAllPermissions',
-          phase: 'failed',
           message: 'revokeAllPermissions is only available on Health Connect',
           context: {'current_health_platform': _healthPlatform.name},
         );
@@ -460,14 +445,12 @@ final class HealthConnector {
           HealthConnectorLogger.info(
             tag,
             operation: 'revokeAllPermissions',
-            phase: 'succeeded',
             message: 'All permissions revoked successfully',
           );
         } catch (e, st) {
           HealthConnectorLogger.error(
             tag,
             operation: 'revokeAllPermissions',
-            phase: 'failed',
             message: 'Failed to revoke all permissions',
             exception: e,
             stackTrace: st,
@@ -529,7 +512,6 @@ final class HealthConnector {
     HealthConnectorLogger.debug(
       tag,
       operation: 'getFeatureStatus',
-      phase: 'entry',
       message: 'Checking feature status',
       context: {'feature': feature.toString()},
     );
@@ -539,7 +521,6 @@ final class HealthConnector {
         HealthConnectorLogger.info(
           tag,
           operation: 'getFeatureStatus',
-          phase: 'succeeded',
           message: 'Feature status retrieved',
           context: {'feature': feature.toString(), 'status': 'available'},
         );
@@ -553,7 +534,6 @@ final class HealthConnector {
           HealthConnectorLogger.info(
             tag,
             operation: 'getFeatureStatus',
-            phase: 'succeeded',
             message: 'Feature status retrieved',
             context: {
               'feature': feature.toString(),
@@ -566,7 +546,6 @@ final class HealthConnector {
           HealthConnectorLogger.error(
             tag,
             operation: 'getFeatureStatus',
-            phase: 'failed',
             message: 'Failed to get feature status',
             context: {'feature': feature.toString()},
             exception: e,
@@ -615,7 +594,6 @@ final class HealthConnector {
     HealthConnectorLogger.debug(
       tag,
       operation: 'readRecord',
-      phase: 'entry',
       message: 'Reading health record',
       context: {'request': request},
     );
@@ -627,7 +605,6 @@ final class HealthConnector {
         HealthConnectorLogger.info(
           tag,
           operation: 'readRecord',
-          phase: 'succeeded',
           message: 'Health record read successfully',
           context: {'request': request, 'response': record},
         );
@@ -635,7 +612,6 @@ final class HealthConnector {
         HealthConnectorLogger.info(
           tag,
           operation: 'readRecord',
-          phase: 'succeeded',
           message: 'Health record not found',
           context: {'request': request, 'response': null},
         );
@@ -646,7 +622,6 @@ final class HealthConnector {
       HealthConnectorLogger.error(
         tag,
         operation: 'readRecord',
-        phase: 'failed',
         message: 'Failed to read health record',
         context: {'request': request},
         exception: e,
@@ -704,7 +679,6 @@ final class HealthConnector {
     HealthConnectorLogger.debug(
       tag,
       operation: 'readRecords',
-      phase: 'entry',
       message: 'Reading health records',
       context: {'request': request},
     );
@@ -715,7 +689,6 @@ final class HealthConnector {
       HealthConnectorLogger.info(
         tag,
         operation: 'readRecords',
-        phase: 'succeeded',
         message: 'Health records read successfully',
         context: {'request': request, 'response': response},
       );
@@ -725,7 +698,6 @@ final class HealthConnector {
       HealthConnectorLogger.error(
         tag,
         operation: 'readRecords',
-        phase: 'failed',
         message: 'Failed to read health records',
         context: {'request': request},
         exception: e,
@@ -780,7 +752,6 @@ final class HealthConnector {
     HealthConnectorLogger.debug(
       tag,
       operation: 'writeRecord',
-      phase: 'entry',
       message: 'Writing health record',
       context: {'record': record},
     );
@@ -796,7 +767,6 @@ final class HealthConnector {
       HealthConnectorLogger.info(
         tag,
         operation: 'writeRecord',
-        phase: 'succeeded',
         message: 'Health record written successfully',
         context: {'record': record, 'assignedRecordId': recordId},
       );
@@ -806,7 +776,6 @@ final class HealthConnector {
       HealthConnectorLogger.error(
         tag,
         operation: 'writeRecord',
-        phase: 'failed',
         message: 'Validation failed',
         context: {'record': record},
         exception: e,
@@ -821,7 +790,6 @@ final class HealthConnector {
       HealthConnectorLogger.error(
         tag,
         operation: 'writeRecord',
-        phase: 'failed',
         message: 'Failed to write health record',
         context: {'record': record},
         exception: e,
@@ -891,7 +859,6 @@ final class HealthConnector {
     HealthConnectorLogger.debug(
       tag,
       operation: 'writeRecords',
-      phase: 'entry',
       message: 'Writing health records',
       context: {'records': records},
     );
@@ -912,7 +879,6 @@ final class HealthConnector {
       HealthConnectorLogger.info(
         tag,
         operation: 'writeRecords',
-        phase: 'succeeded',
         message: 'Health records written successfully',
         context: {'records': records, 'assignedRecordIds': recordIds},
       );
@@ -922,7 +888,6 @@ final class HealthConnector {
       HealthConnectorLogger.error(
         tag,
         operation: 'writeRecords',
-        phase: 'failed',
         message: 'Validation failed',
         context: {'records': records},
         exception: e,
@@ -937,7 +902,6 @@ final class HealthConnector {
       HealthConnectorLogger.error(
         tag,
         operation: 'writeRecords',
-        phase: 'failed',
         message: 'Failed to write health records',
         context: {'records': records},
         exception: e,
@@ -989,7 +953,6 @@ final class HealthConnector {
     HealthConnectorLogger.debug(
       tag,
       operation: 'aggregate',
-      phase: 'entry',
       message: 'Aggregating health data',
       context: {'request': request},
     );
@@ -1000,7 +963,6 @@ final class HealthConnector {
       HealthConnectorLogger.info(
         tag,
         operation: 'aggregate',
-        phase: 'succeeded',
         message: 'Health data aggregated successfully',
         context: {'request': request, 'response': response},
       );
@@ -1010,7 +972,6 @@ final class HealthConnector {
       HealthConnectorLogger.error(
         tag,
         operation: 'aggregate',
-        phase: 'failed',
         message: 'Failed to aggregate health data',
         context: {'request': request},
         exception: e,
@@ -1074,7 +1035,6 @@ final class HealthConnector {
     HealthConnectorLogger.debug(
       tag,
       operation: 'deleteRecords',
-      phase: 'entry',
       message: 'Deleting health records by time range',
       context: {'request': request},
     );
@@ -1091,7 +1051,6 @@ final class HealthConnector {
       HealthConnectorLogger.info(
         tag,
         operation: 'deleteRecords',
-        phase: 'succeeded',
         message: 'Health records deleted successfully',
         context: {'request': request},
       );
@@ -1099,7 +1058,6 @@ final class HealthConnector {
       HealthConnectorLogger.error(
         tag,
         operation: 'deleteRecords',
-        phase: 'failed',
         message: 'Failed to delete health records',
         context: {'request': request},
         exception: e,
@@ -1165,7 +1123,6 @@ final class HealthConnector {
     HealthConnectorLogger.debug(
       tag,
       operation: 'deleteRecordsByIds',
-      phase: 'entry',
       message: 'Deleting health records by IDs',
       context: {'request': request},
     );
@@ -1185,7 +1142,6 @@ final class HealthConnector {
       HealthConnectorLogger.info(
         tag,
         operation: 'deleteRecordsByIds',
-        phase: 'succeeded',
         message: 'Health records deleted successfully',
         context: {'request': request},
       );
@@ -1193,7 +1149,6 @@ final class HealthConnector {
       HealthConnectorLogger.error(
         tag,
         operation: 'deleteRecordsByIds',
-        phase: 'failed',
         message: 'Validation failed',
         context: {'request': request},
         exception: e,
@@ -1208,7 +1163,6 @@ final class HealthConnector {
       HealthConnectorLogger.error(
         tag,
         operation: 'deleteRecordsByIds',
-        phase: 'failed',
         message: 'Failed to delete health records by IDs',
         context: {'request': request},
         exception: e,
@@ -1283,7 +1237,6 @@ final class HealthConnector {
     HealthConnectorLogger.debug(
       tag,
       operation: 'updateRecord',
-      phase: 'entry',
       message: 'Updating health record',
       context: {'record': record},
     );
@@ -1299,7 +1252,6 @@ final class HealthConnector {
       HealthConnectorLogger.info(
         tag,
         operation: 'updateRecord',
-        phase: 'succeeded',
         message: 'Health record updated successfully',
         context: {'record': record},
       );
@@ -1309,7 +1261,6 @@ final class HealthConnector {
       HealthConnectorLogger.warning(
         tag,
         operation: 'updateRecord',
-        phase: 'failed',
         message: 'Validation failed',
         context: {'record': record},
         exception: e,
@@ -1324,7 +1275,6 @@ final class HealthConnector {
       HealthConnectorLogger.error(
         tag,
         operation: 'updateRecord',
-        phase: 'failed',
         message: 'Failed to update health record',
         context: {'record': record},
         exception: e,

--- a/packages/health_connector_hc_android/android/src/main/kotlin/com/phamtunglam/health_connector_hc_android/HealthConnectorClient.kt
+++ b/packages/health_connector_hc_android/android/src/main/kotlin/com/phamtunglam/health_connector_hc_android/HealthConnectorClient.kt
@@ -103,7 +103,6 @@ internal class HealthConnectorClient private constructor(
                 HealthConnectorLogger.error(
                     tag = TAG,
                     operation = "getOrCreate",
-                    phase = "failed",
                     message = "Failed to create Health Connect client " +
                         "due to SDK version too low or running in a profile mode",
                     exception = e,
@@ -116,7 +115,6 @@ internal class HealthConnectorClient private constructor(
                 HealthConnectorLogger.error(
                     tag = TAG,
                     operation = "getOrCreate",
-                    phase = "failed",
                     message = "Failed to create Health Connect client due to service not available",
                     exception = e,
                 )
@@ -136,7 +134,6 @@ internal class HealthConnectorClient private constructor(
             HealthConnectorLogger.debug(
                 tag = TAG,
                 operation = "getHealthPlatformStatus",
-                phase = "entry",
                 message = "Getting Health Connect SDK status",
             )
 
@@ -146,7 +143,6 @@ internal class HealthConnectorClient private constructor(
             HealthConnectorLogger.info(
                 tag = TAG,
                 operation = "getHealthPlatformStatus",
-                phase = "completed",
                 message = "Health Connect platform status retrieved",
                 context = mapOf(
                     "status_code" to statusCode,
@@ -179,7 +175,6 @@ internal class HealthConnectorClient private constructor(
         HealthConnectorLogger.debug(
             tag = TAG,
             operation = "requestPermissions",
-            phase = "entry",
             message = "Requesting Health Connect permissions",
             context = mapOf(
                 "requested_permissions" to request.permissionRequests,
@@ -200,7 +195,6 @@ internal class HealthConnectorClient private constructor(
             HealthConnectorLogger.error(
                 tag = TAG,
                 operation = "requestPermissions",
-                phase = "failed",
                 message = e.message,
                 context = mapOf(
                     "requested_permissions" to request.permissionRequests,
@@ -214,7 +208,6 @@ internal class HealthConnectorClient private constructor(
             HealthConnectorLogger.error(
                 tag = TAG,
                 operation = "requestPermissions",
-                phase = "failed",
                 message = "Failed to request Health Connect permissions",
                 context = mapOf(
                     "requested_permissions" to request.permissionRequests,
@@ -247,7 +240,6 @@ internal class HealthConnectorClient private constructor(
         HealthConnectorLogger.debug(
             tag = TAG,
             operation = "getFeatureStatus",
-            phase = "entry",
             message = "Checking Health Connect feature status",
             context = mapOf("feature" to feature),
         )
@@ -261,7 +253,6 @@ internal class HealthConnectorClient private constructor(
             HealthConnectorLogger.info(
                 tag = TAG,
                 operation = "getFeatureStatus",
-                phase = "completed",
                 message = "Health Connect feature status retrieved",
                 context = mapOf(
                     "feature" to feature,
@@ -274,7 +265,6 @@ internal class HealthConnectorClient private constructor(
             HealthConnectorLogger.error(
                 tag = TAG,
                 operation = "getFeatureStatus",
-                phase = "failed",
                 message = e.message,
                 context = mapOf("feature" to feature),
                 exception = e,
@@ -286,7 +276,6 @@ internal class HealthConnectorClient private constructor(
             HealthConnectorLogger.error(
                 tag = TAG,
                 operation = "getFeatureStatus",
-                phase = "failed",
                 message = "Failed to get Health Connect feature status",
                 context = mapOf("feature" to feature),
                 exception = e,
@@ -312,7 +301,7 @@ internal class HealthConnectorClient private constructor(
         HealthConnectorLogger.debug(
             tag = TAG,
             operation = "readRecord",
-            phase = "entry",
+
             message = "Reading Health Connect record",
             context = mapOf("request" to request),
         )
@@ -331,7 +320,7 @@ internal class HealthConnectorClient private constructor(
             HealthConnectorLogger.info(
                 tag = TAG,
                 operation = "readRecord",
-                phase = "completed",
+
                 message = "Health Connect record read successfully",
                 context = mapOf(
                     "request" to request,
@@ -344,7 +333,7 @@ internal class HealthConnectorClient private constructor(
             HealthConnectorLogger.error(
                 tag = TAG,
                 operation = "readRecord",
-                phase = "failed",
+
                 message = "Failed to read Health Connect record",
                 context = mapOf("request" to request),
                 exception = e,
@@ -357,7 +346,7 @@ internal class HealthConnectorClient private constructor(
             HealthConnectorLogger.error(
                 tag = TAG,
                 operation = "readRecord",
-                phase = "failed",
+
                 message = "Failed to read Health Connect record",
                 context = mapOf("request" to request),
                 exception = e,
@@ -383,7 +372,7 @@ internal class HealthConnectorClient private constructor(
         HealthConnectorLogger.debug(
             tag = TAG,
             operation = "readRecords",
-            phase = "entry",
+
             message = "Reading Health Connect records",
             context = mapOf("request" to request),
         )
@@ -432,7 +421,7 @@ internal class HealthConnectorClient private constructor(
             HealthConnectorLogger.info(
                 tag = TAG,
                 operation = "readRecords",
-                phase = "completed",
+
                 message = "Health Connect records read successfully",
                 context = mapOf(
                     "request" to request,
@@ -445,7 +434,7 @@ internal class HealthConnectorClient private constructor(
             HealthConnectorLogger.error(
                 tag = TAG,
                 operation = "readRecords",
-                phase = "failed",
+
                 message = "Failed to read Health Connect records",
                 context = mapOf("request" to request),
                 exception = e,
@@ -458,7 +447,7 @@ internal class HealthConnectorClient private constructor(
             HealthConnectorLogger.error(
                 tag = TAG,
                 operation = "readRecords",
-                phase = "failed",
+
                 message = "Failed to read Health Connect records",
                 context = mapOf("request" to request),
                 exception = e,
@@ -483,7 +472,7 @@ internal class HealthConnectorClient private constructor(
         HealthConnectorLogger.debug(
             tag = TAG,
             operation = "writeRecord",
-            phase = "entry",
+
             message = "Writing Health Connect record",
             context = mapOf("request" to request),
         )
@@ -499,7 +488,7 @@ internal class HealthConnectorClient private constructor(
             HealthConnectorLogger.info(
                 tag = TAG,
                 operation = "writeRecord",
-                phase = "completed",
+
                 message = "Health Connect record written successfully",
                 context = mapOf(
                     "request" to request,
@@ -512,7 +501,7 @@ internal class HealthConnectorClient private constructor(
             HealthConnectorLogger.error(
                 tag = TAG,
                 operation = "writeRecord",
-                phase = "failed",
+
                 message = "Failed to write Health Connect record",
                 context = mapOf("request" to request),
                 exception = e,
@@ -525,7 +514,7 @@ internal class HealthConnectorClient private constructor(
             HealthConnectorLogger.error(
                 tag = TAG,
                 operation = "writeRecord",
-                phase = "failed",
+
                 message = "Failed to write Health Connect record",
                 context = mapOf("request" to request),
                 exception = e,
@@ -550,7 +539,7 @@ internal class HealthConnectorClient private constructor(
         HealthConnectorLogger.debug(
             tag = TAG,
             operation = "writeRecords",
-            phase = "entry",
+
             message = "Writing Health Connect records",
             context = mapOf("request" to request),
         )
@@ -566,7 +555,7 @@ internal class HealthConnectorClient private constructor(
             HealthConnectorLogger.info(
                 tag = TAG,
                 operation = "writeRecords",
-                phase = "completed",
+
                 message = "Health Connect records written successfully",
                 context = mapOf(
                     "request" to request,
@@ -579,7 +568,7 @@ internal class HealthConnectorClient private constructor(
             HealthConnectorLogger.error(
                 tag = TAG,
                 operation = "writeRecords",
-                phase = "failed",
+
                 message = "Failed to write Health Connect records",
                 context = mapOf("request" to request),
                 exception = e,
@@ -592,7 +581,7 @@ internal class HealthConnectorClient private constructor(
             HealthConnectorLogger.error(
                 tag = TAG,
                 operation = "writeRecords",
-                phase = "failed",
+
                 message = "Failed to write Health Connect records",
                 context = mapOf("request" to request),
                 exception = e,
@@ -618,7 +607,7 @@ internal class HealthConnectorClient private constructor(
         HealthConnectorLogger.debug(
             tag = TAG,
             operation = "updateRecord",
-            phase = "entry",
+
             message = "Updating Health Connect record",
             context = mapOf("request" to request),
         )
@@ -641,7 +630,7 @@ internal class HealthConnectorClient private constructor(
             HealthConnectorLogger.info(
                 tag = TAG,
                 operation = "updateRecord",
-                phase = "completed",
+
                 message = "Health Connect record updated successfully",
                 context = mapOf("request" to request),
             )
@@ -651,7 +640,7 @@ internal class HealthConnectorClient private constructor(
             HealthConnectorLogger.error(
                 tag = TAG,
                 operation = "updateRecord",
-                phase = "failed",
+
                 message = "Failed to update Health Connect record",
                 context = mapOf("request" to request),
                 exception = e,
@@ -663,7 +652,7 @@ internal class HealthConnectorClient private constructor(
             HealthConnectorLogger.error(
                 tag = TAG,
                 operation = "updateRecord",
-                phase = "failed",
+
                 message = "Failed to update Health Connect record",
                 context = mapOf("request" to request),
                 exception = e,
@@ -676,7 +665,7 @@ internal class HealthConnectorClient private constructor(
             HealthConnectorLogger.error(
                 tag = TAG,
                 operation = "updateRecord",
-                phase = "failed",
+
                 message = "Failed to update Health Connect record",
                 context = mapOf("request" to request),
                 exception = e,
@@ -778,7 +767,7 @@ internal class HealthConnectorClient private constructor(
         HealthConnectorLogger.debug(
             tag = TAG,
             operation = "aggregateOxygenSaturationManually",
-            phase = "entry",
+
             message = "Manually aggregating Oxygen Saturation records",
             context = mapOf("request" to request),
         )
@@ -820,7 +809,7 @@ internal class HealthConnectorClient private constructor(
             HealthConnectorLogger.info(
                 tag = TAG,
                 operation = "aggregateOxygenSaturationManually",
-                phase = "completed",
+
                 message = "Oxygen Saturation records aggregated successfully",
                 context = mapOf(
                     "request" to request,
@@ -834,7 +823,7 @@ internal class HealthConnectorClient private constructor(
             HealthConnectorLogger.error(
                 tag = TAG,
                 operation = "aggregateOxygenSaturationManually",
-                phase = "failed",
+
                 message = "Unsupported aggregation operation",
                 context = mapOf("request" to request),
                 exception = e,
@@ -847,7 +836,7 @@ internal class HealthConnectorClient private constructor(
             HealthConnectorLogger.error(
                 tag = TAG,
                 operation = "aggregateOxygenSaturationManually",
-                phase = "failed",
+
                 message = "Invalid aggregation state",
                 context = mapOf("request" to request),
                 exception = e,
@@ -859,7 +848,7 @@ internal class HealthConnectorClient private constructor(
             HealthConnectorLogger.error(
                 tag = TAG,
                 operation = "aggregateOxygenSaturationManually",
-                phase = "failed",
+
                 message = "Failed to aggregate Oxygen Saturation records",
                 context = mapOf("request" to request),
                 exception = e,
@@ -872,7 +861,7 @@ internal class HealthConnectorClient private constructor(
             HealthConnectorLogger.error(
                 tag = TAG,
                 operation = "aggregateOxygenSaturationManually",
-                phase = "failed",
+
                 message = "Failed to aggregate Oxygen Saturation records",
                 context = mapOf("request" to request),
                 exception = e,
@@ -974,7 +963,7 @@ internal class HealthConnectorClient private constructor(
         HealthConnectorLogger.debug(
             tag = TAG,
             operation = "aggregateRespiratoryRateManually",
-            phase = "entry",
+
             message = "Manually aggregating Respiratory Rate records",
             context = mapOf("request" to request),
         )
@@ -1016,7 +1005,7 @@ internal class HealthConnectorClient private constructor(
             HealthConnectorLogger.info(
                 tag = TAG,
                 operation = "aggregateRespiratoryRateManually",
-                phase = "completed",
+
                 message = "Respiratory Rate records aggregated successfully",
                 context = mapOf(
                     "request" to request,
@@ -1030,7 +1019,7 @@ internal class HealthConnectorClient private constructor(
             HealthConnectorLogger.error(
                 tag = TAG,
                 operation = "aggregateRespiratoryRateManually",
-                phase = "failed",
+
                 message = "Unsupported aggregation operation",
                 context = mapOf("request" to request),
                 exception = e,
@@ -1043,7 +1032,7 @@ internal class HealthConnectorClient private constructor(
             HealthConnectorLogger.error(
                 tag = TAG,
                 operation = "aggregateRespiratoryRateManually",
-                phase = "failed",
+
                 message = "Invalid aggregation state",
                 context = mapOf("request" to request),
                 exception = e,
@@ -1055,7 +1044,7 @@ internal class HealthConnectorClient private constructor(
             HealthConnectorLogger.error(
                 tag = TAG,
                 operation = "aggregateRespiratoryRateManually",
-                phase = "failed",
+
                 message = "Failed to aggregate Respiratory Rate records",
                 context = mapOf("request" to request),
                 exception = e,
@@ -1068,7 +1057,7 @@ internal class HealthConnectorClient private constructor(
             HealthConnectorLogger.error(
                 tag = TAG,
                 operation = "aggregateRespiratoryRateManually",
-                phase = "failed",
+
                 message = "Failed to aggregate Respiratory Rate records",
                 context = mapOf("request" to request),
                 exception = e,
@@ -1170,7 +1159,7 @@ internal class HealthConnectorClient private constructor(
         HealthConnectorLogger.debug(
             tag = TAG,
             operation = "aggregateVo2MaxManually",
-            phase = "entry",
+
             message = "Manually aggregating VO2Max records",
             context = mapOf("request" to request),
         )
@@ -1211,7 +1200,7 @@ internal class HealthConnectorClient private constructor(
             HealthConnectorLogger.info(
                 tag = TAG,
                 operation = "aggregateVo2MaxManually",
-                phase = "completed",
+
                 message = "VO2Max records aggregated successfully",
                 context = mapOf(
                     "request" to request,
@@ -1225,7 +1214,7 @@ internal class HealthConnectorClient private constructor(
             HealthConnectorLogger.error(
                 tag = TAG,
                 operation = "aggregateVo2MaxManually",
-                phase = "failed",
+
                 message = "Unsupported aggregation operation",
                 context = mapOf("request" to request),
                 exception = e,
@@ -1238,7 +1227,7 @@ internal class HealthConnectorClient private constructor(
             HealthConnectorLogger.error(
                 tag = TAG,
                 operation = "aggregateVo2MaxManually",
-                phase = "failed",
+
                 message = "Invalid aggregation state",
                 context = mapOf("request" to request),
                 exception = e,
@@ -1250,7 +1239,7 @@ internal class HealthConnectorClient private constructor(
             HealthConnectorLogger.error(
                 tag = TAG,
                 operation = "aggregateVo2MaxManually",
-                phase = "failed",
+
                 message = "Failed to aggregate VO2Max records",
                 context = mapOf("request" to request),
                 exception = e,
@@ -1263,7 +1252,7 @@ internal class HealthConnectorClient private constructor(
             HealthConnectorLogger.error(
                 tag = TAG,
                 operation = "aggregateVo2MaxManually",
-                phase = "failed",
+
                 message = "Failed to aggregate VO2Max records",
                 context = mapOf("request" to request),
                 exception = e,
@@ -1365,7 +1354,7 @@ internal class HealthConnectorClient private constructor(
         HealthConnectorLogger.debug(
             tag = TAG,
             operation = "aggregateBloodGlucoseManually",
-            phase = "entry",
+
             message = "Manually aggregating Blood Glucose records",
             context = mapOf("request" to request),
         )
@@ -1407,7 +1396,7 @@ internal class HealthConnectorClient private constructor(
             HealthConnectorLogger.info(
                 tag = TAG,
                 operation = "aggregateBloodGlucoseManually",
-                phase = "completed",
+
                 message = "Blood Glucose records aggregated successfully",
                 context = mapOf(
                     "request" to request,
@@ -1421,7 +1410,7 @@ internal class HealthConnectorClient private constructor(
             HealthConnectorLogger.error(
                 tag = TAG,
                 operation = "aggregateBloodGlucoseManually",
-                phase = "failed",
+
                 message = "Unsupported aggregation operation",
                 context = mapOf("request" to request),
                 exception = e,
@@ -1434,7 +1423,7 @@ internal class HealthConnectorClient private constructor(
             HealthConnectorLogger.error(
                 tag = TAG,
                 operation = "aggregateBloodGlucoseManually",
-                phase = "failed",
+
                 message = "Invalid aggregation state",
                 context = mapOf("request" to request),
                 exception = e,
@@ -1446,7 +1435,7 @@ internal class HealthConnectorClient private constructor(
             HealthConnectorLogger.error(
                 tag = TAG,
                 operation = "aggregateBloodGlucoseManually",
-                phase = "failed",
+
                 message = "Failed to aggregate Blood Glucose records",
                 context = mapOf("request" to request),
                 exception = e,
@@ -1459,7 +1448,7 @@ internal class HealthConnectorClient private constructor(
             HealthConnectorLogger.error(
                 tag = TAG,
                 operation = "aggregateBloodGlucoseManually",
-                phase = "failed",
+
                 message = "Failed to aggregate Blood Glucose records",
                 context = mapOf("request" to request),
                 exception = e,
@@ -1485,7 +1474,7 @@ internal class HealthConnectorClient private constructor(
         HealthConnectorLogger.debug(
             tag = TAG,
             operation = "aggregate",
-            phase = "entry",
+
             message = "Aggregating Health Connect data",
             context = mapOf("request" to request),
         )
@@ -1547,7 +1536,7 @@ internal class HealthConnectorClient private constructor(
             HealthConnectorLogger.info(
                 tag = TAG,
                 operation = "aggregate",
-                phase = "completed",
+
                 message = "Health Connect data aggregated successfully",
                 context = mapOf(
                     "request" to request,
@@ -1560,7 +1549,7 @@ internal class HealthConnectorClient private constructor(
             HealthConnectorLogger.error(
                 tag = TAG,
                 operation = "aggregate",
-                phase = "failed",
+
                 message = "Unsupported aggregation operation",
                 context = mapOf("request" to request),
                 exception = e,
@@ -1573,7 +1562,7 @@ internal class HealthConnectorClient private constructor(
             HealthConnectorLogger.error(
                 tag = TAG,
                 operation = "aggregate",
-                phase = "failed",
+
                 message = "Invalid aggregation state - null result from Health Connect",
                 context = mapOf("request" to request),
                 exception = e,
@@ -1587,7 +1576,7 @@ internal class HealthConnectorClient private constructor(
             HealthConnectorLogger.error(
                 tag = TAG,
                 operation = "aggregate",
-                phase = "failed",
+
                 message = "Failed to aggregate Health Connect data",
                 context = mapOf("request" to request),
                 exception = e,
@@ -1597,7 +1586,7 @@ internal class HealthConnectorClient private constructor(
             HealthConnectorLogger.error(
                 tag = TAG,
                 operation = "aggregate",
-                phase = "failed",
+
                 message = "Failed to aggregate Health Connect data",
                 context = mapOf("request" to request),
                 exception = e,
@@ -1610,7 +1599,7 @@ internal class HealthConnectorClient private constructor(
             HealthConnectorLogger.error(
                 tag = TAG,
                 operation = "aggregate",
-                phase = "failed",
+
                 message = "Failed to aggregate Health Connect data",
                 context = mapOf("request" to request),
                 exception = e,
@@ -1633,7 +1622,7 @@ internal class HealthConnectorClient private constructor(
         HealthConnectorLogger.debug(
             tag = TAG,
             operation = "deleteRecords",
-            phase = "entry",
+
             message = "Deleting Health Connect records by time range",
             context = mapOf("request" to request),
         )
@@ -1653,7 +1642,7 @@ internal class HealthConnectorClient private constructor(
             HealthConnectorLogger.info(
                 tag = TAG,
                 operation = "deleteRecords",
-                phase = "completed",
+
                 message = "Health Connect records deleted successfully",
                 context = mapOf("request" to request),
             )
@@ -1661,7 +1650,7 @@ internal class HealthConnectorClient private constructor(
             HealthConnectorLogger.error(
                 tag = TAG,
                 operation = "deleteRecords",
-                phase = "failed",
+
                 message = "Failed to delete Health Connect records",
                 context = mapOf("request" to request),
                 exception = e,
@@ -1674,7 +1663,7 @@ internal class HealthConnectorClient private constructor(
             HealthConnectorLogger.error(
                 tag = TAG,
                 operation = "deleteRecords",
-                phase = "failed",
+
                 message = "Failed to delete Health Connect records",
                 context = mapOf("request" to request),
                 exception = e,
@@ -1697,7 +1686,7 @@ internal class HealthConnectorClient private constructor(
         HealthConnectorLogger.debug(
             tag = TAG,
             operation = "deleteRecordsByIds",
-            phase = "entry",
+
             message = "Deleting Health Connect records by IDs",
             context = mapOf("request" to request),
         )
@@ -1706,7 +1695,7 @@ internal class HealthConnectorClient private constructor(
             HealthConnectorLogger.warning(
                 tag = TAG,
                 operation = "deleteRecordsByIds",
-                phase = "completed",
+
                 message = "No records to delete (empty IDs list)",
             )
             return
@@ -1724,7 +1713,7 @@ internal class HealthConnectorClient private constructor(
             HealthConnectorLogger.info(
                 tag = TAG,
                 operation = "deleteRecordsByIds",
-                phase = "completed",
+
                 message = "Health Connect records deleted successfully",
                 context = mapOf("request" to request),
             )
@@ -1732,7 +1721,7 @@ internal class HealthConnectorClient private constructor(
             HealthConnectorLogger.error(
                 tag = TAG,
                 operation = "deleteRecordsByIds",
-                phase = "failed",
+
                 message = "Failed to delete Health Connect records by IDs",
                 context = mapOf("request" to request),
                 exception = e,
@@ -1745,7 +1734,7 @@ internal class HealthConnectorClient private constructor(
             HealthConnectorLogger.error(
                 tag = TAG,
                 operation = "deleteRecordsByIds",
-                phase = "failed",
+
                 message = "Failed to delete Health Connect records by IDs",
                 context = mapOf("request" to request),
                 exception = e,
@@ -1769,7 +1758,7 @@ internal class HealthConnectorClient private constructor(
         HealthConnectorLogger.debug(
             tag = TAG,
             operation = "getGrantedPermissions",
-            phase = "entry",
+
             message = "Getting granted Health Connect permissions",
         )
 
@@ -1779,7 +1768,7 @@ internal class HealthConnectorClient private constructor(
             HealthConnectorLogger.error(
                 tag = TAG,
                 operation = "getGrantedPermissions",
-                phase = "failed",
+
                 message = "Failed to get granted Health Connect permissions",
                 exception = e,
             )
@@ -1799,7 +1788,7 @@ internal class HealthConnectorClient private constructor(
         HealthConnectorLogger.debug(
             tag = TAG,
             operation = "revokeAllPermissions",
-            phase = "entry",
+
             message = "Revoking all Health Connect permissions",
         )
 
@@ -1809,14 +1798,14 @@ internal class HealthConnectorClient private constructor(
             HealthConnectorLogger.info(
                 tag = TAG,
                 operation = "revokeAllPermissions",
-                phase = "completed",
+
                 message = "All Health Connect permissions revoked successfully",
             )
         } catch (e: RuntimeException) {
             HealthConnectorLogger.error(
                 tag = TAG,
                 operation = "revokeAllPermissions",
-                phase = "failed",
+
                 message = "Failed to revoke all Health Connect permissions",
                 exception = e,
             )

--- a/packages/health_connector_hc_android/android/src/main/kotlin/com/phamtunglam/health_connector_hc_android/HealthConnectorHCAndroidPlugin.kt
+++ b/packages/health_connector_hc_android/android/src/main/kotlin/com/phamtunglam/health_connector_hc_android/HealthConnectorHCAndroidPlugin.kt
@@ -94,7 +94,6 @@ class HealthConnectorHCAndroidPlugin :
             HealthConnectorLogger.warning(
                 tag = TAG,
                 operation = "coroutineExceptionHandler",
-                phase = "unhandled_exception",
                 message = "Unhandled exception in coroutine scope",
                 exception = e,
             )
@@ -190,7 +189,6 @@ class HealthConnectorHCAndroidPlugin :
             HealthConnectorLogger.debug(
                 tag = TAG,
                 operation = "create",
-                phase = "entry",
                 message = "Creating ${HealthConnectorClient.TAG}...",
                 context = mapOf("isLoggerEnabled" to config.isLoggerEnabled.toString()),
             )
@@ -205,7 +203,6 @@ class HealthConnectorHCAndroidPlugin :
                 HealthConnectorLogger.debug(
                     tag = TAG,
                     operation = "create",
-                    phase = "succeeded",
                     message = "${HealthConnectorClient.TAG} initialized successfully",
                     context = mapOf("isLoggerEnabled" to config.isLoggerEnabled.toString()),
                 )
@@ -215,7 +212,6 @@ class HealthConnectorHCAndroidPlugin :
                 HealthConnectorLogger.error(
                     tag = TAG,
                     operation = "create",
-                    phase = "failed",
                     message = "Failed to create ${HealthConnectorClient.TAG}",
                     context = mapOf(
                         "error_code" to e.code,
@@ -262,7 +258,6 @@ class HealthConnectorHCAndroidPlugin :
                     HealthConnectorLogger.error(
                         tag = TAG,
                         operation = "requestPermissions",
-                        phase = "failed",
                         message = "Activity is null. " +
                             "Cannot request permissions without activity context",
                     )
@@ -291,7 +286,6 @@ class HealthConnectorHCAndroidPlugin :
                 HealthConnectorLogger.error(
                     tag = TAG,
                     operation = "requestPermissions",
-                    phase = "failed",
                     message = "Failed to request Health Connect permissions",
                     context = mapOf(
                         "error_code" to e.code,
@@ -321,7 +315,7 @@ class HealthConnectorHCAndroidPlugin :
                 HealthConnectorLogger.error(
                     tag = TAG,
                     operation = "getGrantedPermissions",
-                    phase = "failed",
+
                     message = "Failed to get granted Health Connect permissions",
                     context = mapOf(
                         "error_code" to e.code,
@@ -351,7 +345,7 @@ class HealthConnectorHCAndroidPlugin :
                 HealthConnectorLogger.error(
                     tag = TAG,
                     operation = "revokeAllPermissions",
-                    phase = "failed",
+
                     message = "Failed to revoke all Health Connect permissions",
                     context = mapOf(
                         "error_code" to e.code,
@@ -385,7 +379,7 @@ class HealthConnectorHCAndroidPlugin :
                 HealthConnectorLogger.error(
                     tag = TAG,
                     operation = "getFeatureStatus",
-                    phase = "failed",
+
                     message = "Failed to get Health Connect feature status",
                     context = mapOf(
                         "feature" to feature.toString(),
@@ -420,7 +414,7 @@ class HealthConnectorHCAndroidPlugin :
                 HealthConnectorLogger.error(
                     tag = TAG,
                     operation = "readRecord",
-                    phase = "failed",
+
                     message = "Failed to read Health Connect record",
                     context = mapOf(
                         "dataType" to request.dataType.toString(),
@@ -456,7 +450,7 @@ class HealthConnectorHCAndroidPlugin :
                 HealthConnectorLogger.error(
                     tag = TAG,
                     operation = "readRecords",
-                    phase = "failed",
+
                     message = "Failed to read Health Connect records",
                     context = mapOf(
                         "dataType" to request.dataType.toString(),
@@ -494,7 +488,7 @@ class HealthConnectorHCAndroidPlugin :
                 HealthConnectorLogger.error(
                     tag = TAG,
                     operation = "writeRecord",
-                    phase = "failed",
+
                     message = "Failed to write Health Connect record",
                     context = mapOf(
                         "error_code" to e.code,
@@ -528,7 +522,7 @@ class HealthConnectorHCAndroidPlugin :
                 HealthConnectorLogger.error(
                     tag = TAG,
                     operation = "writeRecords",
-                    phase = "failed",
+
                     message = "Failed to write Health Connect records",
                     context = mapOf(
                         "recordsCount" to request.records.size,
@@ -563,7 +557,7 @@ class HealthConnectorHCAndroidPlugin :
                 HealthConnectorLogger.error(
                     tag = TAG,
                     operation = "updateRecord",
-                    phase = "failed",
+
                     message = "Failed to update Health Connect record",
                     context = mapOf(
                         "error_code" to e.code,
@@ -597,7 +591,7 @@ class HealthConnectorHCAndroidPlugin :
                 HealthConnectorLogger.error(
                     tag = TAG,
                     operation = "deleteRecordsByIds",
-                    phase = "failed",
+
                     message = "Failed to delete Health Connect records by IDs",
                     context = mapOf(
                         "dataType" to request.dataType.toString(),
@@ -633,7 +627,7 @@ class HealthConnectorHCAndroidPlugin :
                 HealthConnectorLogger.error(
                     tag = TAG,
                     operation = "deleteRecordsByTimeRange",
-                    phase = "failed",
+
                     message = "Failed to delete Health Connect records by time range",
                     context = mapOf(
                         "dataType" to request.dataType.toString(),
@@ -670,7 +664,7 @@ class HealthConnectorHCAndroidPlugin :
                 HealthConnectorLogger.error(
                     tag = TAG,
                     operation = "aggregate",
-                    phase = "failed",
+
                     message = "Failed to aggregate Health Connect data",
                     context = mapOf(
                         "dataType" to request.dataType.toString(),

--- a/packages/health_connector_hc_android/android/src/main/kotlin/com/phamtunglam/health_connector_hc_android/logger/HealthConnectorLogger.kt
+++ b/packages/health_connector_hc_android/android/src/main/kotlin/com/phamtunglam/health_connector_hc_android/logger/HealthConnectorLogger.kt
@@ -136,7 +136,7 @@ internal object HealthConnectorLogger {
      * only non-null fields.
      *
      * @param operation The operation being performed (e.g., 'readRecords').
-     * @param phase The phase of the operation (e.g., 'entry', 'completed').
+
      * @param message Optional message to include in the log.
      * @param context Optional map of contextual information.
      * @param exception Optional exception object.
@@ -145,7 +145,6 @@ internal object HealthConnectorLogger {
      */
     private fun formatStructuredMessage(
         operation: String,
-        phase: String,
         message: String? = null,
         context: Map<String, Any?>? = null,
         exception: Throwable? = null,
@@ -156,9 +155,6 @@ internal object HealthConnectorLogger {
         // Always include operation
         buffer.appendLine("{")
         buffer.append("${getIndent(0)}operation: $operation,")
-
-        // Include phase if provided
-        buffer.append("\n${getIndent(0)}phase: $phase,")
 
         // Include message if provided
         if (message != null) {
@@ -203,7 +199,7 @@ internal object HealthConnectorLogger {
      * ```
      * {
      *    operation: {operation},
-     *    phase: {phase},
+
      *    message: {message},
      *    exception: {
      *      cause: {exception},
@@ -221,7 +217,7 @@ internal object HealthConnectorLogger {
      * @param level The log level (DEBUG, INFO, WARNING, ERROR).
      * @param tag The tag for categorizing the log entry (converted to uppercase).
      * @param operation The operation being performed.
-     * @param phase The phase of the operation.
+
      * @param message Optional message to include in the log.
      * @param context Optional contextual information.
      * @param exception Optional exception object.
@@ -230,7 +226,6 @@ internal object HealthConnectorLogger {
         level: LogLevel,
         tag: String,
         operation: String,
-        phase: String,
         message: String? = null,
         context: Map<String, Any?>? = null,
         exception: Throwable? = null,
@@ -242,7 +237,7 @@ internal object HealthConnectorLogger {
         val stackTrace = exception?.stackTrace
         val structuredMessage = formatStructuredMessage(
             operation = operation,
-            phase = phase,
+
             message = message,
             context = context,
             exception = exception,
@@ -295,7 +290,7 @@ internal object HealthConnectorLogger {
      *
      * @param tag A tag for categorizing the log entry (converted to uppercase).
      * @param operation The operation being performed.
-     * @param phase The phase of the operation.
+
      * @param message Optional message to include in the log.
      * @param context Optional contextual information.
      * @param exception Optional exception object to include in the log.
@@ -303,7 +298,6 @@ internal object HealthConnectorLogger {
     fun debug(
         tag: String,
         operation: String,
-        phase: String,
         message: String? = null,
         context: Map<String, Any?>? = null,
         exception: Throwable? = null,
@@ -312,7 +306,7 @@ internal object HealthConnectorLogger {
             level = LogLevel.DEBUG,
             tag = tag,
             operation = operation,
-            phase = phase,
+
             message = message,
             context = context,
             exception = exception,
@@ -327,7 +321,7 @@ internal object HealthConnectorLogger {
      *
      * @param tag A tag for categorizing the log entry (converted to uppercase).
      * @param operation The operation being performed.
-     * @param phase The phase of the operation.
+
      * @param message Optional message to include in the log.
      * @param context Optional contextual information.
      * @param exception Optional exception object to include in the log.
@@ -335,7 +329,6 @@ internal object HealthConnectorLogger {
     fun info(
         tag: String,
         operation: String,
-        phase: String,
         message: String? = null,
         context: Map<String, Any?>? = null,
         exception: Throwable? = null,
@@ -344,7 +337,7 @@ internal object HealthConnectorLogger {
             level = LogLevel.INFO,
             tag = tag,
             operation = operation,
-            phase = phase,
+
             message = message,
             context = context,
             exception = exception,
@@ -359,7 +352,7 @@ internal object HealthConnectorLogger {
      *
      * @param tag A tag for categorizing the log entry (converted to uppercase).
      * @param operation The operation being performed.
-     * @param phase The phase of the operation.
+
      * @param message Optional message to include in the log.
      * @param context Optional contextual information.
      * @param exception Optional exception object to include in the log.
@@ -367,7 +360,6 @@ internal object HealthConnectorLogger {
     fun warning(
         tag: String,
         operation: String,
-        phase: String,
         message: String? = null,
         context: Map<String, Any?>? = null,
         exception: Throwable? = null,
@@ -376,7 +368,7 @@ internal object HealthConnectorLogger {
             level = LogLevel.WARNING,
             tag = tag,
             operation = operation,
-            phase = phase,
+
             message = message,
             context = context,
             exception = exception,
@@ -391,7 +383,7 @@ internal object HealthConnectorLogger {
      *
      * @param tag A tag for categorizing the log entry (converted to uppercase).
      * @param operation The operation being performed.
-     * @param phase The phase of the operation.
+
      * @param message Optional message to include in the log.
      * @param context Optional contextual information.
      * @param exception Optional exception object to include in the log.
@@ -399,7 +391,6 @@ internal object HealthConnectorLogger {
     fun error(
         tag: String,
         operation: String,
-        phase: String,
         message: String? = null,
         context: Map<String, Any?>? = null,
         exception: Throwable? = null,
@@ -408,7 +399,7 @@ internal object HealthConnectorLogger {
             level = LogLevel.ERROR,
             tag = tag,
             operation = operation,
-            phase = phase,
+
             message = message,
             context = context,
             exception = exception,

--- a/packages/health_connector_hc_android/lib/src/health_connector_hc_client.dart
+++ b/packages/health_connector_hc_android/lib/src/health_connector_hc_client.dart
@@ -124,7 +124,6 @@ final class HealthConnectorHCClient implements HealthConnectorPlatformClient {
     HealthConnectorLogger.debug(
       tag,
       operation: 'getHealthPlatformStatus',
-      phase: 'entry',
       message: 'Checking Health Connect platform status',
     );
 
@@ -142,7 +141,6 @@ final class HealthConnectorHCClient implements HealthConnectorPlatformClient {
       HealthConnectorLogger.info(
         tag,
         operation: 'getHealthPlatformStatus',
-        phase: 'succeeded',
         message: 'Health Connect platform status retrieved',
         context: {
           'health_platform_status': status.name,
@@ -154,7 +152,6 @@ final class HealthConnectorHCClient implements HealthConnectorPlatformClient {
       HealthConnectorLogger.error(
         tag,
         operation: 'getHealthPlatformStatus',
-        phase: 'failed',
         message: 'Failed to get Health Connect platform status',
         exception: e,
         stackTrace: st,
@@ -177,7 +174,6 @@ final class HealthConnectorHCClient implements HealthConnectorPlatformClient {
     HealthConnectorLogger.debug(
       tag,
       operation: 'requestPermissions',
-      phase: 'entry',
       message: 'Requesting Health Connect permissions',
       context: {
         'requested_health_data_permissions': permissions.healthDataPermissions,
@@ -189,7 +185,6 @@ final class HealthConnectorHCClient implements HealthConnectorPlatformClient {
       HealthConnectorLogger.warning(
         tag,
         operation: 'requestPermissions',
-        phase: 'succeeded',
         message: 'No permissions to request (empty list)',
       );
 
@@ -213,7 +208,6 @@ final class HealthConnectorHCClient implements HealthConnectorPlatformClient {
       HealthConnectorLogger.info(
         tag,
         operation: 'requestPermissions',
-        phase: 'succeeded',
         message: 'Health Connect permissions requested successfully',
         context: {
           'granted_health_data_permissions':
@@ -227,7 +221,6 @@ final class HealthConnectorHCClient implements HealthConnectorPlatformClient {
       HealthConnectorLogger.error(
         tag,
         operation: 'requestPermissions',
-        phase: 'failed',
         message: 'Failed to request Health Connect permissions',
         context: {
           'requested_permissions': {
@@ -267,7 +260,6 @@ final class HealthConnectorHCClient implements HealthConnectorPlatformClient {
     HealthConnectorLogger.debug(
       tag,
       operation: 'getGrantedPermissions',
-      phase: 'entry',
       message: 'Getting granted Health Connect permissions',
     );
 
@@ -289,7 +281,6 @@ final class HealthConnectorHCClient implements HealthConnectorPlatformClient {
       HealthConnectorLogger.info(
         tag,
         operation: 'getGrantedPermissions',
-        phase: 'succeeded',
         message: 'Granted Health Connect permissions retrieved',
         context: {
           'granted_health_data_permissions':
@@ -303,7 +294,7 @@ final class HealthConnectorHCClient implements HealthConnectorPlatformClient {
       HealthConnectorLogger.error(
         tag,
         operation: 'getGrantedPermissions',
-        phase: 'failed',
+
         message: 'Failed to get granted Health Connect permissions',
         exception: e,
         stackTrace: st,
@@ -332,7 +323,7 @@ final class HealthConnectorHCClient implements HealthConnectorPlatformClient {
     HealthConnectorLogger.debug(
       tag,
       operation: 'revokeAllPermissions',
-      phase: 'entry',
+
       message: 'Revoking all Health Connect permissions',
     );
 
@@ -342,14 +333,14 @@ final class HealthConnectorHCClient implements HealthConnectorPlatformClient {
       HealthConnectorLogger.info(
         tag,
         operation: 'revokeAllPermissions',
-        phase: 'succeeded',
+
         message: 'All Health Connect permissions revoked successfully',
       );
     } on PlatformException catch (e, st) {
       HealthConnectorLogger.error(
         tag,
         operation: 'revokeAllPermissions',
-        phase: 'failed',
+
         message: 'Failed to revoke all Health Connect permissions',
         exception: e,
         stackTrace: st,
@@ -388,7 +379,7 @@ final class HealthConnectorHCClient implements HealthConnectorPlatformClient {
     HealthConnectorLogger.debug(
       tag,
       operation: 'getFeatureStatus',
-      phase: 'entry',
+
       message: 'Checking Health Connect feature status',
       context: {'feature': feature},
     );
@@ -403,7 +394,7 @@ final class HealthConnectorHCClient implements HealthConnectorPlatformClient {
       HealthConnectorLogger.info(
         tag,
         operation: 'getFeatureStatus',
-        phase: 'succeeded',
+
         message: 'Health Connect feature status retrieved',
         context: {'feature': feature, 'status': status.name},
       );
@@ -413,7 +404,7 @@ final class HealthConnectorHCClient implements HealthConnectorPlatformClient {
       HealthConnectorLogger.error(
         tag,
         operation: 'getFeatureStatus',
-        phase: 'failed',
+
         message: 'Failed to get Health Connect feature status',
         context: {'feature': feature},
         exception: e,
@@ -437,7 +428,7 @@ final class HealthConnectorHCClient implements HealthConnectorPlatformClient {
     HealthConnectorLogger.debug(
       tag,
       operation: 'readRecord',
-      phase: 'entry',
+
       message: 'Reading Health Connect record',
       context: {'request': request},
     );
@@ -451,7 +442,7 @@ final class HealthConnectorHCClient implements HealthConnectorPlatformClient {
         HealthConnectorLogger.info(
           tag,
           operation: 'readRecord',
-          phase: 'succeeded',
+
           message: 'Health Connect record not found',
           context: {'request': request, 'response': null},
         );
@@ -464,7 +455,7 @@ final class HealthConnectorHCClient implements HealthConnectorPlatformClient {
       HealthConnectorLogger.info(
         tag,
         operation: 'readRecord',
-        phase: 'succeeded',
+
         message: 'Health Connect record read successfully',
         context: {'request': request, 'response': record},
       );
@@ -474,7 +465,7 @@ final class HealthConnectorHCClient implements HealthConnectorPlatformClient {
       HealthConnectorLogger.error(
         tag,
         operation: 'readRecord',
-        phase: 'failed',
+
         message: 'Failed to read Health Connect record',
         context: {'request': request},
         exception: e,
@@ -497,7 +488,7 @@ final class HealthConnectorHCClient implements HealthConnectorPlatformClient {
     HealthConnectorLogger.debug(
       tag,
       operation: 'readRecords',
-      phase: 'entry',
+
       message: 'Reading Health Connect records',
       context: {'request': request},
     );
@@ -512,7 +503,7 @@ final class HealthConnectorHCClient implements HealthConnectorPlatformClient {
       HealthConnectorLogger.info(
         tag,
         operation: 'readRecords',
-        phase: 'succeeded',
+
         message: 'Health Connect records read successfully',
         context: {'request': request, 'response': response},
       );
@@ -522,7 +513,7 @@ final class HealthConnectorHCClient implements HealthConnectorPlatformClient {
       HealthConnectorLogger.error(
         tag,
         operation: 'readRecords',
-        phase: 'failed',
+
         message: 'Failed to read Health Connect records',
         context: {'request': request},
         exception: e,
@@ -543,7 +534,7 @@ final class HealthConnectorHCClient implements HealthConnectorPlatformClient {
     HealthConnectorLogger.debug(
       tag,
       operation: 'writeRecord',
-      phase: 'entry',
+
       message: 'Writing Health Connect record',
       context: {'record': record},
     );
@@ -558,7 +549,7 @@ final class HealthConnectorHCClient implements HealthConnectorPlatformClient {
       HealthConnectorLogger.info(
         tag,
         operation: 'writeRecord',
-        phase: 'succeeded',
+
         message: 'Health Connect record written successfully',
         context: {'record': record, 'assignedRecordId': assignedRecordId},
       );
@@ -568,7 +559,7 @@ final class HealthConnectorHCClient implements HealthConnectorPlatformClient {
       HealthConnectorLogger.error(
         tag,
         operation: 'writeRecord',
-        phase: 'failed',
+
         message: 'Failed to write Health Connect record',
         context: {'record': record},
         exception: e,
@@ -591,7 +582,7 @@ final class HealthConnectorHCClient implements HealthConnectorPlatformClient {
     HealthConnectorLogger.debug(
       tag,
       operation: 'writeRecords',
-      phase: 'entry',
+
       message: 'Writing Health Connect records',
       context: {'records': records},
     );
@@ -600,7 +591,7 @@ final class HealthConnectorHCClient implements HealthConnectorPlatformClient {
       HealthConnectorLogger.warning(
         tag,
         operation: 'writeRecords',
-        phase: 'succeeded',
+
         message: 'No records to write (empty list)',
       );
 
@@ -619,7 +610,7 @@ final class HealthConnectorHCClient implements HealthConnectorPlatformClient {
       HealthConnectorLogger.info(
         tag,
         operation: 'writeRecords',
-        phase: 'succeeded',
+
         message: 'Health Connect records written successfully',
         context: {'records': records, 'assignedRecordIds': recordIds},
       );
@@ -629,7 +620,7 @@ final class HealthConnectorHCClient implements HealthConnectorPlatformClient {
       HealthConnectorLogger.error(
         tag,
         operation: 'writeRecords',
-        phase: 'failed',
+
         message: 'Failed to write Health Connect records',
         context: {'records': records},
         exception: e,
@@ -650,7 +641,7 @@ final class HealthConnectorHCClient implements HealthConnectorPlatformClient {
     HealthConnectorLogger.debug(
       tag,
       operation: 'updateRecord',
-      phase: 'entry',
+
       message: 'Updating Health Connect record',
       context: {'record': record},
     );
@@ -665,7 +656,7 @@ final class HealthConnectorHCClient implements HealthConnectorPlatformClient {
       HealthConnectorLogger.info(
         tag,
         operation: 'updateRecord',
-        phase: 'succeeded',
+
         message: 'Health Connect record updated successfully',
         context: {'record': record},
       );
@@ -675,7 +666,7 @@ final class HealthConnectorHCClient implements HealthConnectorPlatformClient {
       HealthConnectorLogger.error(
         tag,
         operation: 'updateRecord',
-        phase: 'failed',
+
         message: 'Failed to update Health Connect record',
         context: {'record': record},
         exception: e,
@@ -699,7 +690,7 @@ final class HealthConnectorHCClient implements HealthConnectorPlatformClient {
     HealthConnectorLogger.debug(
       tag,
       operation: 'aggregate',
-      phase: 'entry',
+
       message: 'Aggregating Health Connect data',
       context: {'request': request},
     );
@@ -714,7 +705,7 @@ final class HealthConnectorHCClient implements HealthConnectorPlatformClient {
       HealthConnectorLogger.info(
         tag,
         operation: 'aggregate',
-        phase: 'succeeded',
+
         message: 'Health Connect data aggregated successfully',
         context: {'request': request, 'response': response},
       );
@@ -724,7 +715,7 @@ final class HealthConnectorHCClient implements HealthConnectorPlatformClient {
       HealthConnectorLogger.error(
         tag,
         operation: 'aggregate',
-        phase: 'failed',
+
         message: 'Failed to aggregate Health Connect data',
         context: {'request': request},
         exception: e,
@@ -754,7 +745,7 @@ final class HealthConnectorHCClient implements HealthConnectorPlatformClient {
     HealthConnectorLogger.debug(
       tag,
       operation: 'deleteRecords',
-      phase: 'entry',
+
       message: 'Deleting Health Connect records by time range',
       context: {'request': request},
     );
@@ -771,7 +762,7 @@ final class HealthConnectorHCClient implements HealthConnectorPlatformClient {
       HealthConnectorLogger.info(
         tag,
         operation: 'deleteRecords',
-        phase: 'succeeded',
+
         message: 'Health Connect records deleted successfully',
         context: {'request': request},
       );
@@ -779,7 +770,7 @@ final class HealthConnectorHCClient implements HealthConnectorPlatformClient {
       HealthConnectorLogger.error(
         tag,
         operation: 'deleteRecords',
-        phase: 'failed',
+
         message: 'Failed to delete Health Connect records',
         context: {'request': request},
         exception: e,
@@ -808,7 +799,7 @@ final class HealthConnectorHCClient implements HealthConnectorPlatformClient {
     HealthConnectorLogger.debug(
       tag,
       operation: 'deleteRecordsByIds',
-      phase: 'entry',
+
       message: 'Deleting Health Connect records by IDs',
       context: {'request': request},
     );
@@ -817,7 +808,7 @@ final class HealthConnectorHCClient implements HealthConnectorPlatformClient {
       HealthConnectorLogger.warning(
         tag,
         operation: 'deleteRecordsByIds',
-        phase: 'succeeded',
+
         message: 'No records to delete (empty IDs list)',
       );
 
@@ -835,7 +826,7 @@ final class HealthConnectorHCClient implements HealthConnectorPlatformClient {
       HealthConnectorLogger.info(
         tag,
         operation: 'deleteRecordsByIds',
-        phase: 'succeeded',
+
         message: 'Health Connect records deleted successfully',
         context: {'request': request},
       );
@@ -843,7 +834,7 @@ final class HealthConnectorHCClient implements HealthConnectorPlatformClient {
       HealthConnectorLogger.error(
         tag,
         operation: 'deleteRecordsByIds',
-        phase: 'failed',
+
         message: 'Failed to delete Health Connect records by IDs',
         context: {'request': request},
         exception: e,

--- a/packages/health_connector_hk_ios/ios/health_connector_hk_ios/Sources/health_connector_hk_ios/HealthConnectorClient.swift
+++ b/packages/health_connector_hk_ios/ios/health_connector_hk_ios/Sources/health_connector_hk_ios/HealthConnectorClient.swift
@@ -79,7 +79,6 @@ class HealthConnectorClient {
             HealthConnectorLogger.error(
                 tag: tag,
                 operation: "getOrCreate",
-                phase: "failed",
                 message: "HealthKit is not available on this device"
             )
             throw HealthConnectorErrors.healthProviderUnavailable(
@@ -101,7 +100,6 @@ class HealthConnectorClient {
         HealthConnectorLogger.debug(
             tag: tag,
             operation: "getHealthPlatformStatus",
-            phase: "entry",
             message: "Getting HealthKit availability status"
         )
 
@@ -111,7 +109,6 @@ class HealthConnectorClient {
         HealthConnectorLogger.info(
             tag: tag,
             operation: "getHealthPlatformStatus",
-            phase: "completed",
             message: "HealthKit platform status retrieved",
             context: [
                 "isAvailable": isAvailable,
@@ -142,7 +139,6 @@ class HealthConnectorClient {
             HealthConnectorLogger.debug(
                 tag: HealthConnectorClient.tag,
                 operation: "requestPermissions",
-                phase: "entry",
                 message: "Requesting Health Connect permissions",
                 context: [
                     "requested_health_data_permissions": healthDataPermissions,
@@ -216,7 +212,6 @@ class HealthConnectorClient {
             HealthConnectorLogger.info(
                 tag: HealthConnectorClient.tag,
                 operation: "requestPermissions",
-                phase: "completed",
                 message: "Health Connect permissions requested successfully",
                 context: [
                     "granted_health_data_permissions": results,
@@ -232,7 +227,6 @@ class HealthConnectorClient {
             HealthConnectorLogger.error(
                 tag: HealthConnectorClient.tag,
                 operation: "requestPermissions",
-                phase: "failed",
                 message: "Failed to request Health Connect permissions",
                 context: [
                     "requested_permissions": healthDataPermissions,
@@ -247,7 +241,6 @@ class HealthConnectorClient {
             HealthConnectorLogger.error(
                 tag: HealthConnectorClient.tag,
                 operation: "requestPermissions",
-                phase: "failed",
                 message: "Failed to request Health Connect permissions",
                 context: [
                     "requested_permissions": healthDataPermissions,
@@ -277,7 +270,6 @@ class HealthConnectorClient {
             HealthConnectorLogger.debug(
                 tag: HealthConnectorClient.tag,
                 operation: "readRecord",
-                phase: "entry",
                 message: "Reading Health Connect record",
                 context: [
                     "request": request,
@@ -294,7 +286,6 @@ class HealthConnectorClient {
                 HealthConnectorLogger.error(
                     tag: HealthConnectorClient.tag,
                     operation: "readRecord",
-                    phase: "failed",
                     message: "Invalid record ID format",
                     context: [
                         "dataType": String(describing: request.dataType),
@@ -344,7 +335,7 @@ class HealthConnectorClient {
             HealthConnectorLogger.info(
                 tag: HealthConnectorClient.tag,
                 operation: "readRecord",
-                phase: "completed",
+
                 message: "Health Connect record read successfully",
                 context: [
                     "request": request,
@@ -360,7 +351,7 @@ class HealthConnectorClient {
             HealthConnectorLogger.error(
                 tag: HealthConnectorClient.tag,
                 operation: "readRecord",
-                phase: "failed",
+
                 message: "Failed to read Health Connect record",
                 context: [
                     "request": request,
@@ -376,7 +367,7 @@ class HealthConnectorClient {
             HealthConnectorLogger.error(
                 tag: HealthConnectorClient.tag,
                 operation: "readRecord",
-                phase: "failed",
+
                 message: "Failed to read Health Connect record",
                 context: [
                     "request": request,
@@ -440,7 +431,7 @@ class HealthConnectorClient {
             HealthConnectorLogger.debug(
                 tag: HealthConnectorClient.tag,
                 operation: "readRecords",
-                phase: "entry",
+
                 message: "Reading Health Connect records",
                 context: [
                     "request": request,
@@ -469,7 +460,7 @@ class HealthConnectorClient {
                         HealthConnectorLogger.warning(
                             tag: HealthConnectorClient.tag,
                             operation: "readRecords",
-                            phase: "completed",
+
                             message: "Invalid pageToken: adjusted startTime >= endTime",
                             context: [
                                 "adjustedStartTime": effectiveStartTime,
@@ -482,7 +473,7 @@ class HealthConnectorClient {
                     HealthConnectorLogger.debug(
                         tag: HealthConnectorClient.tag,
                         operation: "readRecords",
-                        phase: "pagination",
+
                         message: "Using pageToken for pagination",
                         context: [
                             "originalStartTime": request.startTime,
@@ -494,7 +485,7 @@ class HealthConnectorClient {
                     HealthConnectorLogger.warning(
                         tag: HealthConnectorClient.tag,
                         operation: "readRecords",
-                        phase: "pagination",
+
                         message: "Invalid pageToken format, using original startTime",
                         context: [
                             "pageToken": pageToken,
@@ -535,7 +526,7 @@ class HealthConnectorClient {
                     HealthConnectorLogger.warning(
                         tag: HealthConnectorClient.tag,
                         operation: "readRecords",
-                        phase: "completed",
+
                         message: "No sources found for bundle identifiers",
                         context: [
                             "bundleIdentifiers": request.dataOriginPackageNames,
@@ -626,7 +617,7 @@ class HealthConnectorClient {
             HealthConnectorLogger.info(
                 tag: HealthConnectorClient.tag,
                 operation: "readRecords",
-                phase: "completed",
+
                 message: "Health Connect records read successfully",
                 context: [
                     "request": request,
@@ -642,7 +633,7 @@ class HealthConnectorClient {
             HealthConnectorLogger.error(
                 tag: HealthConnectorClient.tag,
                 operation: "readRecords",
-                phase: "failed",
+
                 message: "Failed to read Health Connect records",
                 context: [
                     "request": request,
@@ -654,7 +645,7 @@ class HealthConnectorClient {
             HealthConnectorLogger.error(
                 tag: HealthConnectorClient.tag,
                 operation: "readRecords",
-                phase: "failed",
+
                 message: "Failed to read Health Connect records",
                 context: [
                     "request": request,
@@ -797,7 +788,7 @@ class HealthConnectorClient {
             HealthConnectorLogger.debug(
                 tag: HealthConnectorClient.tag,
                 operation: "writeRecord",
-                phase: "entry",
+
                 message: "Writing Health Connect record",
                 context: [
                     "request": request,
@@ -842,7 +833,7 @@ class HealthConnectorClient {
                         HealthConnectorLogger.info(
                             tag: HealthConnectorClient.tag,
                             operation: "writeRecord",
-                            phase: "completed",
+
                             message: "Health Connect record written successfully",
                             context: [
                                 "request": request,
@@ -867,7 +858,7 @@ class HealthConnectorClient {
             HealthConnectorLogger.error(
                 tag: HealthConnectorClient.tag,
                 operation: "writeRecord",
-                phase: "failed",
+
                 message: "Failed to write Health Connect record",
                 context: [
                     "request": request,
@@ -879,7 +870,7 @@ class HealthConnectorClient {
             HealthConnectorLogger.error(
                 tag: HealthConnectorClient.tag,
                 operation: "writeRecord",
-                phase: "failed",
+
                 message: "Failed to write Health Connect record",
                 context: [
                     "request": request,
@@ -917,7 +908,7 @@ class HealthConnectorClient {
             HealthConnectorLogger.debug(
                 tag: HealthConnectorClient.tag,
                 operation: "updateRecord",
-                phase: "entry",
+
                 message: "Updating Health Connect record",
                 context: [
                     "request": request,
@@ -1056,7 +1047,7 @@ class HealthConnectorClient {
                         HealthConnectorLogger.info(
                             tag: HealthConnectorClient.tag,
                             operation: "updateRecord",
-                            phase: "completed",
+
                             message: "Health Connect record updated successfully",
                             context: [
                                 "request": request,
@@ -1082,7 +1073,7 @@ class HealthConnectorClient {
             HealthConnectorLogger.error(
                 tag: HealthConnectorClient.tag,
                 operation: "updateRecord",
-                phase: "failed",
+
                 message: "Failed to update Health Connect record",
                 context: [
                     "request": request,
@@ -1094,7 +1085,7 @@ class HealthConnectorClient {
             HealthConnectorLogger.error(
                 tag: HealthConnectorClient.tag,
                 operation: "updateRecord",
-                phase: "failed",
+
                 message: "Failed to update Health Connect record",
                 context: [
                     "request": request,
@@ -1124,7 +1115,7 @@ class HealthConnectorClient {
             HealthConnectorLogger.debug(
                 tag: HealthConnectorClient.tag,
                 operation: "writeRecords",
-                phase: "entry",
+
                 message: "Writing Health Connect records",
                 context: [
                     "request": request,
@@ -1175,7 +1166,7 @@ class HealthConnectorClient {
                         HealthConnectorLogger.info(
                             tag: HealthConnectorClient.tag,
                             operation: "writeRecords",
-                            phase: "completed",
+
                             message: "Health Connect records written successfully",
                             context: [
                                 "request": request,
@@ -1200,7 +1191,7 @@ class HealthConnectorClient {
             HealthConnectorLogger.error(
                 tag: HealthConnectorClient.tag,
                 operation: "writeRecords",
-                phase: "failed",
+
                 message: "Failed to write Health Connect records",
                 context: [
                     "request": request,
@@ -1212,7 +1203,7 @@ class HealthConnectorClient {
             HealthConnectorLogger.error(
                 tag: HealthConnectorClient.tag,
                 operation: "writeRecords",
-                phase: "failed",
+
                 message: "Failed to write Health Connect records",
                 context: [
                     "request": request,
@@ -1242,7 +1233,7 @@ class HealthConnectorClient {
             HealthConnectorLogger.debug(
                 tag: HealthConnectorClient.tag,
                 operation: "aggregate",
-                phase: "entry",
+
                 message: "Aggregating Health Connect data",
                 context: [
                     "request": request,
@@ -1297,7 +1288,7 @@ class HealthConnectorClient {
             HealthConnectorLogger.info(
                 tag: HealthConnectorClient.tag,
                 operation: "aggregate",
-                phase: "completed",
+
                 message: "Health Connect data aggregated successfully",
                 context: [
                     "request": request,
@@ -1313,7 +1304,7 @@ class HealthConnectorClient {
             HealthConnectorLogger.error(
                 tag: HealthConnectorClient.tag,
                 operation: "aggregate",
-                phase: "failed",
+
                 message: "Failed to aggregate Health Connect data",
                 context: [
                     "request": request,
@@ -1325,7 +1316,7 @@ class HealthConnectorClient {
             HealthConnectorLogger.error(
                 tag: HealthConnectorClient.tag,
                 operation: "aggregate",
-                phase: "failed",
+
                 message: "Failed to aggregate Health Connect data",
                 context: [
                     "request": request,
@@ -1708,7 +1699,7 @@ class HealthConnectorClient {
         HealthConnectorLogger.debug(
             tag: HealthConnectorClient.tag,
             operation: "deleteRecordsByTimeRange",
-            phase: "entry",
+
             message: "Deleting Health Connect records by time range",
             context: [
                 "request": request,
@@ -1765,7 +1756,7 @@ class HealthConnectorClient {
                         HealthConnectorLogger.info(
                             tag: HealthConnectorClient.tag,
                             operation: "deleteRecordsByTimeRange",
-                            phase: "completed",
+
                             message: "Health Connect records deleted successfully",
                             context: [
                                 "request": request,
@@ -1789,7 +1780,7 @@ class HealthConnectorClient {
             HealthConnectorLogger.error(
                 tag: HealthConnectorClient.tag,
                 operation: "deleteRecordsByTimeRange",
-                phase: "failed",
+
                 message: "Failed to delete Health Connect records by time range",
                 context: [
                     "request": request,
@@ -1801,7 +1792,7 @@ class HealthConnectorClient {
             HealthConnectorLogger.error(
                 tag: HealthConnectorClient.tag,
                 operation: "deleteRecordsByTimeRange",
-                phase: "failed",
+
                 message: "Failed to delete Health Connect records by time range",
                 context: [
                     "request": request,
@@ -1830,7 +1821,7 @@ class HealthConnectorClient {
         HealthConnectorLogger.debug(
             tag: HealthConnectorClient.tag,
             operation: "deleteRecordsByIds",
-            phase: "entry",
+
             message: "Deleting Health Connect records by IDs",
             context: [
                 "request": request,
@@ -1918,7 +1909,7 @@ class HealthConnectorClient {
                             HealthConnectorLogger.info(
                                 tag: HealthConnectorClient.tag,
                                 operation: "deleteRecordsByIds",
-                                phase: "completed",
+
                                 message: "Health Connect records deleted successfully",
                                 context: [
                                     "request": request,
@@ -1939,7 +1930,7 @@ class HealthConnectorClient {
                 HealthConnectorLogger.warning(
                     tag: HealthConnectorClient.tag,
                     operation: "deleteRecordsByIds",
-                    phase: "completed",
+
                     message: "No records to delete (empty IDs list)"
                 )
             }
@@ -1950,7 +1941,7 @@ class HealthConnectorClient {
             HealthConnectorLogger.error(
                 tag: HealthConnectorClient.tag,
                 operation: "deleteRecordsByIds",
-                phase: "failed",
+
                 message: "Failed to delete Health Connect records by IDs",
                 context: [
                     "request": request,
@@ -1962,7 +1953,7 @@ class HealthConnectorClient {
             HealthConnectorLogger.error(
                 tag: HealthConnectorClient.tag,
                 operation: "deleteRecordsByIds",
-                phase: "failed",
+
                 message: "Failed to delete Health Connect records by IDs",
                 context: [
                     "request": request,

--- a/packages/health_connector_hk_ios/ios/health_connector_hk_ios/Sources/health_connector_hk_ios/HealthConnectorHkIosPlugin.swift
+++ b/packages/health_connector_hk_ios/ios/health_connector_hk_ios/Sources/health_connector_hk_ios/HealthConnectorHkIosPlugin.swift
@@ -43,7 +43,6 @@ public class HealthConnectorHkIosPlugin: NSObject, FlutterPlugin, HealthConnecto
         HealthConnectorLogger.debug(
             tag: HealthConnectorHkIosPlugin.tag,
             operation: "create",
-            phase: "entry",
             message: "Creating HealthConnectorClient...",
             context: ["isLoggerEnabled": String(config.isLoggerEnabled)]
         )
@@ -59,7 +58,6 @@ public class HealthConnectorHkIosPlugin: NSObject, FlutterPlugin, HealthConnecto
             HealthConnectorLogger.debug(
                 tag: HealthConnectorHkIosPlugin.tag,
                 operation: "create",
-                phase: "succeeded",
                 message: "HealthConnector initialized successfully",
                 context: ["isLoggerEnabled": String(config.isLoggerEnabled)]
             )
@@ -69,7 +67,6 @@ public class HealthConnectorHkIosPlugin: NSObject, FlutterPlugin, HealthConnecto
             HealthConnectorLogger.error(
                 tag: HealthConnectorHkIosPlugin.tag,
                 operation: "create",
-                phase: "failed",
                 message: "Failed to create HealthConnectorClient",
                 exception: error
             )
@@ -116,7 +113,6 @@ public class HealthConnectorHkIosPlugin: NSObject, FlutterPlugin, HealthConnecto
                 HealthConnectorLogger.error(
                     tag: HealthConnectorHkIosPlugin.tag,
                     operation: "requestPermissions",
-                    phase: "failed",
                     message: "Failed to request Health Connect permissions",
                     context: [
                         "error_code": String(describing: error.code),
@@ -129,7 +125,6 @@ public class HealthConnectorHkIosPlugin: NSObject, FlutterPlugin, HealthConnecto
                 HealthConnectorLogger.error(
                     tag: HealthConnectorHkIosPlugin.tag,
                     operation: "requestPermissions",
-                    phase: "failed",
                     message: "Failed to request Health Connect permissions",
                     exception: error
                 )
@@ -162,7 +157,6 @@ public class HealthConnectorHkIosPlugin: NSObject, FlutterPlugin, HealthConnecto
                 HealthConnectorLogger.error(
                     tag: HealthConnectorHkIosPlugin.tag,
                     operation: "readRecord",
-                    phase: "failed",
                     message: "Failed to read Health Connect record",
                     context: [
                         "error_code": String(describing: error.code),
@@ -175,7 +169,6 @@ public class HealthConnectorHkIosPlugin: NSObject, FlutterPlugin, HealthConnecto
                 HealthConnectorLogger.error(
                     tag: HealthConnectorHkIosPlugin.tag,
                     operation: "readRecord",
-                    phase: "failed",
                     message: "Failed to read Health Connect record",
                     exception: error
                 )
@@ -208,7 +201,6 @@ public class HealthConnectorHkIosPlugin: NSObject, FlutterPlugin, HealthConnecto
                 HealthConnectorLogger.error(
                     tag: HealthConnectorHkIosPlugin.tag,
                     operation: "readRecords",
-                    phase: "failed",
                     message: "Failed to read Health Connect records",
                     context: [
                         "error_code": String(describing: error.code),
@@ -221,7 +213,6 @@ public class HealthConnectorHkIosPlugin: NSObject, FlutterPlugin, HealthConnecto
                 HealthConnectorLogger.error(
                     tag: HealthConnectorHkIosPlugin.tag,
                     operation: "readRecords",
-                    phase: "failed",
                     message: "Failed to read Health Connect records",
                     exception: error
                 )
@@ -254,7 +245,6 @@ public class HealthConnectorHkIosPlugin: NSObject, FlutterPlugin, HealthConnecto
                 HealthConnectorLogger.error(
                     tag: HealthConnectorHkIosPlugin.tag,
                     operation: "writeRecord",
-                    phase: "failed",
                     message: "Failed to write Health Connect record",
                     context: [
                         "error_code": String(describing: error.code),
@@ -267,7 +257,6 @@ public class HealthConnectorHkIosPlugin: NSObject, FlutterPlugin, HealthConnecto
                 HealthConnectorLogger.error(
                     tag: HealthConnectorHkIosPlugin.tag,
                     operation: "writeRecord",
-                    phase: "failed",
                     message: "Failed to write Health Connect record",
                     exception: error
                 )
@@ -300,7 +289,6 @@ public class HealthConnectorHkIosPlugin: NSObject, FlutterPlugin, HealthConnecto
                 HealthConnectorLogger.error(
                     tag: HealthConnectorHkIosPlugin.tag,
                     operation: "writeRecords",
-                    phase: "failed",
                     message: "Failed to write Health Connect records",
                     context: [
                         "error_code": String(describing: error.code),
@@ -313,7 +301,7 @@ public class HealthConnectorHkIosPlugin: NSObject, FlutterPlugin, HealthConnecto
                 HealthConnectorLogger.error(
                     tag: HealthConnectorHkIosPlugin.tag,
                     operation: "writeRecords",
-                    phase: "failed",
+
                     message: "Failed to write Health Connect records",
                     exception: error
                 )
@@ -346,7 +334,7 @@ public class HealthConnectorHkIosPlugin: NSObject, FlutterPlugin, HealthConnecto
                 HealthConnectorLogger.error(
                     tag: HealthConnectorHkIosPlugin.tag,
                     operation: "updateRecord",
-                    phase: "failed",
+
                     message: "Failed to update Health Connect record",
                     context: [
                         "error_code": String(describing: error.code),
@@ -359,7 +347,7 @@ public class HealthConnectorHkIosPlugin: NSObject, FlutterPlugin, HealthConnecto
                 HealthConnectorLogger.error(
                     tag: HealthConnectorHkIosPlugin.tag,
                     operation: "updateRecord",
-                    phase: "failed",
+
                     message: "Failed to update Health Connect record",
                     exception: error
                 )
@@ -392,7 +380,7 @@ public class HealthConnectorHkIosPlugin: NSObject, FlutterPlugin, HealthConnecto
                 HealthConnectorLogger.error(
                     tag: HealthConnectorHkIosPlugin.tag,
                     operation: "aggregate",
-                    phase: "failed",
+
                     message: "Failed to aggregate Health Connect data",
                     context: [
                         "error_code": String(describing: error.code),
@@ -405,7 +393,7 @@ public class HealthConnectorHkIosPlugin: NSObject, FlutterPlugin, HealthConnecto
                 HealthConnectorLogger.error(
                     tag: HealthConnectorHkIosPlugin.tag,
                     operation: "aggregate",
-                    phase: "failed",
+
                     message: "Failed to aggregate Health Connect data",
                     exception: error
                 )
@@ -440,7 +428,7 @@ public class HealthConnectorHkIosPlugin: NSObject, FlutterPlugin, HealthConnecto
                 HealthConnectorLogger.error(
                     tag: HealthConnectorHkIosPlugin.tag,
                     operation: "deleteRecordsByIds",
-                    phase: "failed",
+
                     message: "Failed to delete Health Connect records by IDs",
                     context: [
                         "error_code": String(describing: error.code),
@@ -453,7 +441,7 @@ public class HealthConnectorHkIosPlugin: NSObject, FlutterPlugin, HealthConnecto
                 HealthConnectorLogger.error(
                     tag: HealthConnectorHkIosPlugin.tag,
                     operation: "deleteRecordsByIds",
-                    phase: "failed",
+
                     message: "Failed to delete Health Connect records by IDs",
                     exception: error
                 )
@@ -486,7 +474,7 @@ public class HealthConnectorHkIosPlugin: NSObject, FlutterPlugin, HealthConnecto
                 HealthConnectorLogger.error(
                     tag: HealthConnectorHkIosPlugin.tag,
                     operation: "deleteRecordsByTimeRange",
-                    phase: "failed",
+
                     message: "Failed to delete Health Connect records by time range",
                     context: [
                         "error_code": String(describing: error.code),
@@ -499,7 +487,7 @@ public class HealthConnectorHkIosPlugin: NSObject, FlutterPlugin, HealthConnecto
                 HealthConnectorLogger.error(
                     tag: HealthConnectorHkIosPlugin.tag,
                     operation: "deleteRecordsByTimeRange",
-                    phase: "failed",
+
                     message: "Failed to delete Health Connect records by time range",
                     exception: error
                 )

--- a/packages/health_connector_hk_ios/ios/health_connector_hk_ios/Sources/health_connector_hk_ios/utils/HealthConnectorLogger.swift
+++ b/packages/health_connector_hk_ios/ios/health_connector_hk_ios/Sources/health_connector_hk_ios/utils/HealthConnectorLogger.swift
@@ -6,7 +6,7 @@ import OSLog
  *
  * This logger provides a consistent structured logging interface with
  * formatted messages across the plugin. It supports structured logging with
- * operation, phase, optional message, and context.
+ * operation, optional message, and context.
  */
 enum HealthConnectorLogger {
     /**
@@ -159,7 +159,7 @@ enum HealthConnectorLogger {
      *
      * - Parameters:
      *   - operation: The operation being performed (e.g., 'readRecords').
-     *   - phase: The phase of the operation (e.g., 'entry', 'completed').
+
      *   - message: Optional message to include in the log.
      *   - context: Optional dictionary of contextual information.
      *   - exception: Optional error object.
@@ -168,7 +168,7 @@ enum HealthConnectorLogger {
      */
     private static func formatStructuredMessage(
         operation: String,
-        phase: String,
+
         message: String? = nil,
         context: [String: Any?]? = nil,
         exception: Error? = nil,
@@ -179,9 +179,6 @@ enum HealthConnectorLogger {
         // Always include operation
         buffer += "{\n"
         buffer += "\(getIndent(depth: 0))operation: \(operation),"
-
-        // Include phase if provided
-        buffer += "\n\(getIndent(depth: 0))phase: \(phase),"
 
         // Include message if provided
         if let message {
@@ -238,7 +235,7 @@ enum HealthConnectorLogger {
      * [{datetime}][{level}]:
      * {
      *    operation: {operation},
-     *    phase: {phase},
+
      *    message: {message},
      *    exception: {
      *      cause: {exception},
@@ -254,7 +251,7 @@ enum HealthConnectorLogger {
      *   - level: The log level (DEBUG, INFO, WARNING, ERROR).
      *   - tag: The tag for categorizing the log entry (converted to uppercase).
      *   - operation: The operation being performed.
-     *   - phase: The phase of the operation.
+
      *   - message: Optional message to include in the log.
      *   - context: Optional contextual information.
      *   - exception: Optional error object.
@@ -263,7 +260,7 @@ enum HealthConnectorLogger {
         level: OSLogType,
         tag: String,
         operation: String,
-        phase: String,
+
         message: String? = nil,
         context: [String: Any?]? = nil,
         exception: Error? = nil
@@ -281,7 +278,7 @@ enum HealthConnectorLogger {
 
         let structuredMessage = formatStructuredMessage(
             operation: operation,
-            phase: phase,
+
             message: message,
             context: context,
             exception: exception,
@@ -341,7 +338,7 @@ enum HealthConnectorLogger {
      * - Parameters:
      *   - tag: A tag for categorizing the log entry (converted to uppercase).
      *   - operation: The operation being performed.
-     *   - phase: The phase of the operation.
+
      *   - message: Optional message to include in the log.
      *   - context: Optional contextual information.
      *   - exception: Optional error object to include in the log.
@@ -349,7 +346,7 @@ enum HealthConnectorLogger {
     static func debug(
         tag: String,
         operation: String,
-        phase: String,
+
         message: String? = nil,
         context: [String: Any?]? = nil,
         exception: Error? = nil
@@ -358,7 +355,7 @@ enum HealthConnectorLogger {
             level: .debug,
             tag: tag,
             operation: operation,
-            phase: phase,
+
             message: message,
             context: context,
             exception: exception
@@ -374,7 +371,7 @@ enum HealthConnectorLogger {
      * - Parameters:
      *   - tag: A tag for categorizing the log entry (converted to uppercase).
      *   - operation: The operation being performed.
-     *   - phase: The phase of the operation.
+
      *   - message: Optional message to include in the log.
      *   - context: Optional contextual information.
      *   - exception: Optional error object to include in the log.
@@ -382,7 +379,7 @@ enum HealthConnectorLogger {
     static func info(
         tag: String,
         operation: String,
-        phase: String,
+
         message: String? = nil,
         context: [String: Any?]? = nil,
         exception: Error? = nil
@@ -391,7 +388,7 @@ enum HealthConnectorLogger {
             level: .info,
             tag: tag,
             operation: operation,
-            phase: phase,
+
             message: message,
             context: context,
             exception: exception
@@ -407,7 +404,7 @@ enum HealthConnectorLogger {
      * - Parameters:
      *   - tag: A tag for categorizing the log entry (converted to uppercase).
      *   - operation: The operation being performed.
-     *   - phase: The phase of the operation.
+
      *   - message: Optional message to include in the log.
      *   - context: Optional contextual information.
      *   - exception: Optional error object to include in the log.
@@ -415,7 +412,7 @@ enum HealthConnectorLogger {
     static func warning(
         tag: String,
         operation: String,
-        phase: String,
+
         message: String? = nil,
         context: [String: Any?]? = nil,
         exception: Error? = nil
@@ -424,7 +421,7 @@ enum HealthConnectorLogger {
             level: .default,
             tag: tag,
             operation: operation,
-            phase: phase,
+
             message: message,
             context: context,
             exception: exception
@@ -440,7 +437,7 @@ enum HealthConnectorLogger {
      * - Parameters:
      *   - tag: A tag for categorizing the log entry (converted to uppercase).
      *   - operation: The operation being performed.
-     *   - phase: The phase of the operation.
+
      *   - message: Optional message to include in the log.
      *   - context: Optional contextual information.
      *   - exception: Optional error object to include in the log.
@@ -448,7 +445,7 @@ enum HealthConnectorLogger {
     static func error(
         tag: String,
         operation: String,
-        phase: String,
+
         message: String? = nil,
         context: [String: Any?]? = nil,
         exception: Error? = nil
@@ -457,7 +454,7 @@ enum HealthConnectorLogger {
             level: .error,
             tag: tag,
             operation: operation,
-            phase: phase,
+
             message: message,
             context: context,
             exception: exception

--- a/packages/health_connector_hk_ios/lib/src/health_connector_hk_client.dart
+++ b/packages/health_connector_hk_ios/lib/src/health_connector_hk_client.dart
@@ -77,7 +77,6 @@ final class HealthConnectorHKClient implements HealthConnectorPlatformClient {
     HealthConnectorLogger.debug(
       tag,
       operation: 'getHealthPlatformStatus',
-      phase: 'entry',
       message: 'Checking HealthKit platform status',
     );
 
@@ -93,7 +92,6 @@ final class HealthConnectorHKClient implements HealthConnectorPlatformClient {
       HealthConnectorLogger.info(
         tag,
         operation: 'getHealthPlatformStatus',
-        phase: 'succeeded',
         message: 'HealthKit platform status retrieved',
         context: {
           'health_platform_status': status.name,
@@ -105,7 +103,6 @@ final class HealthConnectorHKClient implements HealthConnectorPlatformClient {
       HealthConnectorLogger.error(
         tag,
         operation: 'getHealthPlatformStatus',
-        phase: 'failed',
         message: 'Failed to get HealthKit platform status',
         exception: e,
         stackTrace: st,
@@ -138,7 +135,6 @@ final class HealthConnectorHKClient implements HealthConnectorPlatformClient {
     HealthConnectorLogger.debug(
       tag,
       operation: 'requestPermissions',
-      phase: 'entry',
       message: 'Requesting HealthKit permissions',
       context: {
         'requested_health_data_permissions': healthDataPermissions,
@@ -152,7 +148,6 @@ final class HealthConnectorHKClient implements HealthConnectorPlatformClient {
       HealthConnectorLogger.warning(
         tag,
         operation: 'requestPermissions',
-        phase: 'succeeded',
         message: 'No permissions to request (empty list)',
       );
 
@@ -176,7 +171,6 @@ final class HealthConnectorHKClient implements HealthConnectorPlatformClient {
         HealthConnectorLogger.error(
           tag,
           operation: 'requestPermissions',
-          phase: 'failed',
           message: 'Failed to request HealthKit permissions',
           context: {
             'requested_permissions': {
@@ -218,7 +212,6 @@ final class HealthConnectorHKClient implements HealthConnectorPlatformClient {
     HealthConnectorLogger.info(
       tag,
       operation: 'requestPermissions',
-      phase: 'succeeded',
       message: 'HealthKit permissions requested successfully',
       context: {
         'granted_health_data_permissions': grantedHealthDataPermissions,
@@ -237,7 +230,6 @@ final class HealthConnectorHKClient implements HealthConnectorPlatformClient {
     HealthConnectorLogger.debug(
       tag,
       operation: 'readRecord',
-      phase: 'entry',
       message: 'Reading HealthKit record',
       context: {'request': request},
     );
@@ -251,7 +243,6 @@ final class HealthConnectorHKClient implements HealthConnectorPlatformClient {
         HealthConnectorLogger.info(
           tag,
           operation: 'readRecord',
-          phase: 'succeeded',
           message: 'HealthKit record not found',
           context: {'request': request, 'response': null},
         );
@@ -264,7 +255,6 @@ final class HealthConnectorHKClient implements HealthConnectorPlatformClient {
       HealthConnectorLogger.info(
         tag,
         operation: 'readRecord',
-        phase: 'succeeded',
         message: 'HealthKit record read successfully',
         context: {'request': request, 'response': record},
       );
@@ -274,7 +264,6 @@ final class HealthConnectorHKClient implements HealthConnectorPlatformClient {
       HealthConnectorLogger.error(
         tag,
         operation: 'readRecord',
-        phase: 'failed',
         message: 'Failed to read HealthKit record',
         context: {'request': request},
         exception: e,
@@ -297,7 +286,7 @@ final class HealthConnectorHKClient implements HealthConnectorPlatformClient {
     HealthConnectorLogger.debug(
       tag,
       operation: 'readRecords',
-      phase: 'entry',
+
       message: 'Reading HealthKit records',
       context: {'request': request},
     );
@@ -312,7 +301,7 @@ final class HealthConnectorHKClient implements HealthConnectorPlatformClient {
       HealthConnectorLogger.info(
         tag,
         operation: 'readRecords',
-        phase: 'succeeded',
+
         message: 'HealthKit records read successfully',
         context: {'request': request, 'response': response},
       );
@@ -322,7 +311,7 @@ final class HealthConnectorHKClient implements HealthConnectorPlatformClient {
       HealthConnectorLogger.error(
         tag,
         operation: 'readRecords',
-        phase: 'failed',
+
         message: 'Failed to read HealthKit records',
         context: {'request': request},
         exception: e,
@@ -343,7 +332,7 @@ final class HealthConnectorHKClient implements HealthConnectorPlatformClient {
     HealthConnectorLogger.debug(
       tag,
       operation: 'writeRecord',
-      phase: 'entry',
+
       message: 'Writing HealthKit record',
       context: {'record': record},
     );
@@ -358,7 +347,7 @@ final class HealthConnectorHKClient implements HealthConnectorPlatformClient {
       HealthConnectorLogger.info(
         tag,
         operation: 'writeRecord',
-        phase: 'succeeded',
+
         message: 'HealthKit record written successfully',
         context: {'record': record, 'assignedRecordId': assignedRecordId},
       );
@@ -368,7 +357,7 @@ final class HealthConnectorHKClient implements HealthConnectorPlatformClient {
       HealthConnectorLogger.error(
         tag,
         operation: 'writeRecord',
-        phase: 'failed',
+
         message: 'Failed to write HealthKit record',
         context: {'record': record},
         exception: e,
@@ -391,7 +380,7 @@ final class HealthConnectorHKClient implements HealthConnectorPlatformClient {
     HealthConnectorLogger.debug(
       tag,
       operation: 'writeRecords',
-      phase: 'entry',
+
       message: 'Writing HealthKit records',
       context: {'records': records},
     );
@@ -400,7 +389,7 @@ final class HealthConnectorHKClient implements HealthConnectorPlatformClient {
       HealthConnectorLogger.warning(
         tag,
         operation: 'writeRecords',
-        phase: 'succeeded',
+
         message: 'No records to write (empty list)',
       );
 
@@ -419,7 +408,7 @@ final class HealthConnectorHKClient implements HealthConnectorPlatformClient {
       HealthConnectorLogger.info(
         tag,
         operation: 'writeRecords',
-        phase: 'succeeded',
+
         message: 'HealthKit records written successfully',
         context: {'records': records, 'assignedRecordIds': recordIds},
       );
@@ -429,7 +418,7 @@ final class HealthConnectorHKClient implements HealthConnectorPlatformClient {
       HealthConnectorLogger.error(
         tag,
         operation: 'writeRecords',
-        phase: 'failed',
+
         message: 'Failed to write HealthKit records',
         context: {'records': records},
         exception: e,
@@ -450,7 +439,7 @@ final class HealthConnectorHKClient implements HealthConnectorPlatformClient {
     HealthConnectorLogger.debug(
       tag,
       operation: 'updateRecord',
-      phase: 'entry',
+
       message: 'Updating HealthKit record',
       context: {'record': record},
     );
@@ -465,7 +454,7 @@ final class HealthConnectorHKClient implements HealthConnectorPlatformClient {
       HealthConnectorLogger.info(
         tag,
         operation: 'updateRecord',
-        phase: 'succeeded',
+
         message: 'HealthKit record updated successfully',
         context: {'record': record},
       );
@@ -475,7 +464,7 @@ final class HealthConnectorHKClient implements HealthConnectorPlatformClient {
       HealthConnectorLogger.error(
         tag,
         operation: 'updateRecord',
-        phase: 'failed',
+
         message: 'Failed to update HealthKit record',
         context: {'record': record},
         exception: e,
@@ -499,7 +488,7 @@ final class HealthConnectorHKClient implements HealthConnectorPlatformClient {
     HealthConnectorLogger.debug(
       tag,
       operation: 'aggregate',
-      phase: 'entry',
+
       message: 'Aggregating HealthKit data',
       context: {'request': request},
     );
@@ -514,7 +503,7 @@ final class HealthConnectorHKClient implements HealthConnectorPlatformClient {
       HealthConnectorLogger.info(
         tag,
         operation: 'aggregate',
-        phase: 'succeeded',
+
         message: 'HealthKit data aggregated successfully',
         context: {'request': request, 'response': response},
       );
@@ -524,7 +513,7 @@ final class HealthConnectorHKClient implements HealthConnectorPlatformClient {
       HealthConnectorLogger.error(
         tag,
         operation: 'aggregate',
-        phase: 'failed',
+
         message: 'Failed to aggregate HealthKit data',
         context: {'request': request},
         exception: e,
@@ -554,7 +543,7 @@ final class HealthConnectorHKClient implements HealthConnectorPlatformClient {
     HealthConnectorLogger.debug(
       tag,
       operation: 'deleteRecords',
-      phase: 'entry',
+
       message: 'Deleting HealthKit records by time range',
       context: {'request': request},
     );
@@ -571,7 +560,7 @@ final class HealthConnectorHKClient implements HealthConnectorPlatformClient {
       HealthConnectorLogger.info(
         tag,
         operation: 'deleteRecords',
-        phase: 'succeeded',
+
         message: 'HealthKit records deleted successfully',
         context: {'request': request},
       );
@@ -579,7 +568,7 @@ final class HealthConnectorHKClient implements HealthConnectorPlatformClient {
       HealthConnectorLogger.error(
         tag,
         operation: 'deleteRecords',
-        phase: 'failed',
+
         message: 'Failed to delete HealthKit records',
         context: {'request': request},
         exception: e,
@@ -608,7 +597,7 @@ final class HealthConnectorHKClient implements HealthConnectorPlatformClient {
     HealthConnectorLogger.debug(
       tag,
       operation: 'deleteRecordsByIds',
-      phase: 'entry',
+
       message: 'Deleting HealthKit records by IDs',
       context: {'request': request},
     );
@@ -617,7 +606,7 @@ final class HealthConnectorHKClient implements HealthConnectorPlatformClient {
       HealthConnectorLogger.warning(
         tag,
         operation: 'deleteRecordsByIds',
-        phase: 'succeeded',
+
         message: 'No records to delete (empty IDs list)',
       );
 
@@ -635,7 +624,7 @@ final class HealthConnectorHKClient implements HealthConnectorPlatformClient {
       HealthConnectorLogger.info(
         tag,
         operation: 'deleteRecordsByIds',
-        phase: 'succeeded',
+
         message: 'HealthKit records deleted successfully',
         context: {'request': request},
       );
@@ -643,7 +632,7 @@ final class HealthConnectorHKClient implements HealthConnectorPlatformClient {
       HealthConnectorLogger.error(
         tag,
         operation: 'deleteRecordsByIds',
-        phase: 'failed',
+
         message: 'Failed to delete HealthKit records by IDs',
         context: {'request': request},
         exception: e,

--- a/packages/health_connector_logger/README.md
+++ b/packages/health_connector_logger/README.md
@@ -18,7 +18,7 @@ exception tracking.
 
 ### 🔧 Features
 
-- **Structured Logging**: Consistent format with operation, phase, message, and context
+- **Structured Logging**: Consistent format with operation, message, and context
 - **Log Levels**: Support for debug, info, warning, and error levels
 - **Exception Tracking**: Built-in support for exceptions and stack traces
 - **Context Data**: Flexible context map for additional metadata
@@ -58,7 +58,6 @@ HealthConnectorLogger.isEnabled = true;
 HealthConnectorLogger.debug(
   'API',
   operation: 'readRecords',
-  phase: 'entry',
   message: 'Starting to read records',
   context: {'dataType': 'StepsRecord', 'pageSize': 100},
 );
@@ -66,7 +65,6 @@ HealthConnectorLogger.debug(
 HealthConnectorLogger.info(
   'API',
   operation: 'readRecords',
-  phase: 'succeeded',
   message: 'Successfully read records',
   context: {'recordCount': 42, 'duration': '123ms'},
 );
@@ -74,7 +72,6 @@ HealthConnectorLogger.info(
 HealthConnectorLogger.warning(
   'API',
   operation: 'readRecords',
-  phase: 'slow operation detected',
   message: 'Operation exceeded threshold',
   context: {'duration': '6234ms', 'threshold': '5000ms'},
 );
@@ -82,7 +79,6 @@ HealthConnectorLogger.warning(
 HealthConnectorLogger.error(
   'API',
   operation: 'readRecords',
-  phase: 'failed',
   message: 'Failed to read records',
   context: {'dataType': 'StepsRecord', 'duration': '123ms'},
   exception: e,
@@ -112,4 +108,3 @@ The logger produces structured messages in JSON-like format:
 ## 🤝 Contributing
 
 To report issues or request features, please visit our [GitHub Issues](https://github.com/fam-tung-lam/health_connector/issues).
-

--- a/packages/health_connector_logger/lib/src/health_connector_log.dart
+++ b/packages/health_connector_logger/lib/src/health_connector_log.dart
@@ -26,11 +26,6 @@ import 'package:meta/meta.dart';
 /// - [tag]: A category identifier for the log (e.g., 'API', 'DATABASE')
 /// - [operation]: The operation being logged (e.g., 'readRecords')
 /// - [dateTime]: The timestamp when the log was created
-/// - [phase]: Optional operation phase (e.g., 'entry', 'completed')
-/// - [message]: Optional descriptive message
-/// - [context]: Optional contextual data as key-value pairs
-/// - [exception]: Optional exception object if an error occurred
-/// - [stackTrace]: Optional stack trace associated with an exception
 /// - [structuredMessage]: The formatted structured message output
 @immutable
 class HealthConnectorLog {
@@ -50,11 +45,6 @@ class HealthConnectorLog {
 
   /// The timestamp when this log was created.
   final DateTime dateTime;
-
-  /// Optional phase of the operation.
-  ///
-  /// Examples: 'entry', 'exit', 'succeeded', 'failed'.
-  final String? phase;
 
   /// Optional descriptive message.
   final String? message;
@@ -83,8 +73,8 @@ class HealthConnectorLog {
     required this.operation,
     required this.dateTime,
     required this.structuredMessage,
-    this.phase,
     this.message,
+
     this.context,
     this.exception,
     this.stackTrace,
@@ -99,7 +89,6 @@ class HealthConnectorLog {
           tag == other.tag &&
           operation == other.operation &&
           dateTime == other.dateTime &&
-          phase == other.phase &&
           message == other.message &&
           _mapEquals(context, other.context) &&
           exception == other.exception &&
@@ -112,7 +101,6 @@ class HealthConnectorLog {
       tag.hashCode ^
       operation.hashCode ^
       dateTime.hashCode ^
-      phase.hashCode ^
       message.hashCode ^
       _mapHashCode(context) ^
       exception.hashCode ^
@@ -126,7 +114,6 @@ class HealthConnectorLog {
       'tag: $tag, '
       'operation: $operation, '
       'dateTime: $dateTime, '
-      'phase: $phase, '
       'message: $message, '
       'context: $context, '
       'exception: $exception, '

--- a/packages/health_connector_logger/lib/src/health_connector_logger.dart
+++ b/packages/health_connector_logger/lib/src/health_connector_logger.dart
@@ -7,8 +7,14 @@ import 'package:meta/meta.dart' show internal, visibleForTesting;
 /// A singleton logger that wraps the `log` function from `dart:developer`.
 ///
 /// This logger provides a consistent structured logging interface with
-/// formatted messages across the plugin. It supports structured logging with
-/// operation, optional phase, optional message, and context.
+
+/// information:
+///
+/// - Level (INFO, DEBUG, WARNING, ERROR)
+/// - Tag (Category)
+/// - Operation (Action being performed)
+/// - Timestamp
+/// - Structured data (JSON-like format)
 abstract final class HealthConnectorLogger {
   /// Private constructor to prevent instantiation.
   const HealthConnectorLogger._();
@@ -82,7 +88,7 @@ abstract final class HealthConnectorLogger {
   ///
   /// - [tag]: A tag for categorizing the log entry (converted to uppercase).
   /// - [operation]: The operation being performed.
-  /// - [phase]: Optional phase of the operation.
+
   /// - [message]: Optional message to include in the log.
   /// - [context]: Optional contextual information.
   /// - [exception]: Optional exception object to include in the log.
@@ -94,7 +100,6 @@ abstract final class HealthConnectorLogger {
   /// HealthConnectorLogger.info(
   ///   'API',
   ///   operation: 'readRecords',
-  ///   phase: 'succeeded',
   ///   message: 'Successfully read records',
   ///   context: {'recordCount': 42, 'duration': '123ms'},
   /// );
@@ -102,7 +107,6 @@ abstract final class HealthConnectorLogger {
   static void info(
     String tag, {
     required String operation,
-    String? phase,
     String? message,
     Map<String, dynamic>? context,
     Object? exception,
@@ -112,7 +116,6 @@ abstract final class HealthConnectorLogger {
       LogLevel.info,
       tag,
       operation: operation,
-      phase: phase,
       message: message,
       context: context,
       exception: exception,
@@ -129,7 +132,7 @@ abstract final class HealthConnectorLogger {
   ///
   /// - [tag]: A tag for categorizing the log entry (converted to uppercase).
   /// - [operation]: The operation being performed.
-  /// - [phase]: Optional phase of the operation.
+
   /// - [message]: Optional message to include in the log.
   /// - [context]: Optional contextual information.
   /// - [exception]: Optional exception object to include in the log.
@@ -141,7 +144,6 @@ abstract final class HealthConnectorLogger {
   /// HealthConnectorLogger.debug(
   ///   'API',
   ///   operation: 'readRecords',
-  ///   phase: 'entry',
   ///   message: 'Starting to read records',
   ///   context: {'dataType': 'StepsRecord', 'pageSize': 100},
   /// );
@@ -149,7 +151,6 @@ abstract final class HealthConnectorLogger {
   static void debug(
     String tag, {
     required String operation,
-    String? phase,
     String? message,
     Map<String, dynamic>? context,
     Object? exception,
@@ -159,7 +160,6 @@ abstract final class HealthConnectorLogger {
       LogLevel.debug,
       tag,
       operation: operation,
-      phase: phase,
       message: message,
       context: context,
       exception: exception,
@@ -176,7 +176,7 @@ abstract final class HealthConnectorLogger {
   ///
   /// - [tag]: A tag for categorizing the log entry (converted to uppercase).
   /// - [operation]: The operation being performed.
-  /// - [phase]: Optional phase of the operation.
+
   /// - [message]: Optional message to include in the log.
   /// - [context]: Optional contextual information.
   /// - [exception]: Optional exception object to include in the log.
@@ -188,7 +188,6 @@ abstract final class HealthConnectorLogger {
   /// HealthConnectorLogger.warning(
   ///   'API',
   ///   operation: 'readRecords',
-  ///   phase: 'slow operation detected',
   ///   message: 'Operation exceeded threshold',
   ///   context: {'duration': '6234ms', 'threshold': '5000ms'},
   /// );
@@ -196,7 +195,6 @@ abstract final class HealthConnectorLogger {
   static void warning(
     String tag, {
     required String operation,
-    String? phase,
     String? message,
     Map<String, dynamic>? context,
     Object? exception,
@@ -206,7 +204,6 @@ abstract final class HealthConnectorLogger {
       LogLevel.warning,
       tag,
       operation: operation,
-      phase: phase,
       message: message,
       context: context,
       exception: exception,
@@ -223,7 +220,7 @@ abstract final class HealthConnectorLogger {
   ///
   /// - [tag]: A tag for categorizing the log entry (converted to uppercase).
   /// - [operation]: The operation being performed.
-  /// - [phase]: Optional phase of the operation.
+
   /// - [message]: Optional message to include in the log.
   /// - [context]: Optional contextual information.
   /// - [exception]: Optional exception object to include in the log.
@@ -235,7 +232,6 @@ abstract final class HealthConnectorLogger {
   /// HealthConnectorLogger.error(
   ///   'API',
   ///   operation: 'readRecords',
-  ///   phase: 'failed',
   ///   message: 'Failed to read records',
   ///   context: {'dataType': 'StepsRecord', 'duration': '123ms'},
   ///   exception: e,
@@ -245,7 +241,6 @@ abstract final class HealthConnectorLogger {
   static void error(
     String tag, {
     required String operation,
-    String? phase,
     String? message,
     Map<String, dynamic>? context,
     Object? exception,
@@ -255,7 +250,6 @@ abstract final class HealthConnectorLogger {
       LogLevel.error,
       tag,
       operation: operation,
-      phase: phase,
       message: message,
       context: context,
       exception: exception,
@@ -272,7 +266,6 @@ abstract final class HealthConnectorLogger {
   /// {
   ///    datetime: {datetime},
   ///    operation: {operation},
-  ///    phase: {phase},  // Optional, only included if provided
   ///    message: {message},
   ///    exception: {
   ///      cause: {exception},
@@ -289,7 +282,6 @@ abstract final class HealthConnectorLogger {
   /// - [level]: The log level (DEBUG, INFO, WARNING, ERROR).
   /// - [tag]: The tag for categorizing the log entry.
   /// - [operation]: The operation being performed.
-  /// - [phase]: Optional phase of the operation.
   /// - [message]: Optional message to include in the log.
   /// - [context]: Optional contextual information.
   /// - [exception]: Optional exception object.
@@ -298,7 +290,6 @@ abstract final class HealthConnectorLogger {
     LogLevel level,
     String tag, {
     required String operation,
-    String? phase,
     String? message,
     Map<String, dynamic>? context,
     Object? exception,
@@ -313,11 +304,11 @@ abstract final class HealthConnectorLogger {
     final now = DateTime.now();
 
     // Format structured message with the timestamp
+    // Format structured message with the timestamp
     final structuredMessage = formatStructuredMessage(
       level: level,
       operation: operation,
       dateTime: now,
-      phase: phase,
       message: message,
       context: context,
       exception: exception,
@@ -325,12 +316,12 @@ abstract final class HealthConnectorLogger {
     );
 
     // Create and emit log event
+    // Create and emit log event
     final logEvent = HealthConnectorLog(
       level: level,
       tag: tag,
       operation: operation,
       dateTime: now,
-      phase: phase,
       message: message,
       context: context,
       exception: exception,
@@ -356,7 +347,6 @@ abstract final class HealthConnectorLogger {
   /// ## Parameters
   ///
   /// - [operation]: The operation being performed (e.g., 'readRecords').
-  /// - [phase]: Optional phase of the operation (e.g., 'entry', 'completed').
   /// - [message]: Optional message to include in the log.
   /// - [context]: Optional map of contextual information.
   /// - [exception]: Optional exception object.
@@ -371,7 +361,6 @@ abstract final class HealthConnectorLogger {
     required LogLevel level,
     required String operation,
     DateTime? dateTime,
-    String? phase,
     String? message,
     Map<String, dynamic>? context,
     Object? exception,
@@ -400,11 +389,6 @@ abstract final class HealthConnectorLogger {
       ..write(dateTimeToLog.millisecond.toString().padLeft(3, '0'));
     buffer.write(',');
     buffer.write('\n${_getIndent(0)}operation: $operation,');
-
-    // Include phase if provided
-    if (phase != null) {
-      buffer.write('\n${_getIndent(0)}phase: $phase,');
-    }
 
     // Include message if provided
     if (message != null) {

--- a/packages/health_connector_logger/test/unit_test/health_connector_log_test.dart
+++ b/packages/health_connector_logger/test/unit_test/health_connector_log_test.dart
@@ -21,7 +21,7 @@ void main() {
       expect(log.operation, equals('testOp'));
       expect(log.dateTime, equals(testDateTime));
       expect(log.structuredMessage, equals(testStructuredMessage));
-      expect(log.phase, isNull);
+
       expect(log.message, isNull);
       expect(log.context, isNull);
       expect(log.exception, isNull);
@@ -39,14 +39,13 @@ void main() {
         operation: 'failedOp',
         dateTime: testDateTime,
         structuredMessage: testStructuredMessage,
-        phase: 'failed',
+
         message: 'Operation failed',
         context: context,
         exception: exception,
         stackTrace: stackTrace,
       );
 
-      expect(log.phase, equals('failed'));
       expect(log.message, equals('Operation failed'));
       expect(log.context, equals(context));
       expect(log.exception, equals(exception));
@@ -61,7 +60,7 @@ void main() {
           operation: 'testOp',
           dateTime: testDateTime,
           structuredMessage: testStructuredMessage,
-          phase: 'entry',
+
           message: 'test message',
           context: const {'key': 'value'},
         );
@@ -72,7 +71,7 @@ void main() {
           operation: 'testOp',
           dateTime: testDateTime,
           structuredMessage: testStructuredMessage,
-          phase: 'entry',
+
           message: 'test message',
           context: const {'key': 'value'},
         );
@@ -151,7 +150,7 @@ void main() {
         operation: 'warnOp',
         dateTime: testDateTime,
         structuredMessage: testStructuredMessage,
-        phase: 'check',
+
         message: 'Warning message',
         context: const {'count': 5},
       );
@@ -161,7 +160,7 @@ void main() {
       expect(str, contains('WARN'));
       expect(str, contains('warnOp'));
       expect(str, contains('2024-03-15'));
-      expect(str, contains('check'));
+
       expect(str, contains('Warning message'));
       expect(str, contains('{count: 5}'));
     });

--- a/packages/health_connector_logger/test/unit_test/health_connector_logger_stream_test.dart
+++ b/packages/health_connector_logger/test/unit_test/health_connector_logger_stream_test.dart
@@ -49,7 +49,6 @@ void main() {
       HealthConnectorLogger.debug(
         'DEBUG_TAG',
         operation: 'debugOp',
-        phase: 'entry',
       );
 
       await Future<void>.delayed(Duration.zero);
@@ -58,7 +57,6 @@ void main() {
       expect(logs[0].level, equals(LogLevel.debug));
       expect(logs[0].tag, equals('DEBUG_TAG'));
       expect(logs[0].operation, equals('debugOp'));
-      expect(logs[0].phase, equals('entry'));
 
       await subscription.cancel();
     });
@@ -225,12 +223,18 @@ void main() {
         final secondParts = timeParts[2].split('.');
 
         final messageDateTime = DateTime(
-          int.parse(dateParts[2]), // year
-          int.parse(dateParts[1]), // month
-          int.parse(dateParts[0]), // day
-          int.parse(timeParts[0]), // hour
-          int.parse(timeParts[1]), // minute
-          int.parse(secondParts[0]), // second
+          int.parse(dateParts[2]),
+          // year
+          int.parse(dateParts[1]),
+          // month
+          int.parse(dateParts[0]),
+          // day
+          int.parse(timeParts[0]),
+          // hour
+          int.parse(timeParts[1]),
+          // minute
+          int.parse(secondParts[0]),
+          // second
           int.parse(secondParts[1]), // millisecond
         );
 
@@ -253,7 +257,7 @@ void main() {
       HealthConnectorLogger.info(
         'API',
         operation: 'readRecords',
-        phase: 'completed',
+
         message: 'Successfully read 42 records',
         context: {'count': 42, 'duration': '123ms'},
       );
@@ -265,7 +269,7 @@ void main() {
 
       // Verify structured message contains all the data
       expect(log.structuredMessage, contains('operation: readRecords'));
-      expect(log.structuredMessage, contains('phase: completed'));
+
       expect(
         log.structuredMessage,
         contains('message: Successfully read 42 records'),
@@ -311,7 +315,7 @@ void main() {
       HealthConnectorLogger.error(
         'ERROR_TAG',
         operation: 'failedOperation',
-        phase: 'execution',
+
         message: 'Operation failed with error',
         context: {'attempt': 3, 'maxRetries': 5},
         exception: exception,
@@ -326,7 +330,7 @@ void main() {
       expect(log.level, equals(LogLevel.error));
       expect(log.tag, equals('ERROR_TAG'));
       expect(log.operation, equals('failedOperation'));
-      expect(log.phase, equals('execution'));
+
       expect(log.message, equals('Operation failed with error'));
       expect(log.context, equals({'attempt': 3, 'maxRetries': 5}));
       expect(log.exception, equals(exception));

--- a/packages/health_connector_logger/test/unit_test/health_connector_logger_test.dart
+++ b/packages/health_connector_logger/test/unit_test/health_connector_logger_test.dart
@@ -20,7 +20,6 @@ void main() {
         expect(result, contains('operation: readRecords'));
         expect(result, startsWith('{'));
         expect(result, endsWith('\n}'));
-        expect(result, isNot(contains('phase:')));
         expect(result, isNot(contains('message:')));
         expect(result, isNot(contains('exception:')));
         expect(result, isNot(contains('context:')));
@@ -86,42 +85,6 @@ void main() {
           loggedDateTime.isBefore(after.add(const Duration(seconds: 1))),
           isTrue,
         );
-      });
-    });
-
-    group('optional phase parameter', () {
-      test('includes phase field when provided', () {
-        final result = HealthConnectorLogger.formatStructuredMessage(
-          level: LogLevel.info,
-          operation: 'readRecords',
-          phase: 'entry',
-          dateTime: testDateTime,
-        );
-
-        expect(result, contains('phase: entry'));
-        expect(result, contains('operation: readRecords'));
-      });
-
-      test('omits phase field when null', () {
-        final result = HealthConnectorLogger.formatStructuredMessage(
-          level: LogLevel.info,
-          operation: 'readRecords',
-          dateTime: testDateTime,
-        );
-
-        expect(result, isNot(contains('phase:')));
-        expect(result, contains('operation: readRecords'));
-      });
-
-      test('handles phase with special characters', () {
-        final result = HealthConnectorLogger.formatStructuredMessage(
-          level: LogLevel.info,
-          operation: 'test',
-          phase: 'phase with spaces and-special-chars',
-          dateTime: testDateTime,
-        );
-
-        expect(result, contains('phase: phase with spaces and-special-chars'));
       });
     });
 
@@ -456,7 +419,6 @@ void main() {
           level: LogLevel.info,
           operation: 'readRecords',
           dateTime: testDateTime,
-          phase: 'completed',
           message: 'Successfully read records',
           context: context,
           exception: exception,
@@ -466,7 +428,6 @@ void main() {
         // Verify all fields are present
         expect(result, contains('datetime: 15-03-2024 10:30:45.123'));
         expect(result, contains('operation: readRecords'));
-        expect(result, contains('phase: completed'));
         expect(result, contains('message: Successfully read records'));
         expect(result, contains('exception: {'));
         expect(result, contains('cause: $exception'));


### PR DESCRIPTION
### **PR Type**
Enhancement


___

### **Description**
- Remove obsolete `phase` parameter from all logger calls

- Update logger API to eliminate optional phase argument

- Simplify structured logging format across all platforms

- Update documentation and tests to reflect API changes


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Logger API<br/>with phase param"] -->|Remove phase| B["Simplified Logger API<br/>without phase"]
  C["Dart Client Calls<br/>with phase"] -->|Update calls| D["Dart Client Calls<br/>without phase"]
  E["Swift Client Calls<br/>with phase"] -->|Update calls| F["Swift Client Calls<br/>without phase"]
  G["Kotlin Client Calls<br/>with phase"] -->|Update calls| H["Kotlin Client Calls<br/>without phase"]
  B --> I["Cleaner structured<br/>log messages"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><details><summary>10 files</summary><table>
<tr>
  <td><strong>health_connector_logger.dart</strong><dd><code>Remove phase parameter from Dart logger interface</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/fam-tung-lam/health_connector/pull/37/files#diff-6a706c57f1b925fe9d62574fae4f79cf7c1578fe7f8623435807746eccca3a32">+14/-30</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>health_connector_log.dart</strong><dd><code>Remove phase field from HealthConnectorLog model</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/fam-tung-lam/health_connector/pull/37/files#diff-6fe1d186823eab080b60108e965689e95ca1f905cd764f366089b5b683c25089">+1/-14</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>health_connector_hc_client.dart</strong><dd><code>Remove phase arguments from all logger calls</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/fam-tung-lam/health_connector/pull/37/files#diff-a120bdcd1518727307fa1df040f2c1b2d9e37fd032c21f81c5670f5a76d26ed6">+34/-43</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>health_connector_hk_client.dart</strong><dd><code>Remove phase arguments from all logger calls</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/fam-tung-lam/health_connector/pull/37/files#diff-02bc71965d968ac39ac3fe030036e2ade416f2e655d8db6451b93a93fa180137">+23/-34</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>HealthConnectorClient.kt</strong><dd><code>Remove phase arguments from Kotlin logger calls</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/fam-tung-lam/health_connector/pull/37/files#diff-ad31ca5ffb54a1dccd985fd236c8328c8c9c1e372e881727fe17d8dc60b56e2d">+66/-77</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>HealthConnectorLogger.kt</strong><dd><code>Remove phase parameter from Kotlin logger methods</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/fam-tung-lam/health_connector/pull/37/files#diff-24e9e885715e77f0dcf2fd29df835b7559504d9e6a04f1e2a2d5f5a753cfd1c2">+12/-21</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>HealthConnectorHCAndroidPlugin.kt</strong><dd><code>Remove phase arguments from plugin logger calls</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/fam-tung-lam/health_connector/pull/37/files#diff-d12ef408900b74499ec89a26a23b12a1b53cd24657c1403ed5ea77fcda65155c">+11/-17</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>HealthConnectorClient.swift</strong><dd><code>Remove phase arguments from Swift logger calls</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/fam-tung-lam/health_connector/pull/37/files#diff-7ba7a6730c323361114ecfcd6fd7f2c783b62de742fd417e2b020ed14ed961fb">+36/-45</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>HealthConnectorLogger.swift</strong><dd><code>Remove phase parameter from Swift logger methods</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/fam-tung-lam/health_connector/pull/37/files#diff-d4a7dd3bd969f0191270cde3cc8ebb006c95acded2a7146c35bb48beff2d8fec">+19/-22</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>HealthConnectorHkIosPlugin.swift</strong><dd><code>Remove phase arguments from plugin logger calls</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/fam-tung-lam/health_connector/pull/37/files#diff-d32ef736d1ea3139ea58944d56d32e3219003e2c8e29d8ff9d8913cf829611f5">+9/-21</a>&nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Tests</strong></td><td><details><summary>2 files</summary><table>
<tr>
  <td><strong>health_connector_logger_stream_test.dart</strong><dd><code>Update tests to remove phase parameter assertions</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/fam-tung-lam/health_connector/pull/37/files#diff-0e9cf49cbf9c4cf3bcc74d18df115a67cb24ee1963a6d12de94390104a705d44">+16/-12</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>health_connector_log_test.dart</strong><dd><code>Update tests to remove phase field validation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/fam-tung-lam/health_connector/pull/37/files#diff-fe7baf77407d3f5c25a0f823efee13c426f128b936c82c3d22b51325975ca2bc">+6/-7</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Documentation</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td><strong>README.md</strong><dd><code>Update documentation to reflect phase removal</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/fam-tung-lam/health_connector/pull/37/files#diff-60b961e7159b1b11cea5817094017ae3ba341bb14bd5bded6428d48070dfd285">+1/-6</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Additional files</strong></td><td><details><summary>2 files</summary><table>
<tr>
  <td><strong>health_connector.dart</strong></td>
  <td><a href="https://github.com/fam-tung-lam/health_connector/pull/37/files#diff-a7c3b4728d2f5d7620a681bac605cc57250cad25ec594cc421f1eed837b56cb6">+0/-50</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>health_connector_logger_test.dart</strong></td>
  <td><a href="https://github.com/fam-tung-lam/health_connector/pull/37/files#diff-626e0530e36fefcb70877984061234b7eb875723dc0619c963857e162768ee1b">+0/-39</a>&nbsp; &nbsp; </td>

</tr>
</table></details></td></tr></tbody></table>

</details>

___

