### PR TITLE
refactor(health_connector,health_connector_core,health_connector_hc_android,health_connector_hk_ios)!: Convert `HealthConnectorException` to sealed class hierarchy

### DIFF
--- a/packages/health_connector/lib/src/health_connector.dart
+++ b/packages/health_connector/lib/src/health_connector.dart
@@ -29,6 +29,8 @@ import 'package:health_connector_core/health_connector_core.dart'
         sinceV2_0_0,
         DeleteRecordsInTimeRangeRequest,
         DeleteRecordsByIdsRequest,
+        HealthProviderUnavailableException,
+        HealthProviderNotInstalledOrUpdateRequiredException,
         sinceV1_0_0;
 import 'package:health_connector_hc_android/health_connector_hc_android.dart'
     show HealthConnectorHCClient;
@@ -84,8 +86,7 @@ abstract interface class HealthConnector {
           context: {'platform': healthPlatform.name},
         );
 
-        throw HealthConnectorException(
-          HealthConnectorErrorCode.healthProviderUnavailable,
+        throw HealthProviderUnavailableException(
           '$healthPlatform is not available.',
         );
       case HealthPlatformStatus.installationOrUpdateRequired:
@@ -96,8 +97,7 @@ abstract interface class HealthConnector {
           context: {'platform': healthPlatform.name},
         );
 
-        throw HealthConnectorException(
-          HealthConnectorErrorCode.healthProviderNotInstalledOrUpdateRequired,
+        throw HealthProviderNotInstalledOrUpdateRequiredException(
           '$healthPlatform needs installation or update.',
         );
       case HealthPlatformStatus.available:

--- a/packages/health_connector/lib/src/health_connector_impl.dart
+++ b/packages/health_connector/lib/src/health_connector_impl.dart
@@ -8,7 +8,6 @@ import 'package:health_connector_core/health_connector_core.dart'
         DeleteRecordsInTimeRangeRequest,
         HealthConnectorConfig,
         HealthConnectorException,
-        HealthConnectorErrorCode,
         HealthConnectorPlatformClient,
         HealthPlatform,
         HealthPlatformFeature,
@@ -23,7 +22,9 @@ import 'package:health_connector_core/health_connector_core.dart'
         ReadRecordsInTimeRangeRequest,
         ReadRecordsInTimeRangeResponse,
         require,
-        supportedOnHealthConnect;
+        supportedOnHealthConnect,
+        UnsupportedOperationException,
+        InvalidArgumentException;
 import 'package:health_connector_hc_android/health_connector_hc_android.dart'
     show HealthConnectorHCClient;
 import 'package:health_connector_logger/health_connector_logger.dart';
@@ -107,8 +108,7 @@ final class HealthConnectorImpl implements HealthConnector {
           context: {'current_health_platform': _healthPlatform.name},
         );
 
-        throw const HealthConnectorException(
-          HealthConnectorErrorCode.unsupportedOperation,
+        throw const UnsupportedOperationException(
           'getGrantedPermissions is only available on Health Connect. ',
         );
       case HealthPlatform.healthConnect:
@@ -190,8 +190,7 @@ final class HealthConnectorImpl implements HealthConnector {
           context: {'current_health_platform': _healthPlatform.name},
         );
 
-        throw const HealthConnectorException(
-          HealthConnectorErrorCode.unsupportedOperation,
+        throw const UnsupportedOperationException(
           'revokeAllPermissions is only available on Health Connect. ',
         );
       case HealthPlatform.healthConnect:
@@ -386,8 +385,7 @@ final class HealthConnectorImpl implements HealthConnector {
         stackTrace: st,
       );
 
-      throw HealthConnectorException(
-        HealthConnectorErrorCode.invalidArgument,
+      throw InvalidArgumentException(
         (e.message as String?) ?? e.toString(),
       );
     } catch (e, st) {
@@ -446,8 +444,7 @@ final class HealthConnectorImpl implements HealthConnector {
         stackTrace: st,
       );
 
-      throw HealthConnectorException(
-        HealthConnectorErrorCode.invalidArgument,
+      throw InvalidArgumentException(
         (e.message as String?) ?? e.toString(),
       );
     } on HealthConnectorException catch (e, st) {
@@ -576,8 +573,7 @@ final class HealthConnectorImpl implements HealthConnector {
         stackTrace: st,
       );
 
-      throw HealthConnectorException(
-        HealthConnectorErrorCode.invalidArgument,
+      throw InvalidArgumentException(
         (e.message as String?) ?? e.toString(),
       );
     } on HealthConnectorException catch (e, st) {
@@ -627,8 +623,7 @@ final class HealthConnectorImpl implements HealthConnector {
         stackTrace: st,
       );
 
-      throw HealthConnectorException(
-        HealthConnectorErrorCode.invalidArgument,
+      throw InvalidArgumentException(
         (e.message as String?) ?? e.toString(),
       );
     } on HealthConnectorException catch (e, st) {

--- a/packages/health_connector_core/lib/src/models/exceptions/health_connector_exception.dart
+++ b/packages/health_connector_core/lib/src/models/exceptions/health_connector_exception.dart
@@ -1,13 +1,29 @@
 import 'package:health_connector_core/src/annotations/annotations.dart'
-    show sinceV1_0_0;
+    show sinceV1_0_0, sinceV2_0_0;
 import 'package:health_connector_core/src/models/exceptions/health_connector_error_code.dart'
     show HealthConnectorErrorCode;
 import 'package:meta/meta.dart' show immutable;
 
-/// Exception class for all health connector plugin errors.
+/// Sealed exception class for all health connector plugin errors.
+///
+/// Use the specific subclasses to create exceptions with the appropriate error
+/// code automatically assigned. Each subclass corresponds to a specific
+/// [HealthConnectorErrorCode].
+///
+/// Example:
+/// ```dart
+/// throw NotAuthorizedException('User denied permissions');
+///
+/// // With cause and stack trace
+/// throw RemoteErrorException(
+///   'Failed to sync data',
+///   cause: originalError,
+///   stackTrace: originalStackTrace,
+/// );
+/// ```
 @sinceV1_0_0
 @immutable
-final class HealthConnectorException implements Exception {
+sealed class HealthConnectorException implements Exception {
   /// Creates a [HealthConnectorException] with the given [code], [message],
   /// optional [cause] and [stackTrace].
   ///
@@ -20,6 +36,73 @@ final class HealthConnectorException implements Exception {
     this.cause,
     this.stackTrace,
   });
+
+  /// Creates a specific [HealthConnectorException] subclass based on the
+  /// provided [code].
+  @sinceV2_0_0
+  factory HealthConnectorException.fromCode(
+    HealthConnectorErrorCode code,
+    String message, {
+    Object? cause,
+    StackTrace? stackTrace,
+  }) {
+    switch (code) {
+      case HealthConnectorErrorCode.healthProviderNotInstalledOrUpdateRequired:
+        return HealthProviderNotInstalledOrUpdateRequiredException(
+          message,
+          cause: cause,
+          stackTrace: stackTrace,
+        );
+      case HealthConnectorErrorCode.healthProviderUnavailable:
+        return HealthProviderUnavailableException(
+          message,
+          cause: cause,
+          stackTrace: stackTrace,
+        );
+      case HealthConnectorErrorCode.unsupportedOperation:
+        return UnsupportedOperationException(
+          message,
+          cause: cause,
+          stackTrace: stackTrace,
+        );
+      case HealthConnectorErrorCode.invalidConfiguration:
+        return InvalidConfigurationException(
+          message,
+          cause: cause,
+          stackTrace: stackTrace,
+        );
+      case HealthConnectorErrorCode.invalidArgument:
+        return InvalidArgumentException(
+          message,
+          cause: cause,
+          stackTrace: stackTrace,
+        );
+      case HealthConnectorErrorCode.notAuthorized:
+        return NotAuthorizedException(
+          message,
+          cause: cause,
+          stackTrace: stackTrace,
+        );
+      case HealthConnectorErrorCode.remoteError:
+        return RemoteErrorException(
+          message,
+          cause: cause,
+          stackTrace: stackTrace,
+        );
+      case HealthConnectorErrorCode.userCancelled:
+        return UserCancelledException(
+          message,
+          cause: cause,
+          stackTrace: stackTrace,
+        );
+      case HealthConnectorErrorCode.unknown:
+        return UnknownException(
+          message,
+          cause: cause,
+          stackTrace: stackTrace,
+        );
+    }
+  }
 
   /// The error code identifying the type of error.
   final HealthConnectorErrorCode code;
@@ -61,4 +144,248 @@ final class HealthConnectorException implements Exception {
 
     return buffer.toString();
   }
+}
+
+/// Exception thrown when the health platform needs to be installed or updated.
+///
+/// **Platform:** Android only (iOS Apple Health is pre-installed)
+///
+/// **Causes:**
+/// - Health Connect app is not installed.
+/// - Health Connect app is outdated and requires an update.
+///
+/// **Action:**
+/// - Prompt the user to install or update Health Connect from the Play Store.
+/// - Provide a direct link.
+@sinceV2_0_0
+@immutable
+final class HealthProviderNotInstalledOrUpdateRequiredException
+    extends HealthConnectorException {
+  /// Creates a [HealthProviderNotInstalledOrUpdateRequiredException].
+  const HealthProviderNotInstalledOrUpdateRequiredException(
+    String message, {
+    Object? cause,
+    StackTrace? stackTrace,
+  }) : super(
+         HealthConnectorErrorCode.healthProviderNotInstalledOrUpdateRequired,
+         message,
+         cause: cause,
+         stackTrace: stackTrace,
+       );
+}
+
+/// Exception thrown when the health platform is unavailable on this device.
+///
+/// **Causes:**
+/// - Device does not support health API (Android < SDK 28, unsupported iPad).
+/// - Enterprise policy (MDM) or parental controls block access.
+/// - Health service is explicitly disabled by the system.
+/// - Device is in a restricted profile (Android work profile).
+///
+/// **Action:**
+/// - Inform the user that health features are not available on their device.
+/// - Gracefully disable health-related functionality.
+@sinceV2_0_0
+@immutable
+final class HealthProviderUnavailableException
+    extends HealthConnectorException {
+  /// Creates a [HealthProviderUnavailableException].
+  const HealthProviderUnavailableException(
+    String message, {
+    Object? cause,
+    StackTrace? stackTrace,
+  }) : super(
+         HealthConnectorErrorCode.healthProviderUnavailable,
+         message,
+         cause: cause,
+         stackTrace: stackTrace,
+       );
+}
+
+/// Exception thrown when an API not supported by the current platform or
+/// version is used.
+///
+/// **Causes:**
+/// - Calling an Android-specific API on iOS (or vice versa).
+/// - Requesting a data type unsupported by the current SDK version.
+///
+/// **Action:**
+/// - Check platform/version before calling the API.
+/// - This error should not occur in production if properly guarded.
+@sinceV2_0_0
+@immutable
+final class UnsupportedOperationException extends HealthConnectorException {
+  /// Creates an [UnsupportedOperationException].
+  const UnsupportedOperationException(
+    String message, {
+    Object? cause,
+    StackTrace? stackTrace,
+  }) : super(
+         HealthConnectorErrorCode.unsupportedOperation,
+         message,
+         cause: cause,
+         stackTrace: stackTrace,
+       );
+}
+
+/// Exception thrown when the app configuration is missing or invalid.
+///
+/// **Causes:**
+/// - Android: Missing permissions in `AndroidManifest.xml`.
+/// - Android: Missing Play Console health data declarations.
+/// - iOS: Missing HealthKit entitlement in Signing & Capabilities.
+/// - iOS: Missing usage description keys in `Info.plist`.
+///
+/// **Action:**
+/// - Check build logs and fix the app configuration.
+/// - This error should not occur in production if properly configured.
+@sinceV2_0_0
+@immutable
+final class InvalidConfigurationException extends HealthConnectorException {
+  /// Creates an [InvalidConfigurationException].
+  const InvalidConfigurationException(
+    String message, {
+    Object? cause,
+    StackTrace? stackTrace,
+  }) : super(
+         HealthConnectorErrorCode.invalidConfiguration,
+         message,
+         cause: cause,
+         stackTrace: stackTrace,
+       );
+}
+
+/// Exception thrown when an invalid argument is provided to the API.
+///
+/// **Causes:**
+/// - `startTime` is after `endTime`.
+/// - Value out of valid range (e.g., negative step count).
+/// - Record ID does not exist (delete/update operations).
+///
+/// **Action:**
+/// - Validate inputs before calling the plugin.
+/// - Refresh local record ID cache before delete/update operations.
+@sinceV2_0_0
+@immutable
+final class InvalidArgumentException extends HealthConnectorException {
+  /// Creates an [InvalidArgumentException].
+  const InvalidArgumentException(
+    String message, {
+    Object? cause,
+    StackTrace? stackTrace,
+  }) : super(
+         HealthConnectorErrorCode.invalidArgument,
+         message,
+         cause: cause,
+         stackTrace: stackTrace,
+       );
+}
+
+/// Exception thrown when access to health data was denied or not yet
+/// authorized.
+///
+/// **Causes:**
+/// - Permissions have not been requested yet.
+/// - User denied permissions in the system dialog.
+/// - Permissions were revoked via system settings.
+///
+/// **Action:**
+/// - If not yet requested: Trigger the permission request flow.
+/// - If denied: Explain why the feature needs access and guide user to
+///   settings.
+/// - Respect user choice; avoid repeated prompting.
+@sinceV2_0_0
+@immutable
+final class NotAuthorizedException extends HealthConnectorException {
+  /// Creates a [NotAuthorizedException].
+  const NotAuthorizedException(
+    String message, {
+    Object? cause,
+    StackTrace? stackTrace,
+  }) : super(
+         HealthConnectorErrorCode.notAuthorized,
+         message,
+         cause: cause,
+         stackTrace: stackTrace,
+       );
+}
+
+/// Exception thrown when a transient I/O or communication error occurred.
+///
+/// **Causes:**
+/// - Temporary disk I/O failure.
+/// - Inter-process communication (IPC) interrupted.
+/// - Background service temporarily unreachable.
+/// - Too many read/write operations in a short time window (Android only).
+///
+/// **Action:**
+/// - Retry with exponential backoff (e.g., 1s → 2s → 4s, max 30s).
+/// - These issues typically resolve quickly without user intervention.
+@sinceV2_0_0
+@immutable
+final class RemoteErrorException extends HealthConnectorException {
+  /// Creates a [RemoteErrorException].
+  const RemoteErrorException(
+    String message, {
+    Object? cause,
+    StackTrace? stackTrace,
+  }) : super(
+         HealthConnectorErrorCode.remoteError,
+         message,
+         cause: cause,
+         stackTrace: stackTrace,
+       );
+}
+
+/// Exception thrown when the user cancelled the operation.
+///
+/// **Causes:**
+/// - User dismissed the permission dialog without making a choice.
+/// - User cancelled an in-progress action.
+///
+/// **Action:**
+/// - Respect the user's choice; do not immediately re-prompt.
+/// - Continue app flow without health features if appropriate.
+/// - This is not an error condition requiring user notification.
+@sinceV2_0_0
+@immutable
+final class UserCancelledException extends HealthConnectorException {
+  /// Creates a [UserCancelledException].
+  const UserCancelledException(
+    String message, {
+    Object? cause,
+    StackTrace? stackTrace,
+  }) : super(
+         HealthConnectorErrorCode.userCancelled,
+         message,
+         cause: cause,
+         stackTrace: stackTrace,
+       );
+}
+
+/// Exception thrown when an unknown or unexpected error occurred.
+///
+/// **Causes:**
+/// - Unmapped native error code.
+/// - Internal platform bug.
+/// - New error type from SDK update.
+///
+/// **Action:**
+/// - Log the full error details for investigation.
+/// - Show a generic "Something went wrong" message to the user.
+/// - Report to crash analytics.
+@sinceV2_0_0
+@immutable
+final class UnknownException extends HealthConnectorException {
+  /// Creates an [UnknownException].
+  const UnknownException(
+    String message, {
+    Object? cause,
+    StackTrace? stackTrace,
+  }) : super(
+         HealthConnectorErrorCode.unknown,
+         message,
+         cause: cause,
+         stackTrace: stackTrace,
+       );
 }

--- a/packages/health_connector_core/lib/src/models/permissions/health_data_permission.dart
+++ b/packages/health_connector_core/lib/src/models/permissions/health_data_permission.dart
@@ -10,6 +10,24 @@ final class HealthDataPermission extends Permission {
     required this.accessType,
   });
 
+  factory HealthDataPermission.read(
+    HealthDataType<HealthRecord, MeasurementUnit> dataType,
+  ) {
+    return HealthDataPermission(
+      dataType: dataType,
+      accessType: HealthDataPermissionAccessType.read,
+    );
+  }
+
+  factory HealthDataPermission.write(
+    HealthDataType<HealthRecord, MeasurementUnit> dataType,
+  ) {
+    return HealthDataPermission(
+      dataType: dataType,
+      accessType: HealthDataPermissionAccessType.write,
+    );
+  }
+
   /// The specific type of health data (e.g., steps, heart rate, etc.) for
   /// which permission is requested.
   final HealthDataType<HealthRecord, MeasurementUnit> dataType;

--- a/packages/health_connector_hc_android/lib/src/health_connector_hc_client.dart
+++ b/packages/health_connector_hc_android/lib/src/health_connector_hc_client.dart
@@ -151,8 +151,8 @@ final class HealthConnectorHCClient implements HealthConnectorPlatformClient {
         stackTrace: st,
       );
 
-      throw HealthConnectorException(
-        e.code.toHealthConnectorErrorCode(),
+      throw HealthConnectorException.fromCode(
+        e.code.toErrorCode(),
         'Failed to get health platform status: '
         '${e.message ?? 'Unknown error'}',
         cause: e,
@@ -233,8 +233,8 @@ final class HealthConnectorHCClient implements HealthConnectorPlatformClient {
         stackTrace: st,
       );
 
-      throw HealthConnectorException(
-        e.code.toHealthConnectorErrorCode(),
+      throw HealthConnectorException.fromCode(
+        e.code.toErrorCode(),
         'Failed to request permissions: ${e.message ?? 'Unknown error'}',
         cause: e,
         stackTrace: st,
@@ -300,8 +300,8 @@ final class HealthConnectorHCClient implements HealthConnectorPlatformClient {
         stackTrace: st,
       );
 
-      throw HealthConnectorException(
-        e.code.toHealthConnectorErrorCode(),
+      throw HealthConnectorException.fromCode(
+        e.code.toErrorCode(),
         'Failed to get granted permissions from platform: '
         '${e.message ?? 'Unknown error'}',
         cause: e,
@@ -346,8 +346,8 @@ final class HealthConnectorHCClient implements HealthConnectorPlatformClient {
         stackTrace: st,
       );
 
-      throw HealthConnectorException(
-        e.code.toHealthConnectorErrorCode(),
+      throw HealthConnectorException.fromCode(
+        e.code.toErrorCode(),
         'Failed to get permission status: ${e.message ?? 'Unknown error'}',
         cause: e,
         stackTrace: st,
@@ -389,8 +389,8 @@ final class HealthConnectorHCClient implements HealthConnectorPlatformClient {
         stackTrace: st,
       );
 
-      throw HealthConnectorException(
-        e.code.toHealthConnectorErrorCode(),
+      throw HealthConnectorException.fromCode(
+        e.code.toErrorCode(),
         'Failed to revoke all permissions from platform: '
         '${e.message ?? 'Unknown error'}',
         cause: e,
@@ -452,8 +452,8 @@ final class HealthConnectorHCClient implements HealthConnectorPlatformClient {
         stackTrace: st,
       );
 
-      throw HealthConnectorException(
-        e.code.toHealthConnectorErrorCode(),
+      throw HealthConnectorException.fromCode(
+        e.code.toErrorCode(),
         'Failed to get feature status for $feature: '
         '${e.message ?? 'Unknown error'}',
         cause: e,
@@ -507,8 +507,8 @@ final class HealthConnectorHCClient implements HealthConnectorPlatformClient {
         stackTrace: st,
       );
 
-      throw HealthConnectorException(
-        e.code.toHealthConnectorErrorCode(),
+      throw HealthConnectorException.fromCode(
+        e.code.toErrorCode(),
         'Failed to process $request: ${e.message ?? 'Unknown error'}',
         cause: e,
         stackTrace: st,
@@ -553,8 +553,8 @@ final class HealthConnectorHCClient implements HealthConnectorPlatformClient {
         stackTrace: st,
       );
 
-      throw HealthConnectorException(
-        e.code.toHealthConnectorErrorCode(),
+      throw HealthConnectorException.fromCode(
+        e.code.toErrorCode(),
         'Failed to process $request: ${e.message ?? 'Unknown error'}',
         cause: e,
         stackTrace: st,
@@ -595,8 +595,8 @@ final class HealthConnectorHCClient implements HealthConnectorPlatformClient {
         stackTrace: st,
       );
 
-      throw HealthConnectorException(
-        e.code.toHealthConnectorErrorCode(),
+      throw HealthConnectorException.fromCode(
+        e.code.toErrorCode(),
         'Failed to write $record: ${e.message ?? 'Unknown error'}',
         cause: e,
         stackTrace: st,
@@ -651,8 +651,8 @@ final class HealthConnectorHCClient implements HealthConnectorPlatformClient {
         stackTrace: st,
       );
 
-      throw HealthConnectorException(
-        e.code.toHealthConnectorErrorCode(),
+      throw HealthConnectorException.fromCode(
+        e.code.toErrorCode(),
         'Failed to write $records: ${e.message ?? 'Unknown error'}',
         cause: e,
         stackTrace: st,
@@ -689,8 +689,8 @@ final class HealthConnectorHCClient implements HealthConnectorPlatformClient {
         stackTrace: st,
       );
 
-      throw HealthConnectorException(
-        e.code.toHealthConnectorErrorCode(),
+      throw HealthConnectorException.fromCode(
+        e.code.toErrorCode(),
         'Failed to update $record: ${e.message ?? 'Unknown error'}',
         cause: e,
         stackTrace: st,
@@ -725,8 +725,8 @@ final class HealthConnectorHCClient implements HealthConnectorPlatformClient {
         stackTrace: st,
       );
 
-      throw HealthConnectorException(
-        e.code.toHealthConnectorErrorCode(),
+      throw HealthConnectorException.fromCode(
+        e.code.toErrorCode(),
         'Failed to update $records: ${e.message ?? 'Unknown error'}',
         cause: e,
         stackTrace: st,
@@ -771,8 +771,8 @@ final class HealthConnectorHCClient implements HealthConnectorPlatformClient {
         stackTrace: st,
       );
 
-      throw HealthConnectorException(
-        e.code.toHealthConnectorErrorCode(),
+      throw HealthConnectorException.fromCode(
+        e.code.toErrorCode(),
         'Failed to process $request: ${e.message ?? 'Unknown error'}',
         cause: e,
         stackTrace: st,
@@ -810,8 +810,8 @@ final class HealthConnectorHCClient implements HealthConnectorPlatformClient {
         stackTrace: st,
       );
 
-      throw HealthConnectorException(
-        e.code.toHealthConnectorErrorCode(),
+      throw HealthConnectorException.fromCode(
+        e.code.toErrorCode(),
         'Failed to delete records by $request: ${e.message ?? 'Unknown error'}',
         cause: e,
         stackTrace: st,

--- a/packages/health_connector_hc_android/lib/src/mappers/health_connector_error_code_mappers.dart
+++ b/packages/health_connector_hc_android/lib/src/mappers/health_connector_error_code_mappers.dart
@@ -38,8 +38,8 @@ extension HealthConnectorErrorCodeDtoToDomain on HealthConnectorErrorCodeDto {
 /// Converts [PlatformException.code] string to [HealthConnectorErrorCode].
 @sinceV1_0_0
 @internal
-extension StringToHealthConnectorErrorCode on String {
-  HealthConnectorErrorCode toHealthConnectorErrorCode() {
+extension StringToErrorCode on String {
+  HealthConnectorErrorCode toErrorCode() {
     try {
       return HealthConnectorErrorCode.values.firstWhere(
         (errorCode) => this == errorCode.code,

--- a/packages/health_connector_hk_ios/lib/src/health_connector_hk_client.dart
+++ b/packages/health_connector_hk_ios/lib/src/health_connector_hk_client.dart
@@ -20,8 +20,8 @@ import 'package:health_connector_core/health_connector_core.dart'
         PermissionListExtension,
         sinceV1_0_0,
         internalUse,
-        HealthConnectorErrorCode,
-        DeleteRecordsRequest;
+        DeleteRecordsRequest,
+        UnsupportedOperationException;
 import 'package:health_connector_hk_ios/src/mappers/config_mappers.dart';
 import 'package:health_connector_hk_ios/src/mappers/health_connector_error_code_mappers.dart';
 import 'package:health_connector_hk_ios/src/mappers/health_record_mappers/health_record_id_mappers.dart';
@@ -117,8 +117,8 @@ final class HealthConnectorHKClient implements HealthConnectorPlatformClient {
         stackTrace: st,
       );
 
-      throw HealthConnectorException(
-        e.code.toHealthConnectorErrorCode(),
+      throw HealthConnectorException.fromCode(
+        e.code.toErrorCode(),
         'Failed to get health platform status: '
         '${e.message ?? 'Unknown error'}',
         cause: e,
@@ -197,8 +197,8 @@ final class HealthConnectorHKClient implements HealthConnectorPlatformClient {
           stackTrace: st,
         );
 
-        throw HealthConnectorException(
-          e.code.toHealthConnectorErrorCode(),
+        throw HealthConnectorException.fromCode(
+          e.code.toErrorCode(),
           'Failed to request permissions: ${e.message ?? 'Unknown error'}',
           cause: e,
           stackTrace: st,
@@ -289,8 +289,8 @@ final class HealthConnectorHKClient implements HealthConnectorPlatformClient {
         stackTrace: st,
       );
 
-      throw HealthConnectorException(
-        e.code.toHealthConnectorErrorCode(),
+      throw HealthConnectorException.fromCode(
+        e.code.toErrorCode(),
         'Failed to get permission status: ${e.message ?? 'Unknown error'}',
         cause: e,
         stackTrace: st,
@@ -343,8 +343,8 @@ final class HealthConnectorHKClient implements HealthConnectorPlatformClient {
         stackTrace: st,
       );
 
-      throw HealthConnectorException(
-        e.code.toHealthConnectorErrorCode(),
+      throw HealthConnectorException.fromCode(
+        e.code.toErrorCode(),
         'Failed to process $request: ${e.message ?? 'Unknown error'}',
         cause: e,
         stackTrace: st,
@@ -389,8 +389,8 @@ final class HealthConnectorHKClient implements HealthConnectorPlatformClient {
         stackTrace: st,
       );
 
-      throw HealthConnectorException(
-        e.code.toHealthConnectorErrorCode(),
+      throw HealthConnectorException.fromCode(
+        e.code.toErrorCode(),
         'Failed to process $request: ${e.message ?? 'Unknown error'}',
         cause: e,
         stackTrace: st,
@@ -431,8 +431,8 @@ final class HealthConnectorHKClient implements HealthConnectorPlatformClient {
         stackTrace: st,
       );
 
-      throw HealthConnectorException(
-        e.code.toHealthConnectorErrorCode(),
+      throw HealthConnectorException.fromCode(
+        e.code.toErrorCode(),
         'Failed to write $record: ${e.message ?? 'Unknown error'}',
         cause: e,
         stackTrace: st,
@@ -487,8 +487,8 @@ final class HealthConnectorHKClient implements HealthConnectorPlatformClient {
         stackTrace: st,
       );
 
-      throw HealthConnectorException(
-        e.code.toHealthConnectorErrorCode(),
+      throw HealthConnectorException.fromCode(
+        e.code.toErrorCode(),
         'Failed to write $records: ${e.message ?? 'Unknown error'}',
         cause: e,
         stackTrace: st,
@@ -498,16 +498,14 @@ final class HealthConnectorHKClient implements HealthConnectorPlatformClient {
 
   @override
   Future<HealthRecordId> updateRecord<R extends HealthRecord>(R record) async {
-    throw const HealthConnectorException(
-      HealthConnectorErrorCode.unsupportedOperation,
+    throw const UnsupportedOperationException(
       'updateRecord API is not supported on iOS HealthKit SDK',
     );
   }
 
   @override
   Future<void> updateRecords<R extends HealthRecord>(List<R> records) {
-    throw const HealthConnectorException(
-      HealthConnectorErrorCode.unsupportedOperation,
+    throw const UnsupportedOperationException(
       'updateRecords API is not supported on iOS HealthKit SDK',
     );
   }
@@ -549,8 +547,8 @@ final class HealthConnectorHKClient implements HealthConnectorPlatformClient {
         stackTrace: st,
       );
 
-      throw HealthConnectorException(
-        e.code.toHealthConnectorErrorCode(),
+      throw HealthConnectorException.fromCode(
+        e.code.toErrorCode(),
         'Failed to process $request: ${e.message ?? 'Unknown error'}',
         cause: e,
         stackTrace: st,
@@ -588,8 +586,8 @@ final class HealthConnectorHKClient implements HealthConnectorPlatformClient {
         stackTrace: st,
       );
 
-      throw HealthConnectorException(
-        e.code.toHealthConnectorErrorCode(),
+      throw HealthConnectorException.fromCode(
+        e.code.toErrorCode(),
         'Failed to delete records by $request: ${e.message ?? 'Unknown error'}',
         cause: e,
         stackTrace: st,

--- a/packages/health_connector_hk_ios/lib/src/mappers/health_connector_error_code_mappers.dart
+++ b/packages/health_connector_hk_ios/lib/src/mappers/health_connector_error_code_mappers.dart
@@ -6,8 +6,8 @@ import 'package:meta/meta.dart' show internal;
 /// Converts [PlatformException.code] string to [HealthConnectorErrorCode].
 @sinceV1_0_0
 @internal
-extension StringToHealthConnectorErrorCode on String {
-  HealthConnectorErrorCode toHealthConnectorErrorCode() {
+extension StringToErrorCode on String {
+  HealthConnectorErrorCode toErrorCode() {
     try {
       return HealthConnectorErrorCode.values.firstWhere(
         (errorCode) => this == errorCode.code,


### PR DESCRIPTION
### **User description**
Refactors `HealthConnectorException` into a sealed class hierarchy to improve type safety, enforce exhaustiveness checks, and clarify error handling. Each `HealthConnectorErrorCode` now corresponds to a specific final exception subclass.

BREAKING CHANGE: `HealthConnectorException` is now a sealed class. All direct instantiations of `HealthConnectorException` must be replaced with specific subclasses (e.g., `throw InvalidArgumentException(...)`) or the `HealthConnectorException.fromCode(...)` factory.


___

### **PR Type**
Enhancement


___

### **Description**
- Convert `HealthConnectorException` to sealed class hierarchy
  - Base class now sealed with 9 specific exception subclasses
  - Each subclass corresponds to a specific `HealthConnectorErrorCode`

- Add `HealthConnectorException.fromCode()` factory method
  - Enables dynamic exception creation from error codes

- Replace direct exception instantiations with specific subclasses
  - Updated all throw statements across codebase

- Add convenience factory methods to `HealthDataPermission`
  - `read()` and `write()` factory constructors

- Rename error code mapper extension methods for clarity
  - `toHealthConnectorErrorCode()` → `toErrorCode()`


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["HealthConnectorException<br/>sealed class"] --> B["HealthProviderNotInstalledOrUpdateRequiredException"]
  A --> C["HealthProviderUnavailableException"]
  A --> D["UnsupportedOperationException"]
  A --> E["InvalidConfigurationException"]
  A --> F["InvalidArgumentException"]
  A --> G["NotAuthorizedException"]
  A --> H["RemoteErrorException"]
  A --> I["UserCancelledException"]
  A --> J["UnknownException"]
  K["HealthConnectorErrorCode"] -.->|maps to| A
  L["fromCode factory"] -->|creates| A
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>health_connector_exception.dart</strong><dd><code>Create sealed exception hierarchy with subclasses</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/health_connector_core/lib/src/models/exceptions/health_connector_exception.dart

<ul><li>Convert <code>HealthConnectorException</code> from final to sealed class<br> <li> Add comprehensive documentation with usage examples<br> <li> Implement <code>fromCode()</code> factory method for dynamic exception creation<br> <li> Add 9 final exception subclasses (one per error code)<br> <li> Each subclass includes detailed documentation about causes and <br>recommended actions</ul>


</details>


  </td>
  <td><a href="https://github.com/fam-tung-lam/health_connector/pull/45/files#diff-7b13108703df1e7f85e2393f68e6312b105f2daf09e560c98683811fcbe2d9e0">+330/-3</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>health_connector.dart</strong><dd><code>Use specific exception subclasses</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/health_connector/lib/src/health_connector.dart

<ul><li>Import new exception subclasses <code>HealthProviderUnavailableException</code> and <br><code>HealthProviderNotInstalledOrUpdateRequiredException</code><br> <li> Replace generic <code>HealthConnectorException</code> instantiations with specific <br>subclasses<br> <li> Update two throw statements in platform status handling</ul>


</details>


  </td>
  <td><a href="https://github.com/fam-tung-lam/health_connector/pull/45/files#diff-a7c3b4728d2f5d7620a681bac605cc57250cad25ec594cc421f1eed837b56cb6">+4/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>health_connector_impl.dart</strong><dd><code>Replace generic exceptions with specific types</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/health_connector/lib/src/health_connector_impl.dart

<ul><li>Import new exception subclasses <code>UnsupportedOperationException</code> and <br><code>InvalidArgumentException</code><br> <li> Remove unused <code>HealthConnectorErrorCode</code> import<br> <li> Replace 6 generic exception instantiations with specific subclasses<br> <li> Update throw statements in validation and operation checks</ul>


</details>


  </td>
  <td><a href="https://github.com/fam-tung-lam/health_connector/pull/45/files#diff-63342785ee44ba211c4e1c8af97755095c4080e80f1f2676c234ab8284ca9e3e">+9/-14</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>health_data_permission.dart</strong><dd><code>Add factory constructors for permissions</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/health_connector_core/lib/src/models/permissions/health_data_permission.dart

<ul><li>Add <code>read()</code> factory constructor for read-only permissions<br> <li> Add <code>write()</code> factory constructor for write-only permissions<br> <li> Simplify permission creation with convenience methods</ul>


</details>


  </td>
  <td><a href="https://github.com/fam-tung-lam/health_connector/pull/45/files#diff-081733e75379f55fb0e411d88cb2b500ca4e157dc73e595a3105d09edd761456">+18/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>health_connector_hc_client.dart</strong><dd><code>Use fromCode factory for exception creation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/health_connector_hc_android/lib/src/health_connector_hc_client.dart

<ul><li>Replace 12 <code>HealthConnectorException</code> instantiations with <br><code>HealthConnectorException.fromCode()</code><br> <li> Update error code mapper method calls from <br><code>toHealthConnectorErrorCode()</code> to <code>toErrorCode()</code><br> <li> Maintain error handling consistency across all platform operations</ul>


</details>


  </td>
  <td><a href="https://github.com/fam-tung-lam/health_connector/pull/45/files#diff-a120bdcd1518727307fa1df040f2c1b2d9e37fd032c21f81c5670f5a76d26ed6">+28/-28</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>health_connector_error_code_mappers.dart</strong><dd><code>Rename error code mapper extension</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/health_connector_hc_android/lib/src/mappers/health_connector_error_code_mappers.dart

<ul><li>Rename extension <code>StringToHealthConnectorErrorCode</code> to <code>StringToErrorCode</code><br> <li> Rename method <code>toHealthConnectorErrorCode()</code> to <code>toErrorCode()</code><br> <li> Improve naming clarity and consistency</ul>


</details>


  </td>
  <td><a href="https://github.com/fam-tung-lam/health_connector/pull/45/files#diff-997791b3472ef580c220be82adecfffec90a06ee782142a19408be50148fd8f7">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>health_connector_hk_client.dart</strong><dd><code>Use specific exceptions and fromCode factory</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/health_connector_hk_ios/lib/src/health_connector_hk_client.dart

<ul><li>Import <code>UnsupportedOperationException</code> subclass<br> <li> Remove unused <code>HealthConnectorErrorCode</code> import<br> <li> Replace 8 <code>HealthConnectorException</code> instantiations with <br><code>HealthConnectorException.fromCode()</code><br> <li> Replace 2 unsupported operation exceptions with <br><code>UnsupportedOperationException</code> subclass<br> <li> Update error code mapper method calls</ul>


</details>


  </td>
  <td><a href="https://github.com/fam-tung-lam/health_connector/pull/45/files#diff-02bc71965d968ac39ac3fe030036e2ade416f2e655d8db6451b93a93fa180137">+22/-24</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>health_connector_error_code_mappers.dart</strong><dd><code>Rename error code mapper extension</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/health_connector_hk_ios/lib/src/mappers/health_connector_error_code_mappers.dart

<ul><li>Rename extension <code>StringToHealthConnectorErrorCode</code> to <code>StringToErrorCode</code><br> <li> Rename method <code>toHealthConnectorErrorCode()</code> to <code>toErrorCode()</code><br> <li> Align with Android mapper naming conventions</ul>


</details>


  </td>
  <td><a href="https://github.com/fam-tung-lam/health_connector/pull/45/files#diff-00ad0cf411ee8749de76fd86806ce1026b19d107ee0068162ac818c420cf2d4f">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

