### PR TITLE
fix(health_connector_core,health_connector_hk_ios,health_connector_hc_android): Ensure health record timestamps are stored as UTC

### DIFF
--- a/packages/health_connector_core/lib/src/models/health_records/heart_rate_measurement.dart
+++ b/packages/health_connector_core/lib/src/models/health_records/heart_rate_measurement.dart
@@ -3,12 +3,8 @@ import 'package:meta/meta.dart';
 
 /// Represents a single heart rate measurement at a specific point in time.
 ///
-/// This is a platform-agnostic value class used as a building block for both
-/// heart rate series records (Android Health Connect) and heart rate
-/// measurement records (iOS HealthKit).
-///
-/// Note: This class does not have an ID or metadata. Those are properties of
-/// the record that contains the measurement.
+/// **Note**: This class does not have an ID or metadata. Those are
+/// properties of the record that contains the measurement.
 ///
 /// {@category Health Records}
 @immutable
@@ -19,7 +15,10 @@ final class HeartRateMeasurement {
     required this.beatsPerMinute,
   });
 
-  /// The timestamp when this heart rate measurement was taken.
+  /// The timestamp when this heart rate measurement was taken, stored as a
+  /// UTC instant.
+  ///
+  /// Timezone offset information is provided by the parent record.
   final DateTime time;
 
   /// The heart rate value in beats per minute (BPM).

--- a/packages/health_connector_core/lib/src/models/health_records/instant_health_record.dart
+++ b/packages/health_connector_core/lib/src/models/health_records/instant_health_record.dart
@@ -1,18 +1,7 @@
 part of 'health_record.dart';
 
-/// A health record representing a measurement at a single point in time.
-///
-/// ## Time Representation
-///
-/// ### Android Health Connect
-/// - Single timestamp stored as "time"
-/// - Timezone offset supported and preserved
-/// - Instant records map to `InstantRecord` subclasses
-///
-/// ### iOS HealthKit
-/// - Maps to HKQuantitySample or HKCategorySample
-/// - Start and end dates are the same (point-in-time)
-/// ```
+/// Base health record class representing a measurement at a single point
+/// in time.
 ///
 /// {@category Health Records}
 @sinceV1_0_0
@@ -21,16 +10,7 @@ sealed class InstantHealthRecord extends HealthRecord {
   /// Creates an instant health record at the specified [time].
   ///
   /// The [zoneOffsetSeconds] is optional and represents the timezone offset
-  /// in seconds from UTC at the time of measurement.
-  ///
-  /// Example:
-  /// ```dart
-  /// final record = WeightRecord(
-  ///   time: DateTime.now(),
-  ///   weight: Mass.kilograms(72.0),
-  ///   metadata: Metadata.manualEntry(),
-  /// );
-  /// ```
+  /// in seconds from UTC at the [time] of measurement.
   const InstantHealthRecord({
     required this.time,
     required super.metadata,
@@ -38,21 +18,18 @@ sealed class InstantHealthRecord extends HealthRecord {
     this.zoneOffsetSeconds,
   });
 
-  /// The time when this measurement was taken.
+  /// The time when this measurement was taken, stored as a UTC instant.
   ///
-  /// This represents the exact moment the health data was recorded or measured.
+  /// The timestamp is always stored in UTC. To interpret this value in the
+  /// user's local (civil) time, use [zoneOffsetSeconds] if available.
   final DateTime time;
 
   /// The timezone offset in seconds at the time of measurement.
   ///
-  /// This represents the offset from UTC at [time]:
+  /// This offset allows interpreting [time] in the user's local (civil) time
+  /// zone at the moment of measurement:
   /// - Positive for timezones ahead of UTC (e.g., +3600 for UTC+1)
   /// - Negative for timezones behind UTC (e.g., -28800 for UTC-8)
   /// - Null if timezone information is not available
-  ///
-  /// **Platform differences:**
-  /// - **Android Health Connect:** Timezone offset fully supported
-  /// - **iOS HealthKit:** Timezone information less explicit, typically uses
-  ///   device timezone
   final int? zoneOffsetSeconds;
 }

--- a/packages/health_connector_core/lib/src/models/health_records/interval_health_record.dart
+++ b/packages/health_connector_core/lib/src/models/health_records/interval_health_record.dart
@@ -1,14 +1,6 @@
 part of 'health_record.dart';
 
-/// A health record that spans a duration of time.
-///
-/// ### iOS HealthKit Note
-///
-/// On iOS/HealthKit, this value will always be the same as
-/// [endZoneOffsetSeconds]
-/// because HealthKit only provides one metadata key (`HKMetadataKeyTimeZone`)
-/// to store timezone info. This means that even if an interval spans a
-/// timezone change, both values will reflect the same timezone offset.
+/// Base health record class that spans a duration of time.
 ///
 /// {@category Health Records}
 @sinceV1_0_0
@@ -24,24 +16,27 @@ sealed class IntervalHealthRecord extends HealthRecord {
     this.endZoneOffsetSeconds,
   });
 
-  /// The start time of the interval.
+  /// The start time of the interval, stored as a UTC instant.
   ///
-  /// This is when the measurement or activity began.
+  /// This is when the measurement or activity began. To interpret this value
+  /// in the user's local (civil) time, use [startZoneOffsetSeconds] if
+  /// available.
   ///
-  /// For activities like steps or distance, this is when the tracking period
-  /// started. For exercise sessions, this is when the exercise session began.
+  /// Must be before [endTime].
   final DateTime startTime;
 
-  /// The end time of the interval.
+  /// The end time of the interval, stored as a UTC instant.
   ///
-  /// This is when the measurement or activity ended.
+  /// This is when the measurement or activity ended. To interpret this value
+  /// in the user's local (civil) time, use [endZoneOffsetSeconds] if available.
   ///
   /// Must be after [startTime].
   final DateTime endTime;
 
   /// The timezone offset in seconds at the start of the interval.
   ///
-  /// This represents the offset from UTC at [startTime]:
+  /// This offset allows interpreting [startTime] in the user's local (civil)
+  /// time zone at the moment of measurement:
   /// - Positive for timezones ahead of UTC (e.g., +3600 for UTC+1)
   /// - Negative for timezones behind UTC (e.g., -28800 for UTC-8)
   /// - Null if timezone information is not available
@@ -49,13 +44,14 @@ sealed class IntervalHealthRecord extends HealthRecord {
 
   /// The timezone offset in seconds at the end of the interval.
   ///
-  /// This represents the offset from UTC at [endTime]:
+  /// This offset allows interpreting [endTime] in the user's local (civil)
+  /// time zone at the moment of measurement:
   /// - Positive for timezones ahead of UTC (e.g., +3600 for UTC+1)
   /// - Negative for timezones behind UTC (e.g., -28800 for UTC-8)
   /// - Null if timezone information is not available
   ///
-  /// This can differ from [startZoneOffsetSeconds] if the interval spans a
-  /// timezone change, such as:
+  /// **Note**: [endZoneOffsetSeconds] can differ from [startZoneOffsetSeconds]
+  /// if the interval spans a timezone change, such as:
   /// - Daylight saving time transition
   /// - Travel across timezones
   final int? endZoneOffsetSeconds;

--- a/packages/health_connector_core/lib/src/models/health_records/series_health_record.dart
+++ b/packages/health_connector_core/lib/src/models/health_records/series_health_record.dart
@@ -1,19 +1,7 @@
 part of 'health_record.dart';
 
-/// A health record containing multiple data samples within a time interval.
-///
-/// ## Platform Behavior
-///
-/// ### Android Health Connect
-/// - Native support for series records
-/// - Maps to `SeriesRecord` subclasses
-/// - Samples stored as part of the record
-/// - Efficient bulk storage and retrieval
-///
-/// ### iOS HealthKit
-/// - Series represented via `HKQuantitySeries` or multiple `HKQuantitySample`
-/// - Less direct support compared to Android
-/// - May require aggregation of individual samples
+/// Base health record class containing multiple data samples within a
+/// time interval.
 ///
 /// {@category Health Records}
 @sinceV1_0_0

--- a/packages/health_connector_core/lib/src/models/health_records/sleep_records/sleep_session_record.dart
+++ b/packages/health_connector_core/lib/src/models/health_records/sleep_records/sleep_session_record.dart
@@ -157,10 +157,16 @@ final class SleepStage {
     required this.stageType,
   });
 
-  /// The start time of this sleep stage.
+  /// The start time of this sleep stage, stored as a UTC instant.
+  ///
+  /// To interpret this value in the user's local (civil) time, use the zone
+  /// offset information from the parent [SleepSessionRecord].
   final DateTime startTime;
 
-  /// The end time of this sleep stage.
+  /// The end time of this sleep stage, stored as a UTC instant.
+  ///
+  /// To interpret this value in the user's local (civil) time, use the zone
+  /// offset information from the parent [SleepSessionRecord].
   final DateTime endTime;
 
   /// The type of sleep stage.

--- a/packages/health_connector_core/lib/src/models/health_records/speed_records/speed_series_record.dart
+++ b/packages/health_connector_core/lib/src/models/health_records/speed_records/speed_series_record.dart
@@ -131,7 +131,10 @@ final class SpeedMeasurement {
     required this.speed,
   });
 
-  /// The time at which the speed was measured.
+  /// The time at which the speed was measured, stored as a UTC instant.
+  ///
+  /// To interpret this value in the user's local (civil) time, use the zone
+  /// offset information from the parent [SpeedSeriesRecord].
   final DateTime time;
 
   /// The speed measurement value.

--- a/packages/health_connector_hc_android/lib/src/mappers/health_record_mappers/active_calories_burned_record_mappers.dart
+++ b/packages/health_connector_hc_android/lib/src/mappers/health_record_mappers/active_calories_burned_record_mappers.dart
@@ -32,8 +32,8 @@ extension ActiveCaloriesBurnedRecordDtoToDomain
   ActiveCaloriesBurnedRecord toDomain() {
     return ActiveCaloriesBurnedRecord(
       id: id?.toDomain() ?? HealthRecordId.none,
-      startTime: DateTime.fromMillisecondsSinceEpoch(startTime),
-      endTime: DateTime.fromMillisecondsSinceEpoch(endTime),
+      startTime: DateTime.fromMillisecondsSinceEpoch(startTime, isUtc: true),
+      endTime: DateTime.fromMillisecondsSinceEpoch(endTime, isUtc: true),
       startZoneOffsetSeconds: startZoneOffsetSeconds,
       endZoneOffsetSeconds: endZoneOffsetSeconds,
       metadata: metadata.toDomain(),

--- a/packages/health_connector_hc_android/lib/src/mappers/health_record_mappers/blood_glucose_record_mappers.dart
+++ b/packages/health_connector_hc_android/lib/src/mappers/health_record_mappers/blood_glucose_record_mappers.dart
@@ -42,7 +42,7 @@ extension BloodGlucoseRecordDtoToDomain on BloodGlucoseRecordDto {
   BloodGlucoseRecord toDomain() {
     return BloodGlucoseRecord(
       id: id?.toDomain() ?? HealthRecordId.none,
-      time: DateTime.fromMillisecondsSinceEpoch(time),
+      time: DateTime.fromMillisecondsSinceEpoch(time, isUtc: true),
       zoneOffsetSeconds: zoneOffsetSeconds,
       metadata: metadata.toDomain(),
       bloodGlucose: bloodGlucose.toDomain(),

--- a/packages/health_connector_hc_android/lib/src/mappers/health_record_mappers/blood_pressure_record_mappers.dart
+++ b/packages/health_connector_hc_android/lib/src/mappers/health_record_mappers/blood_pressure_record_mappers.dart
@@ -37,7 +37,7 @@ extension BloodPressureRecordDtoToDomain on BloodPressureRecordDto {
   BloodPressureRecord toDomain() {
     return BloodPressureRecord(
       id: id?.toDomain() ?? HealthRecordId.none,
-      time: DateTime.fromMillisecondsSinceEpoch(time),
+      time: DateTime.fromMillisecondsSinceEpoch(time, isUtc: true),
       zoneOffsetSeconds: zoneOffsetSeconds,
       metadata: metadata.toDomain(),
       systolic: systolic.toDomain(),

--- a/packages/health_connector_hc_android/lib/src/mappers/health_record_mappers/body_fat_percentage_record_mappers.dart
+++ b/packages/health_connector_hc_android/lib/src/mappers/health_record_mappers/body_fat_percentage_record_mappers.dart
@@ -29,7 +29,7 @@ extension BodyFatPercentageRecordDtoToDomain on BodyFatPercentageRecordDto {
   BodyFatPercentageRecord toDomain() {
     return BodyFatPercentageRecord(
       id: id?.toDomain() ?? HealthRecordId.none,
-      time: DateTime.fromMillisecondsSinceEpoch(time),
+      time: DateTime.fromMillisecondsSinceEpoch(time, isUtc: true),
       zoneOffsetSeconds: zoneOffsetSeconds,
       metadata: metadata.toDomain(),
       percentage: percentage.toDomain(),

--- a/packages/health_connector_hc_android/lib/src/mappers/health_record_mappers/body_temperature_record_mappers.dart
+++ b/packages/health_connector_hc_android/lib/src/mappers/health_record_mappers/body_temperature_record_mappers.dart
@@ -29,7 +29,7 @@ extension BodyTemperatureRecordDtoToDomain on BodyTemperatureRecordDto {
   BodyTemperatureRecord toDomain() {
     return BodyTemperatureRecord(
       id: id?.toDomain() ?? HealthRecordId.none,
-      time: DateTime.fromMillisecondsSinceEpoch(time),
+      time: DateTime.fromMillisecondsSinceEpoch(time, isUtc: true),
       zoneOffsetSeconds: zoneOffsetSeconds,
       metadata: metadata.toDomain(),
       temperature: temperature.toDomain(),

--- a/packages/health_connector_hc_android/lib/src/mappers/health_record_mappers/distance_record_mappers.dart
+++ b/packages/health_connector_hc_android/lib/src/mappers/health_record_mappers/distance_record_mappers.dart
@@ -31,8 +31,8 @@ extension DistanceRecordDtoToDomain on DistanceRecordDto {
   DistanceRecord toDomain() {
     return DistanceRecord(
       id: id?.toDomain() ?? HealthRecordId.none,
-      startTime: DateTime.fromMillisecondsSinceEpoch(startTime),
-      endTime: DateTime.fromMillisecondsSinceEpoch(endTime),
+      startTime: DateTime.fromMillisecondsSinceEpoch(startTime, isUtc: true),
+      endTime: DateTime.fromMillisecondsSinceEpoch(endTime, isUtc: true),
       startZoneOffsetSeconds: startZoneOffsetSeconds,
       endZoneOffsetSeconds: endZoneOffsetSeconds,
       metadata: metadata.toDomain(),

--- a/packages/health_connector_hc_android/lib/src/mappers/health_record_mappers/exercise_session_record_mappers.dart
+++ b/packages/health_connector_hc_android/lib/src/mappers/health_record_mappers/exercise_session_record_mappers.dart
@@ -31,11 +31,11 @@ extension ExerciseSessionRecordFromDto on ExerciseSessionRecordDto {
       startTime: DateTime.fromMillisecondsSinceEpoch(
         startTime,
         isUtc: true,
-      ).toLocal(),
+      ),
       endTime: DateTime.fromMillisecondsSinceEpoch(
         endTime,
         isUtc: true,
-      ).toLocal(),
+      ),
       exerciseType: exerciseType.fromDto(),
       title: title,
       notes: notes,

--- a/packages/health_connector_hc_android/lib/src/mappers/health_record_mappers/floors_climbed_record_mappers.dart
+++ b/packages/health_connector_hc_android/lib/src/mappers/health_record_mappers/floors_climbed_record_mappers.dart
@@ -31,8 +31,8 @@ extension FloorsClimbedRecordDtoToDomain on FloorsClimbedRecordDto {
   FloorsClimbedRecord toDomain() {
     return FloorsClimbedRecord(
       id: id?.toDomain() ?? HealthRecordId.none,
-      startTime: DateTime.fromMillisecondsSinceEpoch(startTime),
-      endTime: DateTime.fromMillisecondsSinceEpoch(endTime),
+      startTime: DateTime.fromMillisecondsSinceEpoch(startTime, isUtc: true),
+      endTime: DateTime.fromMillisecondsSinceEpoch(endTime, isUtc: true),
       startZoneOffsetSeconds: startZoneOffsetSeconds,
       endZoneOffsetSeconds: endZoneOffsetSeconds,
       metadata: metadata.toDomain(),

--- a/packages/health_connector_hc_android/lib/src/mappers/health_record_mappers/heart_rate_measurement_mappers.dart
+++ b/packages/health_connector_hc_android/lib/src/mappers/health_record_mappers/heart_rate_measurement_mappers.dart
@@ -23,7 +23,7 @@ extension HeartRateMeasurementDtoMapper on HeartRateMeasurement {
 extension HeartRateMeasurementDtoToDomain on HeartRateMeasurementDto {
   HeartRateMeasurement toDomain() {
     return HeartRateMeasurement(
-      time: DateTime.fromMillisecondsSinceEpoch(time),
+      time: DateTime.fromMillisecondsSinceEpoch(time, isUtc: true),
       beatsPerMinute: beatsPerMinute.toDomain(),
     );
   }

--- a/packages/health_connector_hc_android/lib/src/mappers/health_record_mappers/heart_rate_series_record_mappers.dart
+++ b/packages/health_connector_hc_android/lib/src/mappers/health_record_mappers/heart_rate_series_record_mappers.dart
@@ -31,8 +31,8 @@ extension HeartRateSeriesRecordDtoToDomain on HeartRateSeriesRecordDto {
   HeartRateSeriesRecord toDomain() {
     return HeartRateSeriesRecord(
       id: id?.toDomain() ?? HealthRecordId.none,
-      startTime: DateTime.fromMillisecondsSinceEpoch(startTime),
-      endTime: DateTime.fromMillisecondsSinceEpoch(endTime),
+      startTime: DateTime.fromMillisecondsSinceEpoch(startTime, isUtc: true),
+      endTime: DateTime.fromMillisecondsSinceEpoch(endTime, isUtc: true),
       startZoneOffsetSeconds: startZoneOffsetSeconds,
       endZoneOffsetSeconds: endZoneOffsetSeconds,
       metadata: metadata.toDomain(),

--- a/packages/health_connector_hc_android/lib/src/mappers/health_record_mappers/height_record_mappers.dart
+++ b/packages/health_connector_hc_android/lib/src/mappers/health_record_mappers/height_record_mappers.dart
@@ -29,7 +29,7 @@ extension HeightRecordDtoToDomain on HeightRecordDto {
   HeightRecord toDomain() {
     return HeightRecord(
       id: id?.toDomain() ?? HealthRecordId.none,
-      time: DateTime.fromMillisecondsSinceEpoch(time),
+      time: DateTime.fromMillisecondsSinceEpoch(time, isUtc: true),
       zoneOffsetSeconds: zoneOffsetSeconds,
       metadata: metadata.toDomain(),
       height: height.toDomain(),

--- a/packages/health_connector_hc_android/lib/src/mappers/health_record_mappers/hydration_record_mappers.dart
+++ b/packages/health_connector_hc_android/lib/src/mappers/health_record_mappers/hydration_record_mappers.dart
@@ -31,8 +31,8 @@ extension HydrationRecordDtoToDomain on HydrationRecordDto {
   HydrationRecord toDomain() {
     return HydrationRecord(
       id: id?.toDomain() ?? HealthRecordId.none,
-      startTime: DateTime.fromMillisecondsSinceEpoch(startTime),
-      endTime: DateTime.fromMillisecondsSinceEpoch(endTime),
+      startTime: DateTime.fromMillisecondsSinceEpoch(startTime, isUtc: true),
+      endTime: DateTime.fromMillisecondsSinceEpoch(endTime, isUtc: true),
       startZoneOffsetSeconds: startZoneOffsetSeconds,
       endZoneOffsetSeconds: endZoneOffsetSeconds,
       metadata: metadata.toDomain(),

--- a/packages/health_connector_hc_android/lib/src/mappers/health_record_mappers/lean_body_mass_record_mappers.dart
+++ b/packages/health_connector_hc_android/lib/src/mappers/health_record_mappers/lean_body_mass_record_mappers.dart
@@ -29,7 +29,7 @@ extension LeanBodyMassRecordDtoToDomain on LeanBodyMassRecordDto {
   LeanBodyMassRecord toDomain() {
     return LeanBodyMassRecord(
       id: id?.toDomain() ?? HealthRecordId.none,
-      time: DateTime.fromMillisecondsSinceEpoch(time),
+      time: DateTime.fromMillisecondsSinceEpoch(time, isUtc: true),
       zoneOffsetSeconds: zoneOffsetSeconds,
       metadata: metadata.toDomain(),
       mass: mass.toDomain(),

--- a/packages/health_connector_hc_android/lib/src/mappers/health_record_mappers/nutrition_record_mappers.dart
+++ b/packages/health_connector_hc_android/lib/src/mappers/health_record_mappers/nutrition_record_mappers.dart
@@ -66,7 +66,6 @@ extension NutritionRecordToDto on NutritionRecord {
 extension NutritionRecordDtoToDomain on NutritionRecordDto {
   HealthRecord toDomain() {
     final id = this.id?.toDomain() ?? HealthRecordId.none;
-    final time = DateTime.fromMillisecondsSinceEpoch(startTime);
     final zoneOffsetSeconds = startZoneOffsetSeconds;
     final metadata = this.metadata.toDomain();
     final foodName = this.foodName;
@@ -76,8 +75,11 @@ extension NutritionRecordDtoToDomain on NutritionRecordDto {
       case HealthDataTypeDto.nutrition:
         return NutritionRecord(
           id: id,
-          startTime: time,
-          endTime: DateTime.fromMillisecondsSinceEpoch(endTime),
+          startTime: DateTime.fromMillisecondsSinceEpoch(
+            startTime,
+            isUtc: true,
+          ),
+          endTime: DateTime.fromMillisecondsSinceEpoch(endTime, isUtc: true),
           startZoneOffsetSeconds: zoneOffsetSeconds,
           endZoneOffsetSeconds: endZoneOffsetSeconds,
           metadata: metadata,

--- a/packages/health_connector_hc_android/lib/src/mappers/health_record_mappers/oxygen_saturation_record_mappers.dart
+++ b/packages/health_connector_hc_android/lib/src/mappers/health_record_mappers/oxygen_saturation_record_mappers.dart
@@ -29,7 +29,7 @@ extension OxygenSaturationRecordDtoToDomain on OxygenSaturationRecordDto {
   OxygenSaturationRecord toDomain() {
     return OxygenSaturationRecord(
       id: HealthRecordId(id ?? HealthRecordId.none.value),
-      time: DateTime.fromMillisecondsSinceEpoch(time, isUtc: true).toLocal(),
+      time: DateTime.fromMillisecondsSinceEpoch(time, isUtc: true),
       zoneOffsetSeconds: zoneOffsetSeconds,
       metadata: metadata.toDomain(),
       percentage: percentage.toDomain(),

--- a/packages/health_connector_hc_android/lib/src/mappers/health_record_mappers/respiratory_rate_record_mappers.dart
+++ b/packages/health_connector_hc_android/lib/src/mappers/health_record_mappers/respiratory_rate_record_mappers.dart
@@ -29,7 +29,7 @@ extension RespiratoryRateRecordDtoToDomain on RespiratoryRateRecordDto {
   RespiratoryRateRecord toDomain() {
     return RespiratoryRateRecord(
       id: HealthRecordId(id ?? HealthRecordId.none.value),
-      time: DateTime.fromMillisecondsSinceEpoch(time, isUtc: true).toLocal(),
+      time: DateTime.fromMillisecondsSinceEpoch(time, isUtc: true),
       zoneOffsetSeconds: zoneOffsetSeconds,
       metadata: metadata.toDomain(),
       breathsPerMin: Number(breathsPerMin.value),

--- a/packages/health_connector_hc_android/lib/src/mappers/health_record_mappers/resting_heart_rate_record_mappers.dart
+++ b/packages/health_connector_hc_android/lib/src/mappers/health_record_mappers/resting_heart_rate_record_mappers.dart
@@ -14,7 +14,7 @@ extension RestingHeartRateRecordDtoToDomain on RestingHeartRateRecordDto {
   RestingHeartRateRecord toDomain() {
     return RestingHeartRateRecord(
       id: id?.toDomain() ?? HealthRecordId.none,
-      time: DateTime.fromMillisecondsSinceEpoch(time),
+      time: DateTime.fromMillisecondsSinceEpoch(time, isUtc: true),
       zoneOffsetSeconds: zoneOffsetSeconds,
       metadata: metadata.toDomain(),
       beatsPerMinute: beatsPerMinute.toDomain(),

--- a/packages/health_connector_hc_android/lib/src/mappers/health_record_mappers/sleep_session_record_mappers.dart
+++ b/packages/health_connector_hc_android/lib/src/mappers/health_record_mappers/sleep_session_record_mappers.dart
@@ -33,8 +33,8 @@ extension SleepSessionRecordDtoToDomain on SleepSessionRecordDto {
   SleepSessionRecord toDomain() {
     return SleepSessionRecord(
       id: id?.toDomain() ?? HealthRecordId.none,
-      startTime: DateTime.fromMillisecondsSinceEpoch(startTime),
-      endTime: DateTime.fromMillisecondsSinceEpoch(endTime),
+      startTime: DateTime.fromMillisecondsSinceEpoch(startTime, isUtc: true),
+      endTime: DateTime.fromMillisecondsSinceEpoch(endTime, isUtc: true),
       startZoneOffsetSeconds: startZoneOffsetSeconds,
       endZoneOffsetSeconds: endZoneOffsetSeconds,
       metadata: metadata.toDomain(),

--- a/packages/health_connector_hc_android/lib/src/mappers/health_record_mappers/sleep_stage_mappers.dart
+++ b/packages/health_connector_hc_android/lib/src/mappers/health_record_mappers/sleep_stage_mappers.dart
@@ -59,8 +59,8 @@ extension SleepStageDomainToDto on SleepStage {
 extension SleepStageDtoToDomain on SleepStageDto {
   SleepStage toDomain() {
     return SleepStage(
-      startTime: DateTime.fromMillisecondsSinceEpoch(startTime),
-      endTime: DateTime.fromMillisecondsSinceEpoch(endTime),
+      startTime: DateTime.fromMillisecondsSinceEpoch(startTime, isUtc: true),
+      endTime: DateTime.fromMillisecondsSinceEpoch(endTime, isUtc: true),
       stageType: stage.toDomain(),
     );
   }

--- a/packages/health_connector_hc_android/lib/src/mappers/health_record_mappers/speed_record_mappers.dart
+++ b/packages/health_connector_hc_android/lib/src/mappers/health_record_mappers/speed_record_mappers.dart
@@ -46,11 +46,11 @@ extension SpeedSeriesRecordDtoToDomain on SpeedSeriesRecordDto {
       startTime: DateTime.fromMillisecondsSinceEpoch(
         startTime,
         isUtc: true,
-      ).toLocal(),
+      ),
       endTime: DateTime.fromMillisecondsSinceEpoch(
         endTime,
         isUtc: true,
-      ).toLocal(),
+      ),
       metadata: metadata.toDomain(),
       samples: samples.map((dto) => dto._toDomain()).toList(),
       startZoneOffsetSeconds: startZoneOffsetSeconds,
@@ -63,7 +63,7 @@ extension SpeedSeriesRecordDtoToDomain on SpeedSeriesRecordDto {
 extension _SpeedSampleDtoToDomain on SpeedMeasurementDto {
   SpeedMeasurement _toDomain() {
     return SpeedMeasurement(
-      time: DateTime.fromMillisecondsSinceEpoch(time, isUtc: true).toLocal(),
+      time: DateTime.fromMillisecondsSinceEpoch(time, isUtc: true),
       speed: speed.toDomain(),
     );
   }

--- a/packages/health_connector_hc_android/lib/src/mappers/health_record_mappers/steps_record_mappers.dart
+++ b/packages/health_connector_hc_android/lib/src/mappers/health_record_mappers/steps_record_mappers.dart
@@ -31,8 +31,8 @@ extension StepsRecordDtoToDomain on StepsRecordDto {
   StepsRecord toDomain() {
     return StepsRecord(
       id: id?.toDomain() ?? HealthRecordId.none,
-      startTime: DateTime.fromMillisecondsSinceEpoch(startTime),
-      endTime: DateTime.fromMillisecondsSinceEpoch(endTime),
+      startTime: DateTime.fromMillisecondsSinceEpoch(startTime, isUtc: true),
+      endTime: DateTime.fromMillisecondsSinceEpoch(endTime, isUtc: true),
       startZoneOffsetSeconds: startZoneOffsetSeconds,
       endZoneOffsetSeconds: endZoneOffsetSeconds,
       metadata: metadata.toDomain(),

--- a/packages/health_connector_hc_android/lib/src/mappers/health_record_mappers/vo2_max_record_mappers.dart
+++ b/packages/health_connector_hc_android/lib/src/mappers/health_record_mappers/vo2_max_record_mappers.dart
@@ -13,7 +13,7 @@ extension Vo2MaxRecordDtoToDomain on Vo2MaxRecordDto {
   Vo2MaxRecord toDomain() {
     return Vo2MaxRecord(
       id: id?.toDomain() ?? HealthRecordId.none,
-      time: DateTime.fromMillisecondsSinceEpoch(time),
+      time: DateTime.fromMillisecondsSinceEpoch(time, isUtc: true),
       zoneOffsetSeconds: zoneOffsetSeconds,
       metadata: metadata.toDomain(),
       mLPerKgPerMin: Number(mLPerKgPerMin.value),

--- a/packages/health_connector_hc_android/lib/src/mappers/health_record_mappers/weight_record_mappers.dart
+++ b/packages/health_connector_hc_android/lib/src/mappers/health_record_mappers/weight_record_mappers.dart
@@ -29,7 +29,7 @@ extension WeightRecordDtoToDomain on WeightRecordDto {
   WeightRecord toDomain() {
     return WeightRecord(
       id: id?.toDomain() ?? HealthRecordId.none,
-      time: DateTime.fromMillisecondsSinceEpoch(time),
+      time: DateTime.fromMillisecondsSinceEpoch(time, isUtc: true),
       zoneOffsetSeconds: zoneOffsetSeconds,
       metadata: metadata.toDomain(),
       weight: weight.toDomain(),

--- a/packages/health_connector_hc_android/lib/src/mappers/health_record_mappers/wheelchair_pushes_record_mappers.dart
+++ b/packages/health_connector_hc_android/lib/src/mappers/health_record_mappers/wheelchair_pushes_record_mappers.dart
@@ -31,8 +31,8 @@ extension WheelchairPushesRecordDtoToDomain on WheelchairPushesRecordDto {
   WheelchairPushesRecord toDomain() {
     return WheelchairPushesRecord(
       id: id?.toDomain() ?? HealthRecordId.none,
-      startTime: DateTime.fromMillisecondsSinceEpoch(startTime),
-      endTime: DateTime.fromMillisecondsSinceEpoch(endTime),
+      startTime: DateTime.fromMillisecondsSinceEpoch(startTime, isUtc: true),
+      endTime: DateTime.fromMillisecondsSinceEpoch(endTime, isUtc: true),
       startZoneOffsetSeconds: startZoneOffsetSeconds,
       endZoneOffsetSeconds: endZoneOffsetSeconds,
       metadata: metadata.toDomain(),

--- a/packages/health_connector_hk_ios/lib/src/mappers/health_record_mappers/active_calories_burned_record_mappers.dart
+++ b/packages/health_connector_hk_ios/lib/src/mappers/health_record_mappers/active_calories_burned_record_mappers.dart
@@ -31,8 +31,8 @@ extension ActiveCaloriesBurnedRecordDtoToDomain
   ActiveCaloriesBurnedRecord toDomain() {
     return ActiveCaloriesBurnedRecord(
       id: id?.toDomain() ?? HealthRecordId.none,
-      startTime: DateTime.fromMillisecondsSinceEpoch(startTime),
-      endTime: DateTime.fromMillisecondsSinceEpoch(endTime),
+      startTime: DateTime.fromMillisecondsSinceEpoch(startTime, isUtc: true),
+      endTime: DateTime.fromMillisecondsSinceEpoch(endTime, isUtc: true),
       startZoneOffsetSeconds: zoneOffsetSeconds,
       endZoneOffsetSeconds: zoneOffsetSeconds,
       metadata: metadata.toDomain(),

--- a/packages/health_connector_hk_ios/lib/src/mappers/health_record_mappers/blood_glucose_record_mappers.dart
+++ b/packages/health_connector_hk_ios/lib/src/mappers/health_record_mappers/blood_glucose_record_mappers.dart
@@ -42,7 +42,7 @@ extension BloodGlucoseRecordDtoToDomain on BloodGlucoseRecordDto {
   BloodGlucoseRecord toDomain() {
     return BloodGlucoseRecord(
       id: id?.toDomain() ?? HealthRecordId.none,
-      time: DateTime.fromMillisecondsSinceEpoch(time),
+      time: DateTime.fromMillisecondsSinceEpoch(time, isUtc: true),
       zoneOffsetSeconds: zoneOffsetSeconds,
       metadata: metadata.toDomain(),
       bloodGlucose: bloodGlucose.toDomain(),

--- a/packages/health_connector_hk_ios/lib/src/mappers/health_record_mappers/blood_pressure_record_mappers.dart
+++ b/packages/health_connector_hk_ios/lib/src/mappers/health_record_mappers/blood_pressure_record_mappers.dart
@@ -37,7 +37,7 @@ extension BloodPressureRecordDtoToDomain on BloodPressureRecordDto {
   BloodPressureRecord toDomain() {
     return BloodPressureRecord(
       id: id?.toDomain() ?? HealthRecordId.none,
-      time: DateTime.fromMillisecondsSinceEpoch(time),
+      time: DateTime.fromMillisecondsSinceEpoch(time, isUtc: true),
       zoneOffsetSeconds: zoneOffsetSeconds,
       metadata: metadata.toDomain(),
       systolic: systolic.toDomain(),

--- a/packages/health_connector_hk_ios/lib/src/mappers/health_record_mappers/body_fat_percentage_record_mappers.dart
+++ b/packages/health_connector_hk_ios/lib/src/mappers/health_record_mappers/body_fat_percentage_record_mappers.dart
@@ -29,7 +29,7 @@ extension BodyFatPercentageRecordDtoToDomain on BodyFatPercentageRecordDto {
   BodyFatPercentageRecord toDomain() {
     return BodyFatPercentageRecord(
       id: id?.toDomain() ?? HealthRecordId.none,
-      time: DateTime.fromMillisecondsSinceEpoch(time),
+      time: DateTime.fromMillisecondsSinceEpoch(time, isUtc: true),
       zoneOffsetSeconds: zoneOffsetSeconds,
       metadata: metadata.toDomain(),
       percentage: percentage.toDomain(),

--- a/packages/health_connector_hk_ios/lib/src/mappers/health_record_mappers/body_temperature_record_mappers.dart
+++ b/packages/health_connector_hk_ios/lib/src/mappers/health_record_mappers/body_temperature_record_mappers.dart
@@ -29,7 +29,7 @@ extension BodyTemperatureRecordDtoToDomain on BodyTemperatureRecordDto {
   BodyTemperatureRecord toDomain() {
     return BodyTemperatureRecord(
       id: id?.toDomain() ?? HealthRecordId.none,
-      time: DateTime.fromMillisecondsSinceEpoch(time),
+      time: DateTime.fromMillisecondsSinceEpoch(time, isUtc: true),
       zoneOffsetSeconds: zoneOffsetSeconds,
       metadata: metadata.toDomain(),
       temperature: temperature.toDomain(),

--- a/packages/health_connector_hk_ios/lib/src/mappers/health_record_mappers/diastolic_blood_pressure_record_mappers.dart
+++ b/packages/health_connector_hk_ios/lib/src/mappers/health_record_mappers/diastolic_blood_pressure_record_mappers.dart
@@ -32,7 +32,7 @@ extension DiastolicBloodPressureRecordDtoToDomain
   DiastolicBloodPressureRecord toDomain() {
     return DiastolicBloodPressureRecord(
       id: id?.toDomain() ?? HealthRecordId.none,
-      time: DateTime.fromMillisecondsSinceEpoch(time),
+      time: DateTime.fromMillisecondsSinceEpoch(time, isUtc: true),
       zoneOffsetSeconds: zoneOffsetSeconds,
       metadata: metadata.toDomain(),
       pressure: pressure.toDomain(),

--- a/packages/health_connector_hk_ios/lib/src/mappers/health_record_mappers/distance_activity_record_mappers.dart
+++ b/packages/health_connector_hk_ios/lib/src/mappers/health_record_mappers/distance_activity_record_mappers.dart
@@ -59,8 +59,8 @@ extension DistanceActivityRecordToDto on DistanceActivityRecord {
 extension DistanceActivityRecordDtoToDomain on DistanceActivityRecordDto {
   DistanceActivityRecord toDomain() {
     final recordId = id?.toDomain() ?? HealthRecordId.none;
-    final start = DateTime.fromMillisecondsSinceEpoch(startTime);
-    final end = DateTime.fromMillisecondsSinceEpoch(endTime);
+    final start = DateTime.fromMillisecondsSinceEpoch(startTime, isUtc: true);
+    final end = DateTime.fromMillisecondsSinceEpoch(endTime, isUtc: true);
     final meta = metadata.toDomain();
     final dist = distance.toDomain();
     final zoneOffset = zoneOffsetSeconds;

--- a/packages/health_connector_hk_ios/lib/src/mappers/health_record_mappers/floors_climbed_record_mappers.dart
+++ b/packages/health_connector_hk_ios/lib/src/mappers/health_record_mappers/floors_climbed_record_mappers.dart
@@ -31,8 +31,8 @@ extension FloorsClimbedRecordDtoToDomain on FloorsClimbedRecordDto {
   FloorsClimbedRecord toDomain() {
     return FloorsClimbedRecord(
       id: id?.toDomain() ?? HealthRecordId.none,
-      startTime: DateTime.fromMillisecondsSinceEpoch(startTime),
-      endTime: DateTime.fromMillisecondsSinceEpoch(endTime),
+      startTime: DateTime.fromMillisecondsSinceEpoch(startTime, isUtc: true),
+      endTime: DateTime.fromMillisecondsSinceEpoch(endTime, isUtc: true),
       startZoneOffsetSeconds: zoneOffsetSeconds,
       endZoneOffsetSeconds: zoneOffsetSeconds,
       metadata: metadata.toDomain(),

--- a/packages/health_connector_hk_ios/lib/src/mappers/health_record_mappers/heart_rate_measurement_mappers.dart
+++ b/packages/health_connector_hk_ios/lib/src/mappers/health_record_mappers/heart_rate_measurement_mappers.dart
@@ -23,7 +23,7 @@ extension HeartRateMeasurementDomainToDto on HeartRateMeasurement {
 extension HeartRateMeasurementDtoToDomain on HeartRateMeasurementDto {
   HeartRateMeasurement toDomain() {
     return HeartRateMeasurement(
-      time: DateTime.fromMillisecondsSinceEpoch(time),
+      time: DateTime.fromMillisecondsSinceEpoch(time, isUtc: true),
       beatsPerMinute: beatsPerMinute.toDomain(),
     );
   }

--- a/packages/health_connector_hk_ios/lib/src/mappers/health_record_mappers/height_record_mappers.dart
+++ b/packages/health_connector_hk_ios/lib/src/mappers/health_record_mappers/height_record_mappers.dart
@@ -29,7 +29,7 @@ extension HeightRecordDtoToDomain on HeightRecordDto {
   HeightRecord toDomain() {
     return HeightRecord(
       id: id?.toDomain() ?? HealthRecordId.none,
-      time: DateTime.fromMillisecondsSinceEpoch(time),
+      time: DateTime.fromMillisecondsSinceEpoch(time, isUtc: true),
       zoneOffsetSeconds: zoneOffsetSeconds,
       metadata: metadata.toDomain(),
       height: height.toDomain(),

--- a/packages/health_connector_hk_ios/lib/src/mappers/health_record_mappers/hydration_record_mappers.dart
+++ b/packages/health_connector_hk_ios/lib/src/mappers/health_record_mappers/hydration_record_mappers.dart
@@ -31,8 +31,8 @@ extension HydrationRecordDtoToDomain on HydrationRecordDto {
   HydrationRecord toDomain() {
     return HydrationRecord(
       id: id?.toDomain() ?? HealthRecordId.none,
-      startTime: DateTime.fromMillisecondsSinceEpoch(startTime),
-      endTime: DateTime.fromMillisecondsSinceEpoch(endTime),
+      startTime: DateTime.fromMillisecondsSinceEpoch(startTime, isUtc: true),
+      endTime: DateTime.fromMillisecondsSinceEpoch(endTime, isUtc: true),
       startZoneOffsetSeconds: zoneOffsetSeconds,
       endZoneOffsetSeconds: zoneOffsetSeconds,
       metadata: metadata.toDomain(),

--- a/packages/health_connector_hk_ios/lib/src/mappers/health_record_mappers/lean_body_mass_record_mappers.dart
+++ b/packages/health_connector_hk_ios/lib/src/mappers/health_record_mappers/lean_body_mass_record_mappers.dart
@@ -29,7 +29,7 @@ extension LeanBodyMassRecordDtoToDomain on LeanBodyMassRecordDto {
   LeanBodyMassRecord toDomain() {
     return LeanBodyMassRecord(
       id: id?.toDomain() ?? HealthRecordId.none,
-      time: DateTime.fromMillisecondsSinceEpoch(time),
+      time: DateTime.fromMillisecondsSinceEpoch(time, isUtc: true),
       zoneOffsetSeconds: zoneOffsetSeconds,
       metadata: metadata.toDomain(),
       mass: mass.toDomain(),

--- a/packages/health_connector_hk_ios/lib/src/mappers/health_record_mappers/nutrition_record_mappers.dart
+++ b/packages/health_connector_hk_ios/lib/src/mappers/health_record_mappers/nutrition_record_mappers.dart
@@ -710,8 +710,8 @@ extension NutritionRecordDtoToDomain on NutritionRecordDto {
   NutritionRecord toDomain() {
     return NutritionRecord(
       id: id?.toDomain() ?? HealthRecordId.none,
-      startTime: DateTime.fromMillisecondsSinceEpoch(startTime),
-      endTime: DateTime.fromMillisecondsSinceEpoch(endTime),
+      startTime: DateTime.fromMillisecondsSinceEpoch(startTime, isUtc: true),
+      endTime: DateTime.fromMillisecondsSinceEpoch(endTime, isUtc: true),
       startZoneOffsetSeconds: startZoneOffsetSeconds,
       endZoneOffsetSeconds: endZoneOffsetSeconds,
       metadata: metadata.toDomain(),
@@ -766,7 +766,7 @@ extension EnergyNutrientRecordDtoToDomain on EnergyNutrientRecordDto {
   EnergyNutrientRecord toDomain() {
     return EnergyNutrientRecord(
       id: id?.toDomain() ?? HealthRecordId.none,
-      time: DateTime.fromMillisecondsSinceEpoch(time),
+      time: DateTime.fromMillisecondsSinceEpoch(time, isUtc: true),
       zoneOffsetSeconds: zoneOffsetSeconds,
       metadata: metadata.toDomain(),
       value: value.toDomain(),
@@ -783,7 +783,7 @@ extension CaffeineNutrientRecordDtoToDomain on CaffeineNutrientRecordDto {
   CaffeineNutrientRecord toDomain() {
     return CaffeineNutrientRecord(
       id: id?.toDomain() ?? HealthRecordId.none,
-      time: DateTime.fromMillisecondsSinceEpoch(time),
+      time: DateTime.fromMillisecondsSinceEpoch(time, isUtc: true),
       zoneOffsetSeconds: zoneOffsetSeconds,
       metadata: metadata.toDomain(),
       value: value.toDomain(),
@@ -800,7 +800,7 @@ extension ProteinNutrientRecordDtoToDomain on ProteinNutrientRecordDto {
   ProteinNutrientRecord toDomain() {
     return ProteinNutrientRecord(
       id: id?.toDomain() ?? HealthRecordId.none,
-      time: DateTime.fromMillisecondsSinceEpoch(time),
+      time: DateTime.fromMillisecondsSinceEpoch(time, isUtc: true),
       zoneOffsetSeconds: zoneOffsetSeconds,
       metadata: metadata.toDomain(),
       value: value.toDomain(),
@@ -819,7 +819,7 @@ extension TotalCarbohydrateNutrientRecordDtoToDomain
   TotalCarbohydrateNutrientRecord toDomain() {
     return TotalCarbohydrateNutrientRecord(
       id: id?.toDomain() ?? HealthRecordId.none,
-      time: DateTime.fromMillisecondsSinceEpoch(time),
+      time: DateTime.fromMillisecondsSinceEpoch(time, isUtc: true),
       zoneOffsetSeconds: zoneOffsetSeconds,
       metadata: metadata.toDomain(),
       value: value.toDomain(),
@@ -836,7 +836,7 @@ extension TotalFatNutrientRecordDtoToDomain on TotalFatNutrientRecordDto {
   TotalFatNutrientRecord toDomain() {
     return TotalFatNutrientRecord(
       id: id?.toDomain() ?? HealthRecordId.none,
-      time: DateTime.fromMillisecondsSinceEpoch(time),
+      time: DateTime.fromMillisecondsSinceEpoch(time, isUtc: true),
       zoneOffsetSeconds: zoneOffsetSeconds,
       metadata: metadata.toDomain(),
       value: value.toDomain(),
@@ -854,7 +854,7 @@ extension SaturatedFatNutrientRecordDtoToDomain
   SaturatedFatNutrientRecord toDomain() {
     return SaturatedFatNutrientRecord(
       id: id?.toDomain() ?? HealthRecordId.none,
-      time: DateTime.fromMillisecondsSinceEpoch(time),
+      time: DateTime.fromMillisecondsSinceEpoch(time, isUtc: true),
       zoneOffsetSeconds: zoneOffsetSeconds,
       metadata: metadata.toDomain(),
       value: value.toDomain(),
@@ -873,7 +873,7 @@ extension MonounsaturatedFatNutrientRecordDtoToDomain
   MonounsaturatedFatNutrientRecord toDomain() {
     return MonounsaturatedFatNutrientRecord(
       id: id?.toDomain() ?? HealthRecordId.none,
-      time: DateTime.fromMillisecondsSinceEpoch(time),
+      time: DateTime.fromMillisecondsSinceEpoch(time, isUtc: true),
       zoneOffsetSeconds: zoneOffsetSeconds,
       metadata: metadata.toDomain(),
       value: value.toDomain(),
@@ -892,7 +892,7 @@ extension PolyunsaturatedFatNutrientRecordDtoToDomain
   PolyunsaturatedFatNutrientRecord toDomain() {
     return PolyunsaturatedFatNutrientRecord(
       id: id?.toDomain() ?? HealthRecordId.none,
-      time: DateTime.fromMillisecondsSinceEpoch(time),
+      time: DateTime.fromMillisecondsSinceEpoch(time, isUtc: true),
       zoneOffsetSeconds: zoneOffsetSeconds,
       metadata: metadata.toDomain(),
       value: value.toDomain(),
@@ -909,7 +909,7 @@ extension CholesterolNutrientRecordDtoToDomain on CholesterolNutrientRecordDto {
   CholesterolNutrientRecord toDomain() {
     return CholesterolNutrientRecord(
       id: id?.toDomain() ?? HealthRecordId.none,
-      time: DateTime.fromMillisecondsSinceEpoch(time),
+      time: DateTime.fromMillisecondsSinceEpoch(time, isUtc: true),
       zoneOffsetSeconds: zoneOffsetSeconds,
       metadata: metadata.toDomain(),
       value: value.toDomain(),
@@ -927,7 +927,7 @@ extension DietaryFiberNutrientRecordDtoToDomain
   DietaryFiberNutrientRecord toDomain() {
     return DietaryFiberNutrientRecord(
       id: id?.toDomain() ?? HealthRecordId.none,
-      time: DateTime.fromMillisecondsSinceEpoch(time),
+      time: DateTime.fromMillisecondsSinceEpoch(time, isUtc: true),
       zoneOffsetSeconds: zoneOffsetSeconds,
       metadata: metadata.toDomain(),
       value: value.toDomain(),
@@ -944,7 +944,7 @@ extension SugarNutrientRecordDtoToDomain on SugarNutrientRecordDto {
   SugarNutrientRecord toDomain() {
     return SugarNutrientRecord(
       id: id?.toDomain() ?? HealthRecordId.none,
-      time: DateTime.fromMillisecondsSinceEpoch(time),
+      time: DateTime.fromMillisecondsSinceEpoch(time, isUtc: true),
       zoneOffsetSeconds: zoneOffsetSeconds,
       metadata: metadata.toDomain(),
       value: value.toDomain(),
@@ -961,7 +961,7 @@ extension VitaminANutrientRecordDtoToDomain on VitaminANutrientRecordDto {
   VitaminANutrientRecord toDomain() {
     return VitaminANutrientRecord(
       id: id?.toDomain() ?? HealthRecordId.none,
-      time: DateTime.fromMillisecondsSinceEpoch(time),
+      time: DateTime.fromMillisecondsSinceEpoch(time, isUtc: true),
       zoneOffsetSeconds: zoneOffsetSeconds,
       metadata: metadata.toDomain(),
       value: value.toDomain(),
@@ -978,7 +978,7 @@ extension VitaminB6NutrientRecordDtoToDomain on VitaminB6NutrientRecordDto {
   VitaminB6NutrientRecord toDomain() {
     return VitaminB6NutrientRecord(
       id: id?.toDomain() ?? HealthRecordId.none,
-      time: DateTime.fromMillisecondsSinceEpoch(time),
+      time: DateTime.fromMillisecondsSinceEpoch(time, isUtc: true),
       zoneOffsetSeconds: zoneOffsetSeconds,
       metadata: metadata.toDomain(),
       value: value.toDomain(),
@@ -995,7 +995,7 @@ extension VitaminB12NutrientRecordDtoToDomain on VitaminB12NutrientRecordDto {
   VitaminB12NutrientRecord toDomain() {
     return VitaminB12NutrientRecord(
       id: id?.toDomain() ?? HealthRecordId.none,
-      time: DateTime.fromMillisecondsSinceEpoch(time),
+      time: DateTime.fromMillisecondsSinceEpoch(time, isUtc: true),
       zoneOffsetSeconds: zoneOffsetSeconds,
       metadata: metadata.toDomain(),
       value: value.toDomain(),
@@ -1012,7 +1012,7 @@ extension VitaminCNutrientRecordDtoToDomain on VitaminCNutrientRecordDto {
   VitaminCNutrientRecord toDomain() {
     return VitaminCNutrientRecord(
       id: id?.toDomain() ?? HealthRecordId.none,
-      time: DateTime.fromMillisecondsSinceEpoch(time),
+      time: DateTime.fromMillisecondsSinceEpoch(time, isUtc: true),
       zoneOffsetSeconds: zoneOffsetSeconds,
       metadata: metadata.toDomain(),
       value: value.toDomain(),
@@ -1029,7 +1029,7 @@ extension VitaminDNutrientRecordDtoToDomain on VitaminDNutrientRecordDto {
   VitaminDNutrientRecord toDomain() {
     return VitaminDNutrientRecord(
       id: id?.toDomain() ?? HealthRecordId.none,
-      time: DateTime.fromMillisecondsSinceEpoch(time),
+      time: DateTime.fromMillisecondsSinceEpoch(time, isUtc: true),
       zoneOffsetSeconds: zoneOffsetSeconds,
       metadata: metadata.toDomain(),
       value: value.toDomain(),
@@ -1046,7 +1046,7 @@ extension VitaminENutrientRecordDtoToDomain on VitaminENutrientRecordDto {
   VitaminENutrientRecord toDomain() {
     return VitaminENutrientRecord(
       id: id?.toDomain() ?? HealthRecordId.none,
-      time: DateTime.fromMillisecondsSinceEpoch(time),
+      time: DateTime.fromMillisecondsSinceEpoch(time, isUtc: true),
       zoneOffsetSeconds: zoneOffsetSeconds,
       metadata: metadata.toDomain(),
       value: value.toDomain(),
@@ -1063,7 +1063,7 @@ extension VitaminKNutrientRecordDtoToDomain on VitaminKNutrientRecordDto {
   VitaminKNutrientRecord toDomain() {
     return VitaminKNutrientRecord(
       id: id?.toDomain() ?? HealthRecordId.none,
-      time: DateTime.fromMillisecondsSinceEpoch(time),
+      time: DateTime.fromMillisecondsSinceEpoch(time, isUtc: true),
       zoneOffsetSeconds: zoneOffsetSeconds,
       metadata: metadata.toDomain(),
       value: value.toDomain(),
@@ -1080,7 +1080,7 @@ extension ThiaminNutrientRecordDtoToDomain on ThiaminNutrientRecordDto {
   ThiaminNutrientRecord toDomain() {
     return ThiaminNutrientRecord(
       id: id?.toDomain() ?? HealthRecordId.none,
-      time: DateTime.fromMillisecondsSinceEpoch(time),
+      time: DateTime.fromMillisecondsSinceEpoch(time, isUtc: true),
       zoneOffsetSeconds: zoneOffsetSeconds,
       metadata: metadata.toDomain(),
       value: value.toDomain(),
@@ -1097,7 +1097,7 @@ extension RiboflavinNutrientRecordDtoToDomain on RiboflavinNutrientRecordDto {
   RiboflavinNutrientRecord toDomain() {
     return RiboflavinNutrientRecord(
       id: id?.toDomain() ?? HealthRecordId.none,
-      time: DateTime.fromMillisecondsSinceEpoch(time),
+      time: DateTime.fromMillisecondsSinceEpoch(time, isUtc: true),
       zoneOffsetSeconds: zoneOffsetSeconds,
       metadata: metadata.toDomain(),
       value: value.toDomain(),
@@ -1114,7 +1114,7 @@ extension NiacinNutrientRecordDtoToDomain on NiacinNutrientRecordDto {
   NiacinNutrientRecord toDomain() {
     return NiacinNutrientRecord(
       id: id?.toDomain() ?? HealthRecordId.none,
-      time: DateTime.fromMillisecondsSinceEpoch(time),
+      time: DateTime.fromMillisecondsSinceEpoch(time, isUtc: true),
       zoneOffsetSeconds: zoneOffsetSeconds,
       metadata: metadata.toDomain(),
       value: value.toDomain(),
@@ -1131,7 +1131,7 @@ extension FolateNutrientRecordDtoToDomain on FolateNutrientRecordDto {
   FolateNutrientRecord toDomain() {
     return FolateNutrientRecord(
       id: id?.toDomain() ?? HealthRecordId.none,
-      time: DateTime.fromMillisecondsSinceEpoch(time),
+      time: DateTime.fromMillisecondsSinceEpoch(time, isUtc: true),
       zoneOffsetSeconds: zoneOffsetSeconds,
       metadata: metadata.toDomain(),
       value: value.toDomain(),
@@ -1148,7 +1148,7 @@ extension BiotinNutrientRecordDtoToDomain on BiotinNutrientRecordDto {
   BiotinNutrientRecord toDomain() {
     return BiotinNutrientRecord(
       id: id?.toDomain() ?? HealthRecordId.none,
-      time: DateTime.fromMillisecondsSinceEpoch(time),
+      time: DateTime.fromMillisecondsSinceEpoch(time, isUtc: true),
       zoneOffsetSeconds: zoneOffsetSeconds,
       metadata: metadata.toDomain(),
       value: value.toDomain(),
@@ -1167,7 +1167,7 @@ extension PantothenicAcidNutrientRecordDtoToDomain
   PantothenicAcidNutrientRecord toDomain() {
     return PantothenicAcidNutrientRecord(
       id: id?.toDomain() ?? HealthRecordId.none,
-      time: DateTime.fromMillisecondsSinceEpoch(time),
+      time: DateTime.fromMillisecondsSinceEpoch(time, isUtc: true),
       zoneOffsetSeconds: zoneOffsetSeconds,
       metadata: metadata.toDomain(),
       value: value.toDomain(),
@@ -1184,7 +1184,7 @@ extension CalciumNutrientRecordDtoToDomain on CalciumNutrientRecordDto {
   CalciumNutrientRecord toDomain() {
     return CalciumNutrientRecord(
       id: id?.toDomain() ?? HealthRecordId.none,
-      time: DateTime.fromMillisecondsSinceEpoch(time),
+      time: DateTime.fromMillisecondsSinceEpoch(time, isUtc: true),
       zoneOffsetSeconds: zoneOffsetSeconds,
       metadata: metadata.toDomain(),
       value: value.toDomain(),
@@ -1201,7 +1201,7 @@ extension IronNutrientRecordDtoToDomain on IronNutrientRecordDto {
   IronNutrientRecord toDomain() {
     return IronNutrientRecord(
       id: id?.toDomain() ?? HealthRecordId.none,
-      time: DateTime.fromMillisecondsSinceEpoch(time),
+      time: DateTime.fromMillisecondsSinceEpoch(time, isUtc: true),
       zoneOffsetSeconds: zoneOffsetSeconds,
       metadata: metadata.toDomain(),
       value: value.toDomain(),
@@ -1218,7 +1218,7 @@ extension MagnesiumNutrientRecordDtoToDomain on MagnesiumNutrientRecordDto {
   MagnesiumNutrientRecord toDomain() {
     return MagnesiumNutrientRecord(
       id: id?.toDomain() ?? HealthRecordId.none,
-      time: DateTime.fromMillisecondsSinceEpoch(time),
+      time: DateTime.fromMillisecondsSinceEpoch(time, isUtc: true),
       zoneOffsetSeconds: zoneOffsetSeconds,
       metadata: metadata.toDomain(),
       value: value.toDomain(),
@@ -1235,7 +1235,7 @@ extension ManganeseNutrientRecordDtoToDomain on ManganeseNutrientRecordDto {
   ManganeseNutrientRecord toDomain() {
     return ManganeseNutrientRecord(
       id: id?.toDomain() ?? HealthRecordId.none,
-      time: DateTime.fromMillisecondsSinceEpoch(time),
+      time: DateTime.fromMillisecondsSinceEpoch(time, isUtc: true),
       zoneOffsetSeconds: zoneOffsetSeconds,
       metadata: metadata.toDomain(),
       value: value.toDomain(),
@@ -1252,7 +1252,7 @@ extension PhosphorusNutrientRecordDtoToDomain on PhosphorusNutrientRecordDto {
   PhosphorusNutrientRecord toDomain() {
     return PhosphorusNutrientRecord(
       id: id?.toDomain() ?? HealthRecordId.none,
-      time: DateTime.fromMillisecondsSinceEpoch(time),
+      time: DateTime.fromMillisecondsSinceEpoch(time, isUtc: true),
       zoneOffsetSeconds: zoneOffsetSeconds,
       metadata: metadata.toDomain(),
       value: value.toDomain(),
@@ -1269,7 +1269,7 @@ extension PotassiumNutrientRecordDtoToDomain on PotassiumNutrientRecordDto {
   PotassiumNutrientRecord toDomain() {
     return PotassiumNutrientRecord(
       id: id?.toDomain() ?? HealthRecordId.none,
-      time: DateTime.fromMillisecondsSinceEpoch(time),
+      time: DateTime.fromMillisecondsSinceEpoch(time, isUtc: true),
       zoneOffsetSeconds: zoneOffsetSeconds,
       metadata: metadata.toDomain(),
       value: value.toDomain(),
@@ -1286,7 +1286,7 @@ extension SeleniumNutrientRecordDtoToDomain on SeleniumNutrientRecordDto {
   SeleniumNutrientRecord toDomain() {
     return SeleniumNutrientRecord(
       id: id?.toDomain() ?? HealthRecordId.none,
-      time: DateTime.fromMillisecondsSinceEpoch(time),
+      time: DateTime.fromMillisecondsSinceEpoch(time, isUtc: true),
       zoneOffsetSeconds: zoneOffsetSeconds,
       metadata: metadata.toDomain(),
       value: value.toDomain(),
@@ -1303,7 +1303,7 @@ extension SodiumNutrientRecordDtoToDomain on SodiumNutrientRecordDto {
   SodiumNutrientRecord toDomain() {
     return SodiumNutrientRecord(
       id: id?.toDomain() ?? HealthRecordId.none,
-      time: DateTime.fromMillisecondsSinceEpoch(time),
+      time: DateTime.fromMillisecondsSinceEpoch(time, isUtc: true),
       zoneOffsetSeconds: zoneOffsetSeconds,
       metadata: metadata.toDomain(),
       value: value.toDomain(),
@@ -1320,7 +1320,7 @@ extension ZincNutrientRecordDtoToDomain on ZincNutrientRecordDto {
   ZincNutrientRecord toDomain() {
     return ZincNutrientRecord(
       id: id?.toDomain() ?? HealthRecordId.none,
-      time: DateTime.fromMillisecondsSinceEpoch(time),
+      time: DateTime.fromMillisecondsSinceEpoch(time, isUtc: true),
       zoneOffsetSeconds: zoneOffsetSeconds,
       metadata: metadata.toDomain(),
       value: value.toDomain(),

--- a/packages/health_connector_hk_ios/lib/src/mappers/health_record_mappers/oxygen_saturation_record_mappers.dart
+++ b/packages/health_connector_hk_ios/lib/src/mappers/health_record_mappers/oxygen_saturation_record_mappers.dart
@@ -29,7 +29,7 @@ extension OxygenSaturationRecordDtoToDomain on OxygenSaturationRecordDto {
   OxygenSaturationRecord toDomain() {
     return OxygenSaturationRecord(
       id: id?.toDomain() ?? HealthRecordId.none,
-      time: DateTime.fromMillisecondsSinceEpoch(time),
+      time: DateTime.fromMillisecondsSinceEpoch(time, isUtc: true),
       zoneOffsetSeconds: zoneOffsetSeconds,
       metadata: metadata.toDomain(),
       percentage: percentage.toDomain(),

--- a/packages/health_connector_hk_ios/lib/src/mappers/health_record_mappers/resting_heart_rate_record_mappers.dart
+++ b/packages/health_connector_hk_ios/lib/src/mappers/health_record_mappers/resting_heart_rate_record_mappers.dart
@@ -29,7 +29,7 @@ extension RestingHeartRateRecordDtoToDomain on RestingHeartRateRecordDto {
   RestingHeartRateRecord toDomain() {
     return RestingHeartRateRecord(
       id: id?.toDomain() ?? HealthRecordId.none,
-      time: DateTime.fromMillisecondsSinceEpoch(time),
+      time: DateTime.fromMillisecondsSinceEpoch(time, isUtc: true),
       zoneOffsetSeconds: zoneOffsetSeconds,
       metadata: metadata.toDomain(),
       beatsPerMinute: beatsPerMinute.toDomain(),

--- a/packages/health_connector_hk_ios/lib/src/mappers/health_record_mappers/sleep_stage_record_mappers.dart
+++ b/packages/health_connector_hk_ios/lib/src/mappers/health_record_mappers/sleep_stage_record_mappers.dart
@@ -32,8 +32,8 @@ extension SleepStageRecordDtoToDomain on SleepStageRecordDto {
     return SleepStageRecord(
       id: id?.toDomain() ?? HealthRecordId.none,
       metadata: metadata.toDomain(),
-      startTime: DateTime.fromMillisecondsSinceEpoch(startTime),
-      endTime: DateTime.fromMillisecondsSinceEpoch(endTime),
+      startTime: DateTime.fromMillisecondsSinceEpoch(startTime, isUtc: true),
+      endTime: DateTime.fromMillisecondsSinceEpoch(endTime, isUtc: true),
       stageType: stageType.toDomain(),
     );
   }

--- a/packages/health_connector_hk_ios/lib/src/mappers/health_record_mappers/speed_activity_record_mappers.dart
+++ b/packages/health_connector_hk_ios/lib/src/mappers/health_record_mappers/speed_activity_record_mappers.dart
@@ -52,7 +52,7 @@ extension SpeedActivityRecordDtoToDomain on SpeedActivityRecordDto {
     final timeValue = DateTime.fromMillisecondsSinceEpoch(
       time,
       isUtc: true,
-    ).toLocal();
+    );
 
     return switch (activityType) {
       SpeedActivityTypeDto.walking => WalkingSpeedRecord(

--- a/packages/health_connector_hk_ios/lib/src/mappers/health_record_mappers/steps_record_mappers.dart
+++ b/packages/health_connector_hk_ios/lib/src/mappers/health_record_mappers/steps_record_mappers.dart
@@ -31,8 +31,8 @@ extension StepsRecordDtoToDomain on StepsRecordDto {
   StepsRecord toDomain() {
     return StepsRecord(
       id: id?.toDomain() ?? HealthRecordId.none,
-      startTime: DateTime.fromMillisecondsSinceEpoch(startTime),
-      endTime: DateTime.fromMillisecondsSinceEpoch(endTime),
+      startTime: DateTime.fromMillisecondsSinceEpoch(startTime, isUtc: true),
+      endTime: DateTime.fromMillisecondsSinceEpoch(endTime, isUtc: true),
       startZoneOffsetSeconds: zoneOffsetSeconds,
       endZoneOffsetSeconds: zoneOffsetSeconds,
       metadata: metadata.toDomain(),

--- a/packages/health_connector_hk_ios/lib/src/mappers/health_record_mappers/systolic_blood_pressure_record_mappers.dart
+++ b/packages/health_connector_hk_ios/lib/src/mappers/health_record_mappers/systolic_blood_pressure_record_mappers.dart
@@ -30,7 +30,7 @@ extension SystolicBloodPressureRecordDtoToDomain
   SystolicBloodPressureRecord toDomain() {
     return SystolicBloodPressureRecord(
       id: id?.toDomain() ?? HealthRecordId.none,
-      time: DateTime.fromMillisecondsSinceEpoch(time),
+      time: DateTime.fromMillisecondsSinceEpoch(time, isUtc: true),
       zoneOffsetSeconds: zoneOffsetSeconds,
       metadata: metadata.toDomain(),
       pressure: pressure.toDomain(),

--- a/packages/health_connector_hk_ios/lib/src/mappers/health_record_mappers/vo2_max_record_mappers.dart
+++ b/packages/health_connector_hk_ios/lib/src/mappers/health_record_mappers/vo2_max_record_mappers.dart
@@ -12,7 +12,7 @@ extension Vo2MaxRecordDtoToDomain on Vo2MaxRecordDto {
   Vo2MaxRecord toDomain() {
     return Vo2MaxRecord(
       id: id?.toDomain() ?? HealthRecordId.none,
-      time: DateTime.fromMillisecondsSinceEpoch(time),
+      time: DateTime.fromMillisecondsSinceEpoch(time, isUtc: true),
       zoneOffsetSeconds: zoneOffsetSeconds,
       metadata: metadata.toDomain(),
       mLPerKgPerMin: mLPerKgPerMin.toDomain(),

--- a/packages/health_connector_hk_ios/lib/src/mappers/health_record_mappers/weight_record_mappers.dart
+++ b/packages/health_connector_hk_ios/lib/src/mappers/health_record_mappers/weight_record_mappers.dart
@@ -29,7 +29,7 @@ extension WeightRecordDtoToDomain on WeightRecordDto {
   WeightRecord toDomain() {
     return WeightRecord(
       id: id?.toDomain() ?? HealthRecordId.none,
-      time: DateTime.fromMillisecondsSinceEpoch(time),
+      time: DateTime.fromMillisecondsSinceEpoch(time, isUtc: true),
       zoneOffsetSeconds: zoneOffsetSeconds,
       metadata: metadata.toDomain(),
       weight: weight.toDomain(),

--- a/packages/health_connector_hk_ios/lib/src/mappers/health_record_mappers/wheelchair_pushes_record_mappers.dart
+++ b/packages/health_connector_hk_ios/lib/src/mappers/health_record_mappers/wheelchair_pushes_record_mappers.dart
@@ -31,8 +31,8 @@ extension WheelchairPushesRecordDtoToDomain on WheelchairPushesRecordDto {
   WheelchairPushesRecord toDomain() {
     return WheelchairPushesRecord(
       id: id?.toDomain() ?? HealthRecordId.none,
-      startTime: DateTime.fromMillisecondsSinceEpoch(startTime),
-      endTime: DateTime.fromMillisecondsSinceEpoch(endTime),
+      startTime: DateTime.fromMillisecondsSinceEpoch(startTime, isUtc: true),
+      endTime: DateTime.fromMillisecondsSinceEpoch(endTime, isUtc: true),
       startZoneOffsetSeconds: zoneOffsetSeconds,
       endZoneOffsetSeconds: zoneOffsetSeconds,
       metadata: metadata.toDomain(),


### PR DESCRIPTION
### **User description**
Updates documentation and mappers to consistently handle health record timestamps as UTC instants across all packages.

- **Core**: Clarified in documentation that `time`, `startTime`, and `endTime` are stored as UTC. Explicitly noted that timezone offsets should be used for local time interpretation.
- **Android & iOS**: Updated all health record mappers to parse timestamps using `DateTime.fromMillisecondsSinceEpoch(..., isUtc: true)` to prevent accidental conversion to the device's local time during mapping.


___

### **PR Type**
Bug fix


___

### **Description**
- Standardize timestamp handling to UTC across all health record mappers

- Add `isUtc: true` parameter to `DateTime.fromMillisecondsSinceEpoch()` calls

- Remove `.toLocal()` conversions that were causing unintended timezone shifts

- Clarify documentation that timestamps are stored as UTC instants


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Timestamp Data<br/>milliseconds"] -->|"fromMillisecondsSinceEpoch<br/>isUtc: true"| B["UTC DateTime<br/>Instant"]
  B -->|"zoneOffsetSeconds"| C["Local Civil Time<br/>Interpretation"]
  D["Documentation"] -->|"Clarified"| E["UTC Storage<br/>+ Offset Usage"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Documentation</strong></td><td><details><summary>6 files</summary><table>
<tr>
  <td><strong>heart_rate_measurement.dart</strong><dd><code>Clarify heart rate measurement timestamp as UTC</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/fam-tung-lam/health_connector/pull/50/files#diff-1a20d74209a93fe791581cce37dcb615efe167b563281ccf6c70e948aef9767f">+6/-7</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>instant_health_record.dart</strong><dd><code>Document instant record timestamps stored as UTC</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/fam-tung-lam/health_connector/pull/50/files#diff-fab477940ac15f5a2b98bb3bb1f4d84a9284967787e668fd2ce0b16111eead07">+8/-31</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>interval_health_record.dart</strong><dd><code>Document interval record timestamps stored as UTC</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/fam-tung-lam/health_connector/pull/50/files#diff-fcb602f624bc853a1a525314744d11169bbe2bcddde5c698f7e47126ad4230e4">+15/-19</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>series_health_record.dart</strong><dd><code>Simplify series health record documentation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/fam-tung-lam/health_connector/pull/50/files#diff-411c3f4032f2a5181cf35eb258450f66e4bcf65da6f9a5464d5ec365819104c8">+2/-14</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>sleep_session_record.dart</strong><dd><code>Document sleep stage timestamps as UTC instants</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/fam-tung-lam/health_connector/pull/50/files#diff-3d76a6c75776f9f9632fefd6d9f856a58283f57313938f90c87a118ec32ec98d">+8/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>speed_series_record.dart</strong><dd><code>Document speed measurement timestamp as UTC</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/fam-tung-lam/health_connector/pull/50/files#diff-6b825fdaf2c01ca96c662361bc29b2eb0b03606e14d0cc897fa67c821c803447">+4/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Bug fix</strong></td><td><details><summary>46 files</summary><table>
<tr>
  <td><strong>active_calories_burned_record_mappers.dart</strong><dd><code>Add isUtc flag to timestamp parsing</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/fam-tung-lam/health_connector/pull/50/files#diff-604a53399160a66dbf300ab2dad2529a3fb2e13d851783bf432ec4f4511d1a40">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>blood_glucose_record_mappers.dart</strong><dd><code>Add isUtc flag to timestamp parsing</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/fam-tung-lam/health_connector/pull/50/files#diff-5f77e7c7d56869f09472388646416951f493ec23a1602144b340dc3fd3365dc7">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>blood_pressure_record_mappers.dart</strong><dd><code>Add isUtc flag to timestamp parsing</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/fam-tung-lam/health_connector/pull/50/files#diff-fb8ccacfe7916b310e0b50907c669b9603efed5f3bbc9d003d1d4318f65f079b">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>body_fat_percentage_record_mappers.dart</strong><dd><code>Add isUtc flag to timestamp parsing</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/fam-tung-lam/health_connector/pull/50/files#diff-5bc1da866a80ff3d18fac35f6a5996c145147306668395c75c8b7570a01c23db">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>body_temperature_record_mappers.dart</strong><dd><code>Add isUtc flag to timestamp parsing</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/fam-tung-lam/health_connector/pull/50/files#diff-907129401b7af1530ece1b802eaaa19d6ef3f9732ce2d0eda08ec53883df7af7">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>distance_record_mappers.dart</strong><dd><code>Add isUtc flag to timestamp parsing</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/fam-tung-lam/health_connector/pull/50/files#diff-c5e641dae0b95d3058a05c87265c0923743bf0a60b9dafefed783904625c5dae">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>exercise_session_record_mappers.dart</strong><dd><code>Add isUtc flag and remove toLocal conversion</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/fam-tung-lam/health_connector/pull/50/files#diff-36112b386a7aca253d870fc4cdb937ad4c511acf8acd433e466122d03e49f03b">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>floors_climbed_record_mappers.dart</strong><dd><code>Add isUtc flag to timestamp parsing</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/fam-tung-lam/health_connector/pull/50/files#diff-04c25729d0cf2d9522965a1a1eb074e62b5ea703198c7e640533adc679565e80">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>heart_rate_measurement_mappers.dart</strong><dd><code>Add isUtc flag to timestamp parsing</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/fam-tung-lam/health_connector/pull/50/files#diff-c1bd0e5d991222f3cc159a7c76ec613a597a0a1fb0728d92d141df0c01ed24a0">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>heart_rate_series_record_mappers.dart</strong><dd><code>Add isUtc flag to timestamp parsing</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/fam-tung-lam/health_connector/pull/50/files#diff-d8d85a60e6ab6e2c7b3c06f7f41763f191d7e73f7dc9cd9b0546580c33098b34">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>height_record_mappers.dart</strong><dd><code>Add isUtc flag to timestamp parsing</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/fam-tung-lam/health_connector/pull/50/files#diff-9accab895221d114be1bab01b58080f482ab12486e33697d429f977ad9e2ca72">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>hydration_record_mappers.dart</strong><dd><code>Add isUtc flag to timestamp parsing</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/fam-tung-lam/health_connector/pull/50/files#diff-b66c07c388ff2df0ce8d2b942a890e5b461c044e0954b03fea6804eb358f84f7">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>lean_body_mass_record_mappers.dart</strong><dd><code>Add isUtc flag to timestamp parsing</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/fam-tung-lam/health_connector/pull/50/files#diff-a1c4ccebd2e869d09201e3c643a6ec80a4bf0c5e4a0b7c2570e5aa3ba8a6de2c">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>nutrition_record_mappers.dart</strong><dd><code>Add isUtc flag to timestamp parsing</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/fam-tung-lam/health_connector/pull/50/files#diff-bcee7b64ce4c81aecfb3ad6065bde959b1ade9e60bdabff3df5c5051a01a0640">+5/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>oxygen_saturation_record_mappers.dart</strong><dd><code>Add isUtc flag and remove toLocal conversion</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/fam-tung-lam/health_connector/pull/50/files#diff-ad7ec04a1b775d98c0d60c78a6736d07f96e0091d7059e37c26204e414025297">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>respiratory_rate_record_mappers.dart</strong><dd><code>Add isUtc flag and remove toLocal conversion</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/fam-tung-lam/health_connector/pull/50/files#diff-709423e7e4442346bbf8f57db280c4b27f1d5dd835f3d3637b5a51756d3dc52b">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>resting_heart_rate_record_mappers.dart</strong><dd><code>Add isUtc flag to timestamp parsing</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/fam-tung-lam/health_connector/pull/50/files#diff-b0c08bdaf898e527870ee613ff9e06b9d213df1f28ad467d02dbf0ec7ccb1856">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>sleep_session_record_mappers.dart</strong><dd><code>Add isUtc flag to timestamp parsing</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/fam-tung-lam/health_connector/pull/50/files#diff-074e8a71b49ff85b8ed32d4d38ef331ed300e51d407548ddbcdb5fdea6a51d55">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>sleep_stage_mappers.dart</strong><dd><code>Add isUtc flag to timestamp parsing</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/fam-tung-lam/health_connector/pull/50/files#diff-a1a2c3734f98d7c6534cfed0c55dddd72711516c84b825b994f76ad322a3db0b">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>speed_record_mappers.dart</strong><dd><code>Add isUtc flag and remove toLocal conversions</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/fam-tung-lam/health_connector/pull/50/files#diff-1e7f947d35e35aa0a2a9c85541f125ee020961a465375e22ce9da387fd045ae8">+3/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>steps_record_mappers.dart</strong><dd><code>Add isUtc flag to timestamp parsing</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/fam-tung-lam/health_connector/pull/50/files#diff-ce7b10a64aa290aa4180fe500fcbe00474b3ed29fad59d59d0ee6bc74deba0d1">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>vo2_max_record_mappers.dart</strong><dd><code>Add isUtc flag to timestamp parsing</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/fam-tung-lam/health_connector/pull/50/files#diff-1c7be4d69380d570560e7267791b08ae10bbd9705238f5224d3165b286fdffd9">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>weight_record_mappers.dart</strong><dd><code>Add isUtc flag to timestamp parsing</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/fam-tung-lam/health_connector/pull/50/files#diff-08bf4711bfba727497bce70bd7a0596316aea7dbf41bae22bb336397e665e41e">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>wheelchair_pushes_record_mappers.dart</strong><dd><code>Add isUtc flag to timestamp parsing</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/fam-tung-lam/health_connector/pull/50/files#diff-9f23c986306eda9b91727c54b4d12df94301a9f19e8bea2c9335d98957ffa361">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>active_calories_burned_record_mappers.dart</strong><dd><code>Add isUtc flag to timestamp parsing</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/fam-tung-lam/health_connector/pull/50/files#diff-4a8aadb8dc996d9351a2e5e113564beb99491747f0211576f97da9c99b4d5025">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>blood_glucose_record_mappers.dart</strong><dd><code>Add isUtc flag to timestamp parsing</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/fam-tung-lam/health_connector/pull/50/files#diff-0359772d6c8c226a1e3441a61b576710692bdb3de6ecb4c06aefcc08bb1bc73b">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>blood_pressure_record_mappers.dart</strong><dd><code>Add isUtc flag to timestamp parsing</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/fam-tung-lam/health_connector/pull/50/files#diff-71a9e9d4a674b08ec7859d50641e92b9221acdb0e48694dba740c3b4252a2f0e">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>body_fat_percentage_record_mappers.dart</strong><dd><code>Add isUtc flag to timestamp parsing</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/fam-tung-lam/health_connector/pull/50/files#diff-9da4c6f11c346e1427e73d86f28d719b5426a8969bf81c7b1a43d47912c545e7">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>body_temperature_record_mappers.dart</strong><dd><code>Add isUtc flag to timestamp parsing</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/fam-tung-lam/health_connector/pull/50/files#diff-d43eafd5c153f4f0ea4b64205c84d77f4c9b1ba6d1c3f895c013bc189f7df7bd">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>diastolic_blood_pressure_record_mappers.dart</strong><dd><code>Add isUtc flag to timestamp parsing</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/fam-tung-lam/health_connector/pull/50/files#diff-0ec34a93fd01ad0e81a7c86c81f53cf7475abae07a61383209e46c93f2493eee">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>distance_activity_record_mappers.dart</strong><dd><code>Add isUtc flag to timestamp parsing</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/fam-tung-lam/health_connector/pull/50/files#diff-09f437a3c78bc0e8751466b5665e3c5bf70d46ed0fa2387d15bcb73e478c3e36">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>floors_climbed_record_mappers.dart</strong><dd><code>Add isUtc flag to timestamp parsing</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/fam-tung-lam/health_connector/pull/50/files#diff-5fa763b0054a45eaf9fed21af68d5a96f6ca717c1be24c34e1276ff3730adb5d">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>heart_rate_measurement_mappers.dart</strong><dd><code>Add isUtc flag to timestamp parsing</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/fam-tung-lam/health_connector/pull/50/files#diff-1be7a4c9a5e2704e5aabbf3554599daf592cedbb630ed8e07b943a1c765c2e69">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>height_record_mappers.dart</strong><dd><code>Add isUtc flag to timestamp parsing</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/fam-tung-lam/health_connector/pull/50/files#diff-d3bdbc1031a61b78e7f720e490c3a7f2e989ccf335b176a8c7f16a5b53161a41">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>hydration_record_mappers.dart</strong><dd><code>Add isUtc flag to timestamp parsing</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/fam-tung-lam/health_connector/pull/50/files#diff-b8a423d46ce0059d8e2ddcdfcc048fd8075ff1aa51d8070eaeebd81f9662b2a1">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>lean_body_mass_record_mappers.dart</strong><dd><code>Add isUtc flag to timestamp parsing</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/fam-tung-lam/health_connector/pull/50/files#diff-8f0c316b5fc3f647203aa583199ef6c75e2f4f78b2d46d2dafdcee87c7227c60">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>nutrition_record_mappers.dart</strong><dd><code>Add isUtc flag to timestamp parsing</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/fam-tung-lam/health_connector/pull/50/files#diff-bdb5590db295fef28d5c017a61fa6d89ba6641e2e6a24dccea05c14082f28113">+35/-35</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>oxygen_saturation_record_mappers.dart</strong><dd><code>Add isUtc flag to timestamp parsing</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/fam-tung-lam/health_connector/pull/50/files#diff-c6a1dee1f64e64a780835639243f2413a34b52679e5cbcdc9842e0e528a1b99e">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>resting_heart_rate_record_mappers.dart</strong><dd><code>Add isUtc flag to timestamp parsing</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/fam-tung-lam/health_connector/pull/50/files#diff-b686b63e497252dabf3a5839d666d66af2583641b931a3bc23e8edec864a2b63">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>sleep_stage_record_mappers.dart</strong><dd><code>Add isUtc flag to timestamp parsing</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/fam-tung-lam/health_connector/pull/50/files#diff-21eaddcbcab0eff0485e52aa32df4876c7873f50650da0219fdf9a948fef4ebf">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>speed_activity_record_mappers.dart</strong><dd><code>Add isUtc flag and remove toLocal conversion</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/fam-tung-lam/health_connector/pull/50/files#diff-88df44a73255eaa942d47dc5d1b2be57c7cca6ee5cda631e9c6e1e39c4430962">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>steps_record_mappers.dart</strong><dd><code>Add isUtc flag to timestamp parsing</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/fam-tung-lam/health_connector/pull/50/files#diff-972351cfd811b6fb6b012ef8a625474140646d3f70566a9439456569dfb739ac">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>systolic_blood_pressure_record_mappers.dart</strong><dd><code>Add isUtc flag to timestamp parsing</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/fam-tung-lam/health_connector/pull/50/files#diff-a8c6aef4bffe0bd2968f1242e19786ed83aad5a8040472006ec3dd824811c8a1">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>vo2_max_record_mappers.dart</strong><dd><code>Add isUtc flag to timestamp parsing</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/fam-tung-lam/health_connector/pull/50/files#diff-e03024bc22c6b20c82824238504282c2763d6265fcbb20abfbe3926be128cb41">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>weight_record_mappers.dart</strong><dd><code>Add isUtc flag to timestamp parsing</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/fam-tung-lam/health_connector/pull/50/files#diff-a5fe5119a971da941f857a5d0d79c5024f22179e30e6bf9e2ba0c300ba4efada">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>wheelchair_pushes_record_mappers.dart</strong><dd><code>Add isUtc flag to timestamp parsing</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/fam-tung-lam/health_connector/pull/50/files#diff-43afa97a4e71b862fe14e4ab8b032aa1810e254a4591fd8b2bd47219c8ef2bf5">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr></tbody></table>

</details>

___

