### PR TITLE
feat(health_connector,health_connector_core,health_connector_hc_android,health_connector_hk_ios): Add support for cycling pedaling cadence data types and records

### DIFF
--- a/examples/health_connector_toolbox/lib/src/common/constants/app_texts.dart
+++ b/examples/health_connector_toolbox/lib/src/common/constants/app_texts.dart
@@ -107,6 +107,9 @@ abstract final class AppTexts {
       HydrationHealthDataType() => hydration,
       HeartRateMeasurementRecordHealthDataType() ||
       HeartRateSeriesRecordHealthDataType() => heartRate,
+      CyclingPedalingCadenceMeasurementRecordHealthDataType() ||
+      CyclingPedalingCadenceSeriesRecordHealthDataType() =>
+        cyclingPedalingCadence,
       SleepSessionHealthDataType() => sleepSession,
       SleepStageHealthDataType() => sleepStage,
       SexualActivityDataType() => sexualActivity,
@@ -713,6 +716,14 @@ abstract final class AppTexts {
   static const String powerSamples = '$power Samples';
   // endregion
 
+  // region Cycling Cadence Data Types
+  static const String cyclingPedalingCadence = 'Cycling Pedaling Cadence';
+  static const String cyclingPedalingCadenceSamples =
+      '$cyclingPedalingCadence Samples';
+  static const String sampleRpm = 'Sample RPM';
+  static const String rpm = 'RPM';
+  // endregion
+
   // region Health Record Descriptions
 
   // Basic Health Metrics
@@ -772,6 +783,12 @@ abstract final class AppTexts {
   static const String heartRateSeriesRecordDescription =
       'Heart rate measurements over a period of time';
   static const String restingHeartRateDescription = 'Heart rate while at rest';
+
+  // Cycling Pedaling Cadence
+  static const String cyclingPedalingCadenceRecordDescription =
+      'Cycling pedaling cadence (RPM) at a specific point in time';
+  static const String cyclingPedalingCadenceSeriesRecordDescription =
+      'Cycling pedaling cadence (RPM) measurements over a period of time';
 
   // Sleep
   static const String sleepSessionDescription =

--- a/examples/health_connector_toolbox/lib/src/common/utils/extensions/health_data_type_ui_extension.dart
+++ b/examples/health_connector_toolbox/lib/src/common/utils/extensions/health_data_type_ui_extension.dart
@@ -79,6 +79,8 @@ import 'package:health_connector/health_connector_internal.dart'
         StairDescentSpeedDataType,
         PowerSeriesDataType,
         CyclingPowerDataType,
+        CyclingPedalingCadenceMeasurementRecordHealthDataType,
+        CyclingPedalingCadenceSeriesRecordHealthDataType,
         CervicalMucusDataType;
 import 'package:health_connector_toolbox/src/common/constants/app_icons.dart';
 import 'package:health_connector_toolbox/src/common/constants/app_texts.dart';
@@ -117,6 +119,10 @@ extension HealthDataTypeUI on HealthDataType {
       HydrationHealthDataType _ => AppTexts.hydration,
       HeartRateMeasurementRecordHealthDataType _ => AppTexts.heartRate,
       HeartRateSeriesRecordHealthDataType _ => AppTexts.heartRate,
+      CyclingPedalingCadenceMeasurementRecordHealthDataType _ =>
+        AppTexts.cyclingPedalingCadence,
+      CyclingPedalingCadenceSeriesRecordHealthDataType _ =>
+        AppTexts.cyclingPedalingCadence,
       RestingHeartRateHealthDataType _ => AppTexts.restingHeartRate,
       SleepSessionHealthDataType _ => AppTexts.sleepSession,
       SleepStageHealthDataType _ => AppTexts.sleepStage,
@@ -210,6 +216,10 @@ extension HealthDataTypeUI on HealthDataType {
         AppTexts.heartRateRecordDescription,
       HeartRateSeriesRecordHealthDataType _ =>
         AppTexts.heartRateSeriesRecordDescription,
+      CyclingPedalingCadenceMeasurementRecordHealthDataType _ =>
+        AppTexts.cyclingPedalingCadenceRecordDescription,
+      CyclingPedalingCadenceSeriesRecordHealthDataType _ =>
+        AppTexts.cyclingPedalingCadenceSeriesRecordDescription,
       RestingHeartRateHealthDataType _ => AppTexts.restingHeartRateDescription,
       SleepSessionHealthDataType _ => AppTexts.sleepSessionDescription,
       SleepStageHealthDataType _ => AppTexts.sleepStageRecordDescription,
@@ -300,6 +310,8 @@ extension HealthDataTypeUI on HealthDataType {
       HydrationHealthDataType _ => AppIcons.volume,
       HeartRateMeasurementRecordHealthDataType _ => AppIcons.favorite,
       HeartRateSeriesRecordHealthDataType _ => AppIcons.favorite,
+      CyclingPedalingCadenceMeasurementRecordHealthDataType _ => AppIcons.speed,
+      CyclingPedalingCadenceSeriesRecordHealthDataType _ => AppIcons.speed,
       RestingHeartRateHealthDataType _ => AppIcons.favorite,
       SleepSessionHealthDataType _ => AppIcons.bedtime,
       SleepStageHealthDataType _ => AppIcons.bedtime,
@@ -647,6 +659,8 @@ extension HealthDataTypeUIFormExtension on HealthDataType {
       // Reproductive Health
       const (SexualActivityDataType) => AppTexts.sexualActivity,
       const (CervicalMucusDataType) => AppTexts.cervicalMucus,
+      const (CyclingPedalingCadenceMeasurementRecordHealthDataType) =>
+        AppTexts.cyclingPedalingCadence,
 
       _ => throw ArgumentError(
         'No field label for $runtimeType. '

--- a/examples/health_connector_toolbox/lib/src/common/utils/measurement_unit_value_parser.dart
+++ b/examples/health_connector_toolbox/lib/src/common/utils/measurement_unit_value_parser.dart
@@ -19,6 +19,8 @@ abstract class MeasurementUnitValueParser {
       FloorsClimbedHealthDataType() ||
       WheelchairPushesHealthDataType() ||
       HeartRateMeasurementRecordHealthDataType() ||
+      CyclingPedalingCadenceMeasurementRecordHealthDataType() ||
+      CyclingPedalingCadenceSeriesRecordHealthDataType() ||
       RestingHeartRateHealthDataType() => _parseIntegerCount(value),
 
       // Mass types (kilograms)

--- a/examples/health_connector_toolbox/lib/src/features/aggregate_health_data/aggregate_health_data_change_notifier.dart
+++ b/examples/health_connector_toolbox/lib/src/features/aggregate_health_data/aggregate_health_data_change_notifier.dart
@@ -82,6 +82,8 @@ import 'package:health_connector/health_connector_internal.dart'
         StairDescentSpeedDataType,
         PowerSeriesDataType,
         CyclingPowerDataType,
+        CyclingPedalingCadenceMeasurementRecordHealthDataType,
+        CyclingPedalingCadenceSeriesRecordHealthDataType,
         BodyFatPercentageHealthDataType,
         BodyTemperatureHealthDataType,
         LeanBodyMassHealthDataType,
@@ -328,6 +330,40 @@ final class AggregateHealthDataChangeNotifier extends ChangeNotifier {
           endTime: endTime,
         ),
         () => HealthDataType.heartRateSeriesRecord.aggregateMax(
+          startTime: startTime,
+          endTime: endTime,
+        ),
+        metric,
+      ),
+      CyclingPedalingCadenceMeasurementRecordHealthDataType() =>
+        _buildAvgMinMax(
+          () => HealthDataType.cyclingPedalingCadenceMeasurementRecord
+              .aggregateAvg(
+                startTime: startTime,
+                endTime: endTime,
+              ),
+          () => HealthDataType.cyclingPedalingCadenceMeasurementRecord
+              .aggregateMin(
+                startTime: startTime,
+                endTime: endTime,
+              ),
+          () => HealthDataType.cyclingPedalingCadenceMeasurementRecord
+              .aggregateMax(
+                startTime: startTime,
+                endTime: endTime,
+              ),
+          metric,
+        ),
+      CyclingPedalingCadenceSeriesRecordHealthDataType() => _buildAvgMinMax(
+        () => HealthDataType.cyclingPedalingCadenceSeriesRecord.aggregateAvg(
+          startTime: startTime,
+          endTime: endTime,
+        ),
+        () => HealthDataType.cyclingPedalingCadenceSeriesRecord.aggregateMin(
+          startTime: startTime,
+          endTime: endTime,
+        ),
+        () => HealthDataType.cyclingPedalingCadenceSeriesRecord.aggregateMax(
           startTime: startTime,
           endTime: endTime,
         ),

--- a/examples/health_connector_toolbox/lib/src/features/read_health_records/widgets/cycling_pedaling_cadence_series_record_samples_list.dart
+++ b/examples/health_connector_toolbox/lib/src/features/read_health_records/widgets/cycling_pedaling_cadence_series_record_samples_list.dart
@@ -1,0 +1,34 @@
+import 'package:flutter/material.dart';
+import 'package:health_connector/health_connector_internal.dart'
+    show CyclingPedalingCadenceMeasurement;
+import 'package:health_connector_toolbox/src/common/constants/app_texts.dart';
+import 'package:health_connector_toolbox/src/common/utils/date_formatter.dart';
+import 'package:health_connector_toolbox/src/features/read_health_records/widgets/health_record_detail_row.dart';
+import 'package:health_connector_toolbox/src/features/read_health_records/widgets/health_series_record_samples_list.dart';
+
+/// Widget that displays a list of cycling pedaling cadence measurements.
+///
+/// Shows each sample with its time and RPM value in a clean list format.
+@immutable
+final class CyclingPedalingCadenceSeriesRecordSamplesList
+    extends StatelessWidget {
+  const CyclingPedalingCadenceSeriesRecordSamplesList({
+    required this.samples,
+    super.key,
+  });
+
+  /// The list of cycling pedaling cadence measurements to display.
+  final List<CyclingPedalingCadenceMeasurement> samples;
+
+  @override
+  Widget build(BuildContext context) {
+    return HealthSeriesRecordSampleList<CyclingPedalingCadenceMeasurement>(
+      title: AppTexts.cyclingPedalingCadenceSamples,
+      samples: samples,
+      itemBuilder: (sample, index) => HealthRecordDetailRow(
+        label: DateFormatter.formatDateTime(sample.time),
+        value: '${sample.revolutionsPerMinute.value} ${AppTexts.rpm}',
+      ),
+    );
+  }
+}

--- a/examples/health_connector_toolbox/lib/src/features/read_health_records/widgets/health_record_list_tiles/health_record_list_tile.dart
+++ b/examples/health_connector_toolbox/lib/src/features/read_health_records/widgets/health_record_list_tiles/health_record_list_tile.dart
@@ -5,6 +5,7 @@ import 'package:health_connector_toolbox/src/common/constants/app_texts.dart';
 import 'package:health_connector_toolbox/src/features/read_health_records/widgets/health_record_list_tiles/instant_health_record_list_tiles/blood_glucose_list_tile.dart';
 import 'package:health_connector_toolbox/src/features/read_health_records/widgets/health_record_list_tiles/instant_health_record_list_tiles/blood_pressure_list_tile.dart';
 import 'package:health_connector_toolbox/src/features/read_health_records/widgets/health_record_list_tiles/instant_health_record_list_tiles/cervical_mucus_list_tile.dart';
+import 'package:health_connector_toolbox/src/features/read_health_records/widgets/health_record_list_tiles/instant_health_record_list_tiles/cycling_pedaling_cadence_measurement_list_tile.dart';
 import 'package:health_connector_toolbox/src/features/read_health_records/widgets/health_record_list_tiles/instant_health_record_list_tiles/diastolic_blood_pressure_list_tile.dart';
 import 'package:health_connector_toolbox/src/features/read_health_records/widgets/health_record_list_tiles/instant_health_record_list_tiles/energy_nutrient_list_tile.dart';
 import 'package:health_connector_toolbox/src/features/read_health_records/widgets/health_record_list_tiles/instant_health_record_list_tiles/heart_rate_measurement_list_tile.dart';
@@ -20,6 +21,7 @@ import 'package:health_connector_toolbox/src/features/read_health_records/widget
 import 'package:health_connector_toolbox/src/features/read_health_records/widgets/health_record_list_tiles/interval_health_record_list_tiles/simple_interval_measurement_list_tile.dart';
 import 'package:health_connector_toolbox/src/features/read_health_records/widgets/health_record_list_tiles/interval_health_record_list_tiles/sleep_session_list_tile.dart';
 import 'package:health_connector_toolbox/src/features/read_health_records/widgets/health_record_list_tiles/interval_health_record_list_tiles/sleep_stage_list_tile.dart';
+import 'package:health_connector_toolbox/src/features/read_health_records/widgets/health_record_list_tiles/series_health_record_list_tiles/cycling_pedaling_cadence_series_list_tile.dart';
 import 'package:health_connector_toolbox/src/features/read_health_records/widgets/health_record_list_tiles/series_health_record_list_tiles/heart_rate_series_list_tile.dart';
 import 'package:health_connector_toolbox/src/features/read_health_records/widgets/health_record_list_tiles/series_health_record_list_tiles/power_series_list_tile.dart';
 import 'package:health_connector_toolbox/src/features/read_health_records/widgets/health_record_list_tiles/series_health_record_list_tiles/speed_activity_list_tile.dart';
@@ -76,6 +78,16 @@ final class HealthRecordListTile extends StatelessWidget {
           icon: AppIcons.favorite,
           titleBuilder: (r) => '${r.beatsPerMinute.value} ${AppTexts.bpm}',
           valueExtractor: (r) => r.beatsPerMinute,
+          onDelete: onDelete,
+        ),
+      final CyclingPedalingCadenceMeasurementRecord r =>
+        CyclingPedalingCadenceMeasurementTile(
+          record: r,
+          onDelete: onDelete,
+        ),
+      final CyclingPedalingCadenceSeriesRecord r =>
+        CyclingPedalingCadenceSeriesTile(
+          record: r,
           onDelete: onDelete,
         ),
 

--- a/examples/health_connector_toolbox/lib/src/features/read_health_records/widgets/health_record_list_tiles/instant_health_record_list_tiles/cycling_pedaling_cadence_measurement_list_tile.dart
+++ b/examples/health_connector_toolbox/lib/src/features/read_health_records/widgets/health_record_list_tiles/instant_health_record_list_tiles/cycling_pedaling_cadence_measurement_list_tile.dart
@@ -1,0 +1,34 @@
+import 'package:flutter/material.dart';
+import 'package:health_connector/health_connector_internal.dart';
+import 'package:health_connector_toolbox/src/common/constants/app_icons.dart';
+import 'package:health_connector_toolbox/src/common/constants/app_texts.dart';
+import 'package:health_connector_toolbox/src/features/read_health_records/widgets/health_record_list_tiles/health_record_list_tile_subtitle.dart';
+import 'package:health_connector_toolbox/src/features/read_health_records/widgets/health_record_list_tiles/instant_health_record_list_tiles/instant_health_record_list_tile.dart';
+
+/// Widget for displaying cycling pedaling cadence measurement record tiles.
+@immutable
+final class CyclingPedalingCadenceMeasurementTile extends StatelessWidget {
+  const CyclingPedalingCadenceMeasurementTile({
+    required this.record,
+    required this.onDelete,
+    super.key,
+  });
+
+  final CyclingPedalingCadenceMeasurementRecord record;
+  final VoidCallback onDelete;
+
+  @override
+  Widget build(BuildContext context) {
+    return InstantHealthRecordTile<CyclingPedalingCadenceMeasurementRecord>(
+      record: record,
+      icon: AppIcons.speed,
+      title: '${record.revolutionsPerMinute.value} ${AppTexts.rpm}',
+      subtitleBuilder: (r, ctx) => HealthRecordListTileSubtitle.instant(
+        time: r.time,
+        recordingMethod: r.metadata.recordingMethod.name,
+      ),
+      detailRowsBuilder: (r, ctx) => [],
+      onDelete: onDelete,
+    );
+  }
+}

--- a/examples/health_connector_toolbox/lib/src/features/read_health_records/widgets/health_record_list_tiles/series_health_record_list_tiles/cycling_pedaling_cadence_series_list_tile.dart
+++ b/examples/health_connector_toolbox/lib/src/features/read_health_records/widgets/health_record_list_tiles/series_health_record_list_tiles/cycling_pedaling_cadence_series_list_tile.dart
@@ -1,0 +1,52 @@
+import 'package:flutter/material.dart';
+import 'package:health_connector/health_connector_internal.dart';
+import 'package:health_connector_toolbox/src/common/constants/app_icons.dart';
+import 'package:health_connector_toolbox/src/common/constants/app_texts.dart';
+import 'package:health_connector_toolbox/src/features/read_health_records/widgets/cycling_pedaling_cadence_series_record_samples_list.dart';
+import 'package:health_connector_toolbox/src/features/read_health_records/widgets/health_record_list_tiles/series_health_record_list_tiles/series_health_record_list_tile.dart';
+
+/// Widget for displaying cycling pedaling cadence series record tiles.
+@immutable
+final class CyclingPedalingCadenceSeriesTile extends StatelessWidget {
+  const CyclingPedalingCadenceSeriesTile({
+    required this.record,
+    required this.onDelete,
+    super.key,
+  });
+
+  final CyclingPedalingCadenceSeriesRecord record;
+  final VoidCallback onDelete;
+
+  @override
+  Widget build(BuildContext context) {
+    return SeriesHealthRecordTile<
+      CyclingPedalingCadenceSeriesRecord,
+      CyclingPedalingCadenceMeasurement
+    >(
+      record: record,
+      icon: AppIcons.speed,
+      title: '${AppTexts.cyclingPedalingCadence} Series',
+      subtitleBuilder: (r, ctx) => Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Text(
+            '${AppTexts.recording}: ${r.metadata.recordingMethod.name}',
+            style: Theme.of(ctx).textTheme.bodySmall,
+          ),
+          Text(
+            '${AppTexts.average}: ${r.averageRpm.value} ${AppTexts.rpm}',
+            style: Theme.of(ctx).textTheme.bodySmall,
+          ),
+          Text(
+            '${r.samples.length} ${AppTexts.cyclingPedalingCadenceSamples}',
+            style: Theme.of(ctx).textTheme.bodySmall,
+          ),
+        ],
+      ),
+      detailRowsBuilder: (r, ctx) => [],
+      samplesBuilder: (samples, ctx) =>
+          CyclingPedalingCadenceSeriesRecordSamplesList(samples: samples),
+      onDelete: onDelete,
+    );
+  }
+}

--- a/examples/health_connector_toolbox/lib/src/features/write_health_record/pages/health_record_write_page.dart
+++ b/examples/health_connector_toolbox/lib/src/features/write_health_record/pages/health_record_write_page.dart
@@ -11,6 +11,7 @@ import 'package:health_connector_toolbox/src/features/write_health_record/widget
 import 'package:health_connector_toolbox/src/features/write_health_record/widgets/write_forms/instant_health_record_write_forms/blood_glucose_health_record_write_form.dart';
 import 'package:health_connector_toolbox/src/features/write_health_record/widgets/write_forms/instant_health_record_write_forms/body_fat_percentage_health_record_write_form.dart';
 import 'package:health_connector_toolbox/src/features/write_health_record/widgets/write_forms/instant_health_record_write_forms/body_temperature_health_record_write_form.dart';
+import 'package:health_connector_toolbox/src/features/write_health_record/widgets/write_forms/instant_health_record_write_forms/cycling_pedaling_cadence_measurement_health_record_write_form.dart';
 import 'package:health_connector_toolbox/src/features/write_health_record/widgets/write_forms/instant_health_record_write_forms/cycling_power_health_record_write_form.dart';
 import 'package:health_connector_toolbox/src/features/write_health_record/widgets/write_forms/instant_health_record_write_forms/diastolic_blood_pressure_health_record_write_form.dart';
 import 'package:health_connector_toolbox/src/features/write_health_record/widgets/write_forms/instant_health_record_write_forms/heart_rate_measurement_health_record_write_form.dart';
@@ -47,6 +48,7 @@ import 'package:health_connector_toolbox/src/features/write_health_record/widget
 import 'package:health_connector_toolbox/src/features/write_health_record/widgets/write_forms/interval_health_record_write_forms/walking_running_distance_health_record_write_form.dart';
 import 'package:health_connector_toolbox/src/features/write_health_record/widgets/write_forms/interval_health_record_write_forms/wheelchair_distance_health_record_write_form.dart';
 import 'package:health_connector_toolbox/src/features/write_health_record/widgets/write_forms/interval_health_record_write_forms/wheelchair_pushes_health_record_write_form.dart';
+import 'package:health_connector_toolbox/src/features/write_health_record/widgets/write_forms/series_health_record_write_forms/cycling_pedaling_cadence_series_health_record_write_form.dart';
 import 'package:health_connector_toolbox/src/features/write_health_record/widgets/write_forms/series_health_record_write_forms/heart_rate_series_health_record_write_form.dart';
 import 'package:health_connector_toolbox/src/features/write_health_record/widgets/write_forms/series_health_record_write_forms/power_series_health_record_write_form.dart';
 import 'package:health_connector_toolbox/src/features/write_health_record/widgets/write_forms/series_health_record_write_forms/sleep_session_health_record_write_form.dart';
@@ -162,6 +164,16 @@ class _HealthRecordWritePageState extends State<HealthRecordWritePage>
       ),
       HeartRateMeasurementRecordHealthDataType _ =>
         HeartRateMeasurementWriteForm(
+          healthPlatform: _notifier.healthPlatform,
+          onSubmit: _onSubmit,
+        ),
+      CyclingPedalingCadenceMeasurementRecordHealthDataType _ =>
+        CyclingPedalingCadenceMeasurementWriteForm(
+          healthPlatform: _notifier.healthPlatform,
+          onSubmit: _onSubmit,
+        ),
+      CyclingPedalingCadenceSeriesRecordHealthDataType _ =>
+        CyclingPedalingCadenceSeriesWriteForm(
           healthPlatform: _notifier.healthPlatform,
           onSubmit: _onSubmit,
         ),

--- a/examples/health_connector_toolbox/lib/src/features/write_health_record/widgets/write_form_fields/cycling_pedaling_cadence_measurements_write_form_field_group.dart
+++ b/examples/health_connector_toolbox/lib/src/features/write_health_record/widgets/write_form_fields/cycling_pedaling_cadence_measurements_write_form_field_group.dart
@@ -1,0 +1,67 @@
+import 'package:flutter/material.dart';
+import 'package:health_connector/health_connector_internal.dart'
+    show CyclingPedalingCadenceMeasurement, Number;
+import 'package:health_connector_toolbox/src/common/constants/app_icons.dart';
+import 'package:health_connector_toolbox/src/common/constants/app_texts.dart';
+import 'package:health_connector_toolbox/src/features/write_health_record/widgets/write_form_fields/record_sample_form_field_group.dart';
+
+/// A form field widget for managing multiple cycling pedaling cadence
+/// measurement samples.
+@immutable
+final class CyclingPedalingCadenceMeasurementsWriteFormFieldGroup
+    extends StatelessWidget {
+  const CyclingPedalingCadenceMeasurementsWriteFormFieldGroup({
+    required this.startDateTime,
+    required this.endDateTime,
+    required this.onChanged,
+    super.key,
+    this.initialSamples,
+    this.validator,
+  });
+
+  final DateTime? startDateTime;
+  final DateTime? endDateTime;
+  final ValueChanged<List<CyclingPedalingCadenceMeasurement>?> onChanged;
+  final List<CyclingPedalingCadenceMeasurement>? initialSamples;
+  final String? Function(List<CyclingPedalingCadenceMeasurement>?)? validator;
+
+  @override
+  Widget build(BuildContext context) {
+    return RecordSampleFormFieldGroup<CyclingPedalingCadenceMeasurement, int>(
+      title: AppTexts.cyclingPedalingCadenceSamples,
+      startDateTime: startDateTime,
+      endDateTime: endDateTime,
+      onChanged: onChanged,
+      initialSamples: initialSamples,
+      validator: validator,
+      defaultValue: 60,
+      valueInputBuilder: (index, rpm, onRpmChanged) {
+        return TextFormField(
+          initialValue: rpm?.toString() ?? '60',
+          decoration: const InputDecoration(
+            labelText: AppTexts.sampleRpm,
+            border: OutlineInputBorder(),
+            prefixIcon: Icon(AppIcons.numbers),
+          ),
+          keyboardType: TextInputType.number,
+          onChanged: (value) {
+            final parsedRpm = int.tryParse(value);
+            if (parsedRpm != null) {
+              onRpmChanged(parsedRpm);
+            }
+          },
+        );
+      },
+      sampleFactory: (time, _, rpm) => CyclingPedalingCadenceMeasurement(
+        time: time,
+        revolutionsPerMinute: Number(rpm),
+      ),
+      sampleExtractor: (sample) => (
+        time: sample.time,
+        endTime: null as DateTime?,
+        value: sample.revolutionsPerMinute.value as int,
+      ),
+      valueValidator: (rpm) => rpm != null && rpm > 0,
+    );
+  }
+}

--- a/examples/health_connector_toolbox/lib/src/features/write_health_record/widgets/write_forms/instant_health_record_write_forms/cycling_pedaling_cadence_measurement_health_record_write_form.dart
+++ b/examples/health_connector_toolbox/lib/src/features/write_health_record/widgets/write_forms/instant_health_record_write_forms/cycling_pedaling_cadence_measurement_health_record_write_form.dart
@@ -1,0 +1,39 @@
+import 'package:flutter/foundation.dart';
+import 'package:health_connector/health_connector_internal.dart';
+import 'package:health_connector_toolbox/src/features/write_health_record/widgets/write_forms/instant_health_record_write_form.dart';
+
+/// Form widget for cycling pedaling cadence measurement records.
+@immutable
+final class CyclingPedalingCadenceMeasurementWriteForm
+    extends InstantHealthRecordWriteForm {
+  const CyclingPedalingCadenceMeasurementWriteForm({
+    required super.healthPlatform,
+    required super.onSubmit,
+    super.key,
+  }) : super(
+         dataType: HealthDataType.cyclingPedalingCadenceMeasurementRecord,
+       );
+
+  @override
+  CyclingPedalingCadenceMeasurementFormState createState() =>
+      CyclingPedalingCadenceMeasurementFormState();
+}
+
+/// State for cycling pedaling cadence measurement form widget.
+final class CyclingPedalingCadenceMeasurementFormState
+    extends
+        InstantHealthRecordFormState<
+          CyclingPedalingCadenceMeasurementWriteForm
+        > {
+  @override
+  HealthRecord buildRecord() {
+    return CyclingPedalingCadenceMeasurementRecord(
+      id: HealthRecordId.none,
+      measurement: CyclingPedalingCadenceMeasurement(
+        time: startDateTime!,
+        revolutionsPerMinute: value! as Number,
+      ),
+      metadata: metadata,
+    );
+  }
+}

--- a/examples/health_connector_toolbox/lib/src/features/write_health_record/widgets/write_forms/series_health_record_write_forms/cycling_pedaling_cadence_series_health_record_write_form.dart
+++ b/examples/health_connector_toolbox/lib/src/features/write_health_record/widgets/write_forms/series_health_record_write_forms/cycling_pedaling_cadence_series_health_record_write_form.dart
@@ -1,0 +1,52 @@
+import 'package:flutter/material.dart';
+import 'package:health_connector/health_connector_internal.dart';
+import 'package:health_connector_toolbox/src/features/write_health_record/widgets/write_form_fields/cycling_pedaling_cadence_measurements_write_form_field_group.dart';
+import 'package:health_connector_toolbox/src/features/write_health_record/widgets/write_forms/series_health_record_write_form.dart';
+
+/// Form widget for cycling pedaling cadence series records.
+@immutable
+final class CyclingPedalingCadenceSeriesWriteForm
+    extends SeriesHealthRecordWriteForm<CyclingPedalingCadenceMeasurement> {
+  const CyclingPedalingCadenceSeriesWriteForm({
+    required super.healthPlatform,
+    required super.onSubmit,
+    super.key,
+  });
+
+  @override
+  CyclingPedalingCadenceSeriesFormState createState() =>
+      CyclingPedalingCadenceSeriesFormState();
+}
+
+/// State for cycling pedaling cadence series form widget.
+final class CyclingPedalingCadenceSeriesFormState
+    extends
+        SeriesHealthRecordFormState<
+          CyclingPedalingCadenceMeasurement,
+          CyclingPedalingCadenceSeriesWriteForm
+        > {
+  @override
+  List<Widget> buildSeriesFields(BuildContext context) {
+    return [
+      CyclingPedalingCadenceMeasurementsWriteFormFieldGroup(
+        startDateTime: startDateTime,
+        endDateTime: endDateTime,
+        onChanged: (newSamples) {
+          setState(() {
+            samples = newSamples ?? [];
+          });
+        },
+      ),
+    ];
+  }
+
+  @override
+  HealthRecord buildRecord() {
+    return CyclingPedalingCadenceSeriesRecord(
+      startTime: startDateTime!,
+      endTime: endDateTime!,
+      samples: samples,
+      metadata: metadata,
+    );
+  }
+}

--- a/packages/health_connector_core/lib/health_connector_core_internal.dart
+++ b/packages/health_connector_core/lib/health_connector_core_internal.dart
@@ -72,6 +72,7 @@ export 'src/models/health_platform.dart';
 export 'src/models/health_platform_features/health_platform_feature.dart';
 export 'src/models/health_records/blood_pressure_records/blood_pressure_body_position.dart';
 export 'src/models/health_records/blood_pressure_records/blood_pressure_measurement_location.dart';
+export 'src/models/health_records/cycling_pedaling_cadence_measurement.dart';
 // Models - Health Records
 export 'src/models/health_records/health_record.dart'
     hide MacronutrientRecord, MineralNutrientRecord, VitaminNutrientRecord;

--- a/packages/health_connector_core/lib/src/annotations/since.dart
+++ b/packages/health_connector_core/lib/src/annotations/since.dart
@@ -48,3 +48,6 @@ const sinceV2_0_0 = Since('2.0.0');
 
 /// Marks APIs added in version 2.1.0 of the SDK.
 const sinceV2_1_0 = Since('2.1.0');
+
+/// Marks APIs added in version 2.2.0 of the SDK.
+const sinceV2_2_0 = Since('2.2.0');

--- a/packages/health_connector_core/lib/src/models/health_data_types/cycling_pedaling_cadence_measurement_record_health_data_type.dart
+++ b/packages/health_connector_core/lib/src/models/health_data_types/cycling_pedaling_cadence_measurement_record_health_data_type.dart
@@ -1,0 +1,187 @@
+part of 'health_data_type.dart';
+
+/// Cycling pedaling cadence measurement data type.
+///
+/// Represents individual cycling pedaling cadence measurements in
+/// revolutions per minute (RPM).
+/// Each measurement is a discrete reading typically taken at a specific point
+/// in time during cycling activity.
+///
+/// ## Measurement Unit
+///
+/// Values are measured as [Number] (revolutions per minute).
+///
+/// ## Platform Mapping
+///
+/// - **iOS HealthKit Only**:
+///   [`HKQuantityTypeIdentifier.cyclingCadence`](https://developer.apple.com/documentation/healthkit/hkquantitytypeidentifier/cyclingcadence)
+/// - **Android Health Connect**: Use
+///   [CyclingPedalingCadenceSeriesRecordHealthDataType] instead
+///
+/// ## Capabilities
+///
+/// - Readable: Query cycling pedaling cadence measurements
+/// - Writeable: Write cycling pedaling cadence measurements
+/// - Aggregatable: Calculate avg, min, max cadence
+/// - Deletable: Delete records by IDs or time range
+///
+/// ## Platform Notes
+///
+/// On iOS, cycling pedaling cadence data is stored as individual
+/// measurement samples. Each record has its own UUID and can be queried
+/// independently.
+///
+/// ## See also
+///
+/// - [CyclingPedalingCadenceMeasurementRecord]
+///
+/// {@category Health Data Types}
+@sinceV2_2_0
+@immutable
+final class CyclingPedalingCadenceMeasurementRecordHealthDataType
+    extends HealthDataType<CyclingPedalingCadenceMeasurementRecord, Number>
+    implements
+        ReadableHealthDataType<CyclingPedalingCadenceMeasurementRecord>,
+        WriteableHealthDataType,
+        AvgAggregatableHealthDataType<
+          CyclingPedalingCadenceMeasurementRecord,
+          Number
+        >,
+        MinAggregatableHealthDataType<
+          CyclingPedalingCadenceMeasurementRecord,
+          Number
+        >,
+        MaxAggregatableHealthDataType<
+          CyclingPedalingCadenceMeasurementRecord,
+          Number
+        >,
+        DeletableHealthDataType<CyclingPedalingCadenceMeasurementRecord> {
+  /// Creates a cycling pedaling cadence measurement data type.
+  ///
+  /// This is a constant constructor used internally. To reference this data
+  /// type, use the singleton instance from [HealthDataType].
+  @internal
+  const CyclingPedalingCadenceMeasurementRecordHealthDataType();
+
+  @override
+  List<HealthPlatform> get supportedHealthPlatforms => [
+    HealthPlatform.appleHealth,
+  ];
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is CyclingPedalingCadenceMeasurementRecordHealthDataType &&
+          runtimeType == other.runtimeType;
+
+  @override
+  int get hashCode => runtimeType.hashCode;
+
+  @override
+  List<AggregationMetric> get supportedAggregationMetrics => [
+    AggregationMetric.avg,
+    AggregationMetric.min,
+    AggregationMetric.max,
+  ];
+
+  @override
+  HealthDataPermission get readPermission => HealthDataPermission.read(this);
+
+  @override
+  ReadRecordByIdRequest<CyclingPedalingCadenceMeasurementRecord> readById(
+    HealthRecordId id,
+  ) {
+    return ReadRecordByIdRequest(dataType: this, id: id);
+  }
+
+  @override
+  ReadRecordsInTimeRangeRequest<CyclingPedalingCadenceMeasurementRecord>
+  readInTimeRange({
+    required DateTime startTime,
+    required DateTime endTime,
+    List<DataOrigin> dataOrigins = const [],
+    int pageSize = HealthConnectorConfigConstants.defaultPageSize,
+    String? pageToken,
+  }) {
+    return ReadRecordsInTimeRangeRequest(
+      dataType: this,
+      dataOrigins: dataOrigins,
+      startTime: startTime,
+      endTime: endTime,
+      pageSize: pageSize,
+      pageToken: pageToken,
+    );
+  }
+
+  @override
+  HealthDataPermission get writePermission => HealthDataPermission.write(this);
+
+  @override
+  AggregateRequest<CyclingPedalingCadenceMeasurementRecord, Number>
+  aggregateAvg({
+    required DateTime startTime,
+    required DateTime endTime,
+  }) {
+    return CommonAggregateRequest(
+      dataType: this,
+      aggregationMetric: AggregationMetric.avg,
+      startTime: startTime,
+      endTime: endTime,
+    );
+  }
+
+  @override
+  AggregateRequest<CyclingPedalingCadenceMeasurementRecord, Number>
+  aggregateMin({
+    required DateTime startTime,
+    required DateTime endTime,
+  }) {
+    return CommonAggregateRequest(
+      dataType: this,
+      aggregationMetric: AggregationMetric.min,
+      startTime: startTime,
+      endTime: endTime,
+    );
+  }
+
+  @override
+  AggregateRequest<CyclingPedalingCadenceMeasurementRecord, Number>
+  aggregateMax({
+    required DateTime startTime,
+    required DateTime endTime,
+  }) {
+    return CommonAggregateRequest(
+      dataType: this,
+      aggregationMetric: AggregationMetric.max,
+      startTime: startTime,
+      endTime: endTime,
+    );
+  }
+
+  @override
+  List<Permission> get permissions => [readPermission, writePermission];
+
+  @override
+  DeleteRecordsByIdsRequest<CyclingPedalingCadenceMeasurementRecord>
+  deleteByIds(
+    List<HealthRecordId> recordIds,
+  ) {
+    return DeleteRecordsByIdsRequest(
+      dataType: this,
+      recordIds: recordIds,
+    );
+  }
+
+  @override
+  DeleteRecordsInTimeRangeRequest<CyclingPedalingCadenceMeasurementRecord>
+  deleteInTimeRange({
+    required DateTime startTime,
+    required DateTime endTime,
+  }) {
+    return DeleteRecordsInTimeRangeRequest(
+      dataType: this,
+      startTime: startTime,
+      endTime: endTime,
+    );
+  }
+}

--- a/packages/health_connector_core/lib/src/models/health_data_types/cycling_pedaling_cadence_series_record_health_data_type.dart
+++ b/packages/health_connector_core/lib/src/models/health_data_types/cycling_pedaling_cadence_series_record_health_data_type.dart
@@ -1,0 +1,173 @@
+part of 'health_data_type.dart';
+
+/// Health data type for Android cycling pedaling cadence series records.
+///
+/// Cycling pedaling cadence series records on Android are container
+/// records with embedded RPM samples. Each record has a single ID that
+/// encompasses all measurements.
+///
+/// ## Platform Mapping
+///
+/// - **Android Health Connect**:
+///   [`CyclingPedalingCadenceRecord`](https://developer.android.com/reference/kotlin/androidx/health/connect/client/records/CyclingPedalingCadenceRecord)
+/// - **iOS HealthKit**: Not supported (iOS uses discrete
+///   [CyclingPedalingCadenceMeasurementRecordHealthDataType] samples)
+///
+/// ## Capabilities
+///
+/// - Readable: Query cycling pedaling cadence series
+/// - Writeable: Write cycling pedaling cadence series
+/// - Aggregatable: Calculate avg, min, max cadence
+/// - Deletable: Delete records by IDs or time range
+///
+/// ## See also
+///
+/// - [CyclingPedalingCadenceSeriesRecord]
+///
+/// {@category Health Data Types}
+@sinceV2_2_0
+@supportedOnHealthConnect
+@immutable
+final class CyclingPedalingCadenceSeriesRecordHealthDataType
+    extends HealthDataType<CyclingPedalingCadenceSeriesRecord, Number>
+    implements
+        ReadableHealthDataType<CyclingPedalingCadenceSeriesRecord>,
+        WriteableHealthDataType,
+        AvgAggregatableHealthDataType<
+          CyclingPedalingCadenceSeriesRecord,
+          Number
+        >,
+        MinAggregatableHealthDataType<
+          CyclingPedalingCadenceSeriesRecord,
+          Number
+        >,
+        MaxAggregatableHealthDataType<
+          CyclingPedalingCadenceSeriesRecord,
+          Number
+        >,
+        DeletableHealthDataType<CyclingPedalingCadenceSeriesRecord> {
+  /// Creates a cycling pedaling cadence series data type.
+  ///
+  /// This is a constant constructor used internally. To reference this data
+  /// type, use the singleton instance from [HealthDataType].
+  @internal
+  const CyclingPedalingCadenceSeriesRecordHealthDataType();
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is CyclingPedalingCadenceSeriesRecordHealthDataType &&
+          runtimeType == other.runtimeType;
+
+  @override
+  int get hashCode => runtimeType.hashCode;
+
+  @override
+  List<AggregationMetric> get supportedAggregationMetrics => [
+    AggregationMetric.avg,
+    AggregationMetric.min,
+    AggregationMetric.max,
+  ];
+
+  @override
+  List<HealthPlatform> get supportedHealthPlatforms => [
+    HealthPlatform.healthConnect,
+  ];
+
+  @override
+  HealthDataPermission get readPermission => HealthDataPermission.read(this);
+
+  @override
+  ReadRecordByIdRequest<CyclingPedalingCadenceSeriesRecord> readById(
+    HealthRecordId id,
+  ) {
+    return ReadRecordByIdRequest(dataType: this, id: id);
+  }
+
+  @override
+  ReadRecordsInTimeRangeRequest<CyclingPedalingCadenceSeriesRecord>
+  readInTimeRange({
+    required DateTime startTime,
+    required DateTime endTime,
+    List<DataOrigin> dataOrigins = const [],
+    int pageSize = HealthConnectorConfigConstants.defaultPageSize,
+    String? pageToken,
+  }) {
+    return ReadRecordsInTimeRangeRequest(
+      dataType: this,
+      dataOrigins: dataOrigins,
+      startTime: startTime,
+      endTime: endTime,
+      pageSize: pageSize,
+      pageToken: pageToken,
+    );
+  }
+
+  @override
+  HealthDataPermission get writePermission => HealthDataPermission.write(this);
+
+  @override
+  AggregateRequest<CyclingPedalingCadenceSeriesRecord, Number> aggregateAvg({
+    required DateTime startTime,
+    required DateTime endTime,
+  }) {
+    return CommonAggregateRequest(
+      dataType: this,
+      aggregationMetric: AggregationMetric.avg,
+      startTime: startTime,
+      endTime: endTime,
+    );
+  }
+
+  @override
+  AggregateRequest<CyclingPedalingCadenceSeriesRecord, Number> aggregateMin({
+    required DateTime startTime,
+    required DateTime endTime,
+  }) {
+    return CommonAggregateRequest(
+      dataType: this,
+      aggregationMetric: AggregationMetric.min,
+      startTime: startTime,
+      endTime: endTime,
+    );
+  }
+
+  @override
+  AggregateRequest<CyclingPedalingCadenceSeriesRecord, Number> aggregateMax({
+    required DateTime startTime,
+    required DateTime endTime,
+  }) {
+    return CommonAggregateRequest(
+      dataType: this,
+      aggregationMetric: AggregationMetric.max,
+      startTime: startTime,
+      endTime: endTime,
+    );
+  }
+
+  @override
+  List<Permission> get permissions => [readPermission, writePermission];
+
+  @override
+  DeleteRecordsByIdsRequest<CyclingPedalingCadenceSeriesRecord> deleteByIds(
+    List<HealthRecordId> recordIds,
+  ) {
+    return DeleteRecordsByIdsRequest(
+      dataType: this,
+      recordIds: recordIds,
+    );
+  }
+
+  @override
+  DeleteRecordsInTimeRangeRequest<CyclingPedalingCadenceSeriesRecord>
+  deleteInTimeRange({
+    required DateTime startTime,
+    required DateTime endTime,
+  }) {
+    return DeleteRecordsInTimeRangeRequest(
+      dataType: this,
+      startTime: startTime,
+      endTime: endTime,
+    );
+  }
+}

--- a/packages/health_connector_core/lib/src/models/health_data_types/health_data_type.dart
+++ b/packages/health_connector_core/lib/src/models/health_data_types/health_data_type.dart
@@ -17,6 +17,8 @@ import 'package:health_connector_core/src/models/health_records/health_record.da
         CholesterolNutrientRecord,
         CrossCountrySkiingDistanceRecord,
         CyclingDistanceRecord,
+        CyclingPedalingCadenceMeasurementRecord,
+        CyclingPedalingCadenceSeriesRecord,
         CyclingPowerRecord,
         DiastolicBloodPressureRecord,
         DietaryFiberNutrientRecord,
@@ -114,6 +116,8 @@ part 'exercise_session_health_data_type.dart';
 part 'floors_climbed_health_data_type.dart';
 part 'heart_rate_measurement_record_health_data_type.dart';
 part 'heart_rate_series_record_health_data_type.dart';
+part 'cycling_pedaling_cadence_measurement_record_health_data_type.dart';
+part 'cycling_pedaling_cadence_series_record_health_data_type.dart';
 part 'height_health_data_type.dart';
 part 'hydration_health_data_type.dart';
 part 'lean_body_mass_health_data_type.dart';
@@ -537,6 +541,29 @@ sealed class HealthDataType<R extends HealthRecord, U extends MeasurementUnit>
   @supportedOnAppleHealth
   static const cyclingPower = CyclingPowerDataType();
 
+  /// Cycling pedaling cadence series record data type.
+  ///
+  /// Represents cycling cadence measurements in revolutions per minute (RPM).
+  /// Each record contains multiple cadence samples over a time interval.
+  ///
+  /// Supports AVG, MIN, MAX aggregation.
+  @sinceV2_2_0
+  @supportedOnHealthConnect
+  static const cyclingPedalingCadenceSeriesRecord =
+      CyclingPedalingCadenceSeriesRecordHealthDataType();
+
+  /// Cycling pedaling cadence measurement record data type.
+  ///
+  /// Represents individual cycling cadence measurements in revolutions per
+  /// minute (RPM).
+  /// Each record is a discrete measurement at a specific point in time.
+  ///
+  /// Supports AVG, MIN, MAX aggregation.
+  @sinceV2_2_0
+  @supportedOnAppleHealth
+  static const cyclingPedalingCadenceMeasurementRecord =
+      CyclingPedalingCadenceMeasurementRecordHealthDataType();
+
   /// Respiratory rate data type.
   ///
   /// Represents the number of breaths a person takes per minute.
@@ -821,6 +848,8 @@ sealed class HealthDataType<R extends HealthRecord, U extends MeasurementUnit>
     oxygenSaturation,
     powerSeries,
     cyclingPower,
+    cyclingPedalingCadenceMeasurementRecord,
+    cyclingPedalingCadenceSeriesRecord,
     pantothenicAcid,
     phosphorus,
     polyunsaturatedFat,

--- a/packages/health_connector_core/lib/src/models/health_records/cycling_pedaling_cadence_measurement.dart
+++ b/packages/health_connector_core/lib/src/models/health_records/cycling_pedaling_cadence_measurement.dart
@@ -1,0 +1,38 @@
+import 'package:health_connector_core/src/models/measurement_units/measurement_unit.dart';
+import 'package:meta/meta.dart';
+
+/// Represents a single cycling pedaling cadence measurement at a specific
+/// point in time.
+///
+/// **Note**: This class does not have an ID or metadata. Those are
+/// properties of the record that contains the measurement.
+///
+/// {@category Health Records}
+@immutable
+final class CyclingPedalingCadenceMeasurement {
+  /// Creates a cycling pedaling cadence measurement.
+  const CyclingPedalingCadenceMeasurement({
+    required this.time,
+    required this.revolutionsPerMinute,
+  });
+
+  /// The timestamp when this cadence measurement was taken, stored as a
+  /// UTC instant.
+  ///
+  /// Timezone offset information is provided by the parent record.
+  final DateTime time;
+
+  /// The cycling cadence value in revolutions per minute (RPM).
+  final Number revolutionsPerMinute;
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is CyclingPedalingCadenceMeasurement &&
+          runtimeType == other.runtimeType &&
+          time == other.time &&
+          revolutionsPerMinute == other.revolutionsPerMinute;
+
+  @override
+  int get hashCode => time.hashCode ^ revolutionsPerMinute.hashCode;
+}

--- a/packages/health_connector_core/lib/src/models/health_records/cycling_pedaling_cadence_measurement_record.dart
+++ b/packages/health_connector_core/lib/src/models/health_records/cycling_pedaling_cadence_measurement_record.dart
@@ -1,0 +1,105 @@
+part of 'health_record.dart';
+
+/// Represents a single cycling pedaling cadence measurement.
+///
+/// Each cycling pedaling cadence measurement record represents one RPM
+/// measurement at a specific time.
+///
+/// ## Platform Mapping
+///
+/// - **Android Health Connect**: Not supported
+///   (Use [CyclingPedalingCadenceSeriesRecord])
+/// - **iOS HealthKit**:
+///   [`HKQuantityTypeIdentifier.cyclingCadence`](https://developer.apple.com/documentation/healthkit/hkquantitytypeidentifier/cyclingcadence)
+///
+/// ## Example
+///
+/// ```dart
+/// final record = CyclingPedalingCadenceMeasurementRecord(
+///   id: HealthRecordId('ABC-123'),
+///   time: DateTime.now(),
+///   measurement: CyclingPedalingCadenceMeasurement(
+///     time: DateTime.now(),
+///     revolutionsPerMinute: Number(85),
+///   ),
+///   metadata: Metadata.automaticallyRecorded(
+///     dataOrigin: DataOrigin(packageName: 'com.apple.health'),
+///   ),
+/// );
+/// ```
+///
+/// ## See also
+///
+/// - [CyclingPedalingCadenceMeasurementRecordHealthDataType]
+///
+/// {@category Health Records}
+@sinceV2_2_0
+@supportedOnAppleHealth
+@immutable
+final class CyclingPedalingCadenceMeasurementRecord
+    extends InstantHealthRecord {
+  /// Creates a cycling pedaling cadence measurement record.
+  factory CyclingPedalingCadenceMeasurementRecord({
+    required HealthRecordId id,
+    required Metadata metadata,
+    required CyclingPedalingCadenceMeasurement measurement,
+    int? zoneOffsetSeconds,
+  }) {
+    return CyclingPedalingCadenceMeasurementRecord._(
+      id: id,
+      metadata: metadata,
+      time: measurement.time,
+      measurement: measurement,
+      zoneOffsetSeconds: zoneOffsetSeconds,
+    );
+  }
+
+  const CyclingPedalingCadenceMeasurementRecord._({
+    required super.id,
+    required super.metadata,
+    required super.time,
+    required this.measurement,
+    super.zoneOffsetSeconds,
+  });
+
+  /// The cycling pedaling cadence measurement.
+  final CyclingPedalingCadenceMeasurement measurement;
+
+  /// The time when this measurement was taken.
+  ///
+  /// Convenience getter that returns the time from the measurement.
+  @override
+  DateTime get time => measurement.time;
+
+  /// The cycling cadence value in revolutions per minute (RPM).
+  ///
+  /// Convenience getter that returns the RPM from the measurement.
+  Number get revolutionsPerMinute => measurement.revolutionsPerMinute;
+
+  /// Creates a copy with the given fields replaced with the new values.
+  CyclingPedalingCadenceMeasurementRecord copyWith({
+    HealthRecordId? id,
+    Metadata? metadata,
+    CyclingPedalingCadenceMeasurement? measurement,
+    int? zoneOffsetSeconds,
+  }) {
+    return CyclingPedalingCadenceMeasurementRecord(
+      id: id ?? this.id,
+      metadata: metadata ?? this.metadata,
+      measurement: measurement ?? this.measurement,
+      zoneOffsetSeconds: zoneOffsetSeconds ?? this.zoneOffsetSeconds,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is CyclingPedalingCadenceMeasurementRecord &&
+          runtimeType == other.runtimeType &&
+          id == other.id &&
+          metadata == other.metadata &&
+          measurement == other.measurement;
+
+  @override
+  int get hashCode => id.hashCode ^ metadata.hashCode ^ measurement.hashCode;
+}

--- a/packages/health_connector_core/lib/src/models/health_records/cycling_pedaling_cadence_series_record.dart
+++ b/packages/health_connector_core/lib/src/models/health_records/cycling_pedaling_cadence_series_record.dart
@@ -1,0 +1,161 @@
+part of 'health_record.dart';
+
+/// Represents a series of cycling pedaling cadence measurements over a
+/// time interval.
+///
+/// A cycling pedaling cadence series record is a container with a time
+/// range and multiple RPM measurements taken during that period.
+///
+/// ## Platform Mapping
+///
+/// - **Android Health Connect**:
+///   [`CyclingPedalingCadenceRecord`](https://developer.android.com/reference/kotlin/androidx/health/connect/client/records/CyclingPedalingCadenceRecord)
+/// - **iOS HealthKit**: Not supported
+///   (Use [CyclingPedalingCadenceMeasurementRecord])
+///
+/// ## Example
+///
+/// ```dart
+/// final record = CyclingPedalingCadenceSeriesRecord(
+///   id: HealthRecordId.none,
+///   startTime: DateTime.now().subtract(Duration(minutes: 10)),
+///   endTime: DateTime.now(),
+///   samples: [
+///     CyclingPedalingCadenceMeasurement(
+///       time: DateTime.now().subtract(Duration(minutes: 10)),
+///       revolutionsPerMinute: Number(60),
+///     ),
+///     CyclingPedalingCadenceMeasurement(
+///       time: DateTime.now().subtract(Duration(minutes: 5)),
+///       revolutionsPerMinute: Number(90),
+///     ),
+///     CyclingPedalingCadenceMeasurement(
+///       time: DateTime.now(),
+///       revolutionsPerMinute: Number(75),
+///     ),
+///   ],
+///   metadata: Metadata.automaticallyRecorded(
+///     dataOrigin: DataOrigin(packageName: 'com.example.app'),
+///   ),
+/// );
+/// ```
+///
+/// ## See also
+///
+/// - [CyclingPedalingCadenceSeriesRecordHealthDataType]
+///
+/// {@category Health Records}
+@sinceV2_2_0
+@supportedOnHealthConnect
+@immutable
+final class CyclingPedalingCadenceSeriesRecord
+    extends SeriesHealthRecord<CyclingPedalingCadenceMeasurement> {
+  /// Creates a cycling pedaling cadence series record.
+  const CyclingPedalingCadenceSeriesRecord({
+    required super.metadata,
+    required super.startTime,
+    required super.endTime,
+    required super.samples,
+    super.id,
+    super.startZoneOffsetSeconds,
+    super.endZoneOffsetSeconds,
+  });
+
+  /// The average cadence across all samples.
+  Number get averageRpm {
+    if (samples.isEmpty) {
+      return Number.zero;
+    }
+    if (samples.length == 1) {
+      return samples.first.revolutionsPerMinute;
+    }
+
+    final total = samples.fold<double>(
+      0,
+      (sum, sample) => sum + sample.revolutionsPerMinute.value,
+    );
+    final averageRpmValue = (total / samples.length).toInt();
+
+    return Number(averageRpmValue);
+  }
+
+  /// The minimum cadence value among all samples.
+  Number get minRpm {
+    if (samples.isEmpty) {
+      return Number.zero;
+    }
+    return samples
+        .map((s) => s.revolutionsPerMinute)
+        .reduce((a, b) => (a.value < b.value) ? a : b);
+  }
+
+  /// The maximum cadence value among all samples.
+  Number get maxRpm {
+    if (samples.isEmpty) {
+      return Number.zero;
+    }
+    return samples
+        .map((s) => s.revolutionsPerMinute)
+        .reduce((a, b) => (a.value > b.value) ? a : b);
+  }
+
+  /// Creates a copy with the given fields replaced with the new values.
+  CyclingPedalingCadenceSeriesRecord copyWith({
+    HealthRecordId? id,
+    Metadata? metadata,
+    DateTime? startTime,
+    DateTime? endTime,
+    List<CyclingPedalingCadenceMeasurement>? samples,
+    int? startZoneOffsetSeconds,
+    int? endZoneOffsetSeconds,
+  }) {
+    return CyclingPedalingCadenceSeriesRecord(
+      id: id ?? this.id,
+      metadata: metadata ?? this.metadata,
+      startTime: startTime ?? this.startTime,
+      endTime: endTime ?? this.endTime,
+      samples: samples ?? this.samples,
+      startZoneOffsetSeconds:
+          startZoneOffsetSeconds ?? this.startZoneOffsetSeconds,
+      endZoneOffsetSeconds: endZoneOffsetSeconds ?? this.endZoneOffsetSeconds,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is CyclingPedalingCadenceSeriesRecord &&
+          runtimeType == other.runtimeType &&
+          id == other.id &&
+          metadata == other.metadata &&
+          startTime == other.startTime &&
+          endTime == other.endTime &&
+          startZoneOffsetSeconds == other.startZoneOffsetSeconds &&
+          endZoneOffsetSeconds == other.endZoneOffsetSeconds &&
+          _listEquals(samples, other.samples);
+
+  static bool _listEquals<T>(List<T> a, List<T> b) {
+    if (identical(a, b)) {
+      return true;
+    }
+    if (a.length != b.length) {
+      return false;
+    }
+    for (var i = 0; i < a.length; i++) {
+      if (a[i] != b[i]) {
+        return false;
+      }
+    }
+    return true;
+  }
+
+  @override
+  int get hashCode =>
+      id.hashCode ^
+      metadata.hashCode ^
+      startTime.hashCode ^
+      endTime.hashCode ^
+      startZoneOffsetSeconds.hashCode ^
+      endZoneOffsetSeconds.hashCode ^
+      Object.hashAll(samples);
+}

--- a/packages/health_connector_core/lib/src/models/health_records/health_record.dart
+++ b/packages/health_connector_core/lib/src/models/health_records/health_record.dart
@@ -33,6 +33,8 @@ part 'exercise_records/exercise_type.dart';
 part 'floors_climbed_record.dart';
 part 'heart_rate_measurement_record.dart';
 part 'heart_rate_series_record.dart';
+part 'cycling_pedaling_cadence_measurement_record.dart';
+part 'cycling_pedaling_cadence_series_record.dart';
 part 'height_record.dart';
 part 'hydration_record.dart';
 part 'instant_health_record.dart';

--- a/packages/health_connector_core/lib/src/utils/health_record_data_type_extension.dart
+++ b/packages/health_connector_core/lib/src/utils/health_record_data_type_extension.dart
@@ -82,6 +82,12 @@ extension HealthRecordDataTypeExtension on HealthRecord {
       HeartRateSeriesRecord() => HealthDataType.heartRateSeriesRecord,
       HeartRateMeasurementRecord() => HealthDataType.heartRateMeasurementRecord,
 
+      // Cycling pedaling cadence records
+      CyclingPedalingCadenceSeriesRecord() =>
+        HealthDataType.cyclingPedalingCadenceSeriesRecord,
+      CyclingPedalingCadenceMeasurementRecord() =>
+        HealthDataType.cyclingPedalingCadenceMeasurementRecord,
+
       // Sleep records
       SleepSessionRecord() => HealthDataType.sleepSession,
       SleepStageRecord() => HealthDataType.sleepStageRecord,

--- a/packages/health_connector_hc_android/android/src/main/kotlin/com/phamtunglam/health_connector_hc_android/handlers/HealthRecordHandlerRegistry.kt
+++ b/packages/health_connector_hc_android/android/src/main/kotlin/com/phamtunglam/health_connector_hc_android/handlers/HealthRecordHandlerRegistry.kt
@@ -7,6 +7,7 @@ import com.phamtunglam.health_connector_hc_android.handlers.health_record_handle
 import com.phamtunglam.health_connector_hc_android.handlers.health_record_handlers.BodyFatPercentageHandler
 import com.phamtunglam.health_connector_hc_android.handlers.health_record_handlers.BodyTemperatureHandler
 import com.phamtunglam.health_connector_hc_android.handlers.health_record_handlers.CervicalMucusHandler
+import com.phamtunglam.health_connector_hc_android.handlers.health_record_handlers.CyclingPedalingCadenceHandler
 import com.phamtunglam.health_connector_hc_android.handlers.health_record_handlers.DistanceHandler
 import com.phamtunglam.health_connector_hc_android.handlers.health_record_handlers.ExerciseSessionHandler
 import com.phamtunglam.health_connector_hc_android.handlers.health_record_handlers.FloorsClimbedHandler
@@ -36,6 +37,7 @@ internal class HealthRecordHandlerRegistry(private val client: HealthConnectClie
     private val handlers: Map<HealthDataTypeDto, HealthRecordHandler> by lazy {
         buildMap {
             register(HeartRateHandler(client))
+            register(CyclingPedalingCadenceHandler(client))
             register(HeightHandler(client))
             register(BodyTemperatureHandler(client))
             register(CervicalMucusHandler(client))

--- a/packages/health_connector_hc_android/android/src/main/kotlin/com/phamtunglam/health_connector_hc_android/handlers/health_record_handlers/CyclingPedalingCadenceHandler.kt
+++ b/packages/health_connector_hc_android/android/src/main/kotlin/com/phamtunglam/health_connector_hc_android/handlers/health_record_handlers/CyclingPedalingCadenceHandler.kt
@@ -1,0 +1,46 @@
+package com.phamtunglam.health_connector_hc_android.handlers.health_record_handlers
+
+import androidx.health.connect.client.HealthConnectClient
+import androidx.health.connect.client.aggregate.AggregateMetric
+import androidx.health.connect.client.records.CyclingPedalingCadenceRecord
+import com.phamtunglam.health_connector_hc_android.handlers.DeletableHealthRecordHandler
+import com.phamtunglam.health_connector_hc_android.handlers.HealthConnectAggregatableHealthRecordHandler
+import com.phamtunglam.health_connector_hc_android.handlers.ReadableHealthRecordHandler
+import com.phamtunglam.health_connector_hc_android.handlers.UpdatableHealthRecordHandler
+import com.phamtunglam.health_connector_hc_android.handlers.WritableHealthRecordHandler
+import com.phamtunglam.health_connector_hc_android.mappers.health_measurement_unit_mappers.toNumberDto
+import com.phamtunglam.health_connector_hc_android.pigeon.AggregationMetricDto
+import com.phamtunglam.health_connector_hc_android.pigeon.HealthDataTypeDto
+import com.phamtunglam.health_connector_hc_android.pigeon.MeasurementUnitDto
+
+/**
+ * Handler for Cycling Pedaling Cadence records.
+ *
+ * Supports aggregation using Health Connect's native RPM metrics:
+ * - RPM_AVG: Average cycling pedaling cadence
+ * - RPM_MIN: Minimum cycling pedaling cadence
+ * - RPM_MAX: Maximum cycling pedaling cadence
+ */
+internal class CyclingPedalingCadenceHandler(override val client: HealthConnectClient) :
+    ReadableHealthRecordHandler,
+    WritableHealthRecordHandler,
+    UpdatableHealthRecordHandler,
+    DeletableHealthRecordHandler,
+    HealthConnectAggregatableHealthRecordHandler {
+
+    override val dataType = HealthDataTypeDto.CYCLING_PEDALING_CADENCE_SERIES_RECORD
+
+    override val aggregateMetricMappings: Map<AggregationMetricDto, AggregateMetric<*>> =
+        mapOf(
+            AggregationMetricDto.AVG to CyclingPedalingCadenceRecord.RPM_AVG,
+            AggregationMetricDto.MIN to CyclingPedalingCadenceRecord.RPM_MIN,
+            AggregationMetricDto.MAX to CyclingPedalingCadenceRecord.RPM_MAX,
+        )
+
+    override fun convertAggregatedValue(aggregatedValue: Any): MeasurementUnitDto {
+        require(aggregatedValue is Double) {
+            "Expected Double for aggregated RPM value, got ${aggregatedValue::class.simpleName}"
+        }
+        return aggregatedValue.toNumberDto()
+    }
+}

--- a/packages/health_connector_hc_android/android/src/main/kotlin/com/phamtunglam/health_connector_hc_android/mappers/HealthDataTypeMappers.kt
+++ b/packages/health_connector_hc_android/android/src/main/kotlin/com/phamtunglam/health_connector_hc_android/mappers/HealthDataTypeMappers.kt
@@ -7,6 +7,7 @@ import androidx.health.connect.client.records.BloodPressureRecord
 import androidx.health.connect.client.records.BodyFatRecord
 import androidx.health.connect.client.records.BodyTemperatureRecord
 import androidx.health.connect.client.records.CervicalMucusRecord
+import androidx.health.connect.client.records.CyclingPedalingCadenceRecord
 import androidx.health.connect.client.records.DistanceRecord
 import androidx.health.connect.client.records.ExerciseSessionRecord
 import androidx.health.connect.client.records.FloorsClimbedRecord
@@ -64,5 +65,6 @@ internal fun HealthDataTypeDto.toHealthConnectRecordClass(): KClass<out Record> 
     HealthDataTypeDto.NUTRITION -> NutritionRecord::class
     HealthDataTypeDto.SPEED_SERIES -> SpeedRecord::class
     HealthDataTypeDto.POWER_SERIES -> PowerRecord::class
+    HealthDataTypeDto.CYCLING_PEDALING_CADENCE_SERIES_RECORD -> CyclingPedalingCadenceRecord::class
     HealthDataTypeDto.MINDFULNESS_SESSION -> MindfulnessSessionRecord::class
 }

--- a/packages/health_connector_hc_android/android/src/main/kotlin/com/phamtunglam/health_connector_hc_android/mappers/health_record_mappers/CyclingPedalingCadenceRecordMappers.kt
+++ b/packages/health_connector_hc_android/android/src/main/kotlin/com/phamtunglam/health_connector_hc_android/mappers/health_record_mappers/CyclingPedalingCadenceRecordMappers.kt
@@ -1,0 +1,48 @@
+package com.phamtunglam.health_connector_hc_android.mappers.health_record_mappers
+
+import androidx.health.connect.client.records.CyclingPedalingCadenceRecord
+import androidx.health.connect.client.records.CyclingPedalingCadenceRecord.Sample
+import com.phamtunglam.health_connector_hc_android.mappers.health_measurement_unit_mappers.toNumberDto
+import com.phamtunglam.health_connector_hc_android.mappers.metadata_mappers.toDto
+import com.phamtunglam.health_connector_hc_android.mappers.metadata_mappers.toHealthConnect
+import com.phamtunglam.health_connector_hc_android.pigeon.CyclingPedalingCadenceMeasurementDto
+import com.phamtunglam.health_connector_hc_android.pigeon.CyclingPedalingCadenceSeriesRecordDto
+import java.time.Instant
+import java.time.ZoneOffset
+
+/**
+ * Converts a Health Connect [CyclingPedalingCadenceRecord] object to a [CyclingPedalingCadenceSeriesRecordDto].
+ */
+internal fun CyclingPedalingCadenceRecord.toDto(): CyclingPedalingCadenceSeriesRecordDto =
+    CyclingPedalingCadenceSeriesRecordDto(
+        id = metadata.id,
+        startTime = startTime.toEpochMilli(),
+        endTime = endTime.toEpochMilli(),
+        startZoneOffsetSeconds = startZoneOffset?.totalSeconds?.toLong(),
+        endZoneOffsetSeconds = endZoneOffset?.totalSeconds?.toLong(),
+        metadata = metadata.toDto(),
+        samples = samples.map { sample ->
+            CyclingPedalingCadenceMeasurementDto(
+                time = sample.time.toEpochMilli(),
+                revolutionsPerMinute = sample.revolutionsPerMinute.toNumberDto(),
+            )
+        },
+    )
+
+/**
+ * Converts a [CyclingPedalingCadenceSeriesRecordDto] to a Health Connect [CyclingPedalingCadenceRecord] object.
+ */
+internal fun CyclingPedalingCadenceSeriesRecordDto.toHealthConnect(): CyclingPedalingCadenceRecord =
+    CyclingPedalingCadenceRecord(
+        samples = samples.map { sample ->
+            Sample(
+                time = Instant.ofEpochMilli(sample.time),
+                revolutionsPerMinute = sample.revolutionsPerMinute.value,
+            )
+        },
+        startTime = Instant.ofEpochMilli(startTime),
+        endTime = Instant.ofEpochMilli(endTime),
+        startZoneOffset = startZoneOffsetSeconds?.let { ZoneOffset.ofTotalSeconds(it.toInt()) },
+        endZoneOffset = endZoneOffsetSeconds?.let { ZoneOffset.ofTotalSeconds(it.toInt()) },
+        metadata = metadata.toHealthConnect(id),
+    )

--- a/packages/health_connector_hc_android/android/src/main/kotlin/com/phamtunglam/health_connector_hc_android/mappers/health_record_mappers/HealthRecordIdMappers.kt
+++ b/packages/health_connector_hc_android/android/src/main/kotlin/com/phamtunglam/health_connector_hc_android/mappers/health_record_mappers/HealthRecordIdMappers.kt
@@ -6,6 +6,7 @@ import com.phamtunglam.health_connector_hc_android.pigeon.BloodPressureRecordDto
 import com.phamtunglam.health_connector_hc_android.pigeon.BodyFatPercentageRecordDto
 import com.phamtunglam.health_connector_hc_android.pigeon.BodyTemperatureRecordDto
 import com.phamtunglam.health_connector_hc_android.pigeon.CervicalMucusRecordDto
+import com.phamtunglam.health_connector_hc_android.pigeon.CyclingPedalingCadenceSeriesRecordDto
 import com.phamtunglam.health_connector_hc_android.pigeon.DistanceRecordDto
 import com.phamtunglam.health_connector_hc_android.pigeon.ExerciseSessionRecordDto
 import com.phamtunglam.health_connector_hc_android.pigeon.FloorsClimbedRecordDto
@@ -60,6 +61,7 @@ internal val HealthRecordDto.id: String?
         is SleepSessionRecordDto -> id
         is SpeedSeriesRecordDto -> id
         is PowerSeriesRecordDto -> id
+        is CyclingPedalingCadenceSeriesRecordDto -> id
         is RespiratoryRateRecordDto -> id
         is Vo2MaxRecordDto -> id
 

--- a/packages/health_connector_hc_android/android/src/main/kotlin/com/phamtunglam/health_connector_hc_android/mappers/health_record_mappers/HealthRecordMappers.kt
+++ b/packages/health_connector_hc_android/android/src/main/kotlin/com/phamtunglam/health_connector_hc_android/mappers/health_record_mappers/HealthRecordMappers.kt
@@ -7,6 +7,7 @@ import androidx.health.connect.client.records.BloodPressureRecord
 import androidx.health.connect.client.records.BodyFatRecord
 import androidx.health.connect.client.records.BodyTemperatureRecord
 import androidx.health.connect.client.records.CervicalMucusRecord
+import androidx.health.connect.client.records.CyclingPedalingCadenceRecord
 import androidx.health.connect.client.records.DistanceRecord
 import androidx.health.connect.client.records.ExerciseSessionRecord
 import androidx.health.connect.client.records.FloorsClimbedRecord
@@ -34,6 +35,7 @@ import com.phamtunglam.health_connector_hc_android.pigeon.BloodPressureRecordDto
 import com.phamtunglam.health_connector_hc_android.pigeon.BodyFatPercentageRecordDto
 import com.phamtunglam.health_connector_hc_android.pigeon.BodyTemperatureRecordDto
 import com.phamtunglam.health_connector_hc_android.pigeon.CervicalMucusRecordDto
+import com.phamtunglam.health_connector_hc_android.pigeon.CyclingPedalingCadenceSeriesRecordDto
 import com.phamtunglam.health_connector_hc_android.pigeon.DistanceRecordDto
 import com.phamtunglam.health_connector_hc_android.pigeon.ExerciseSessionRecordDto
 import com.phamtunglam.health_connector_hc_android.pigeon.FloorsClimbedRecordDto
@@ -87,6 +89,7 @@ internal val HealthRecordDto.dataType: HealthDataTypeDto
         is NutritionRecordDto -> HealthDataTypeDto.NUTRITION
         is OxygenSaturationRecordDto -> HealthDataTypeDto.OXYGEN_SATURATION
         is PowerSeriesRecordDto -> HealthDataTypeDto.POWER_SERIES
+        is CyclingPedalingCadenceSeriesRecordDto -> HealthDataTypeDto.CYCLING_PEDALING_CADENCE_SERIES_RECORD
         is RespiratoryRateRecordDto -> HealthDataTypeDto.RESPIRATORY_RATE
         is Vo2MaxRecordDto -> HealthDataTypeDto.VO2MAX
         is BloodPressureRecordDto -> HealthDataTypeDto.BLOOD_PRESSURE
@@ -123,6 +126,7 @@ internal fun HealthRecordDto.toHealthConnect(): Record = when (this) {
     is NutritionRecordDto -> toHealthConnect()
     is OxygenSaturationRecordDto -> toHealthConnect()
     is PowerSeriesRecordDto -> toHealthConnect()
+    is CyclingPedalingCadenceSeriesRecordDto -> toHealthConnect()
     is RespiratoryRateRecordDto -> toHealthConnect()
     is Vo2MaxRecordDto -> toHealthConnect()
     is BloodPressureRecordDto -> toHealthConnect()
@@ -165,6 +169,7 @@ internal fun Record.toDto(): HealthRecordDto = when (this) {
     is NutritionRecord -> toDto()
     is OxygenSaturationRecord -> toDto()
     is PowerRecord -> toDto()
+    is CyclingPedalingCadenceRecord -> toDto()
     is RespiratoryRateRecord -> toDto()
     is Vo2MaxRecord -> toDto()
     is BloodPressureRecord -> toDto()

--- a/packages/health_connector_hc_android/android/src/main/kotlin/com/phamtunglam/health_connector_hc_android/mappers/permission_mappers/HealthDataPermissionMapper.kt
+++ b/packages/health_connector_hc_android/android/src/main/kotlin/com/phamtunglam/health_connector_hc_android/mappers/permission_mappers/HealthDataPermissionMapper.kt
@@ -8,6 +8,7 @@ import androidx.health.connect.client.records.BloodPressureRecord
 import androidx.health.connect.client.records.BodyFatRecord
 import androidx.health.connect.client.records.BodyTemperatureRecord
 import androidx.health.connect.client.records.CervicalMucusRecord
+import androidx.health.connect.client.records.CyclingPedalingCadenceRecord
 import androidx.health.connect.client.records.DistanceRecord
 import androidx.health.connect.client.records.ExerciseSessionRecord
 import androidx.health.connect.client.records.FloorsClimbedRecord
@@ -328,6 +329,18 @@ internal fun getHealthConnectPermission(
         }
     }
 
+    HealthDataTypeDto.CYCLING_PEDALING_CADENCE_SERIES_RECORD -> {
+        when (accessType) {
+            PermissionAccessTypeDto.READ -> HealthPermission.getReadPermission(
+                CyclingPedalingCadenceRecord::class,
+            )
+
+            PermissionAccessTypeDto.WRITE -> HealthPermission.getWritePermission(
+                CyclingPedalingCadenceRecord::class,
+            )
+        }
+    }
+
     HealthDataTypeDto.EXERCISE_SESSION -> {
         when (accessType) {
             PermissionAccessTypeDto.READ -> HealthPermission.getReadPermission(
@@ -424,6 +437,7 @@ internal fun String.toHealthDataPermissionDto(): HealthDataPermissionRequestDto 
         "NUTRITION" -> HealthDataTypeDto.NUTRITION
         "SPEED" -> HealthDataTypeDto.SPEED_SERIES
         "POWER" -> HealthDataTypeDto.POWER_SERIES
+        "CYCLING_CADENCE" -> HealthDataTypeDto.CYCLING_PEDALING_CADENCE_SERIES_RECORD
         "EXERCISE_SESSION" -> HealthDataTypeDto.EXERCISE_SESSION
         "MINDFULNESS_SESSION" -> HealthDataTypeDto.MINDFULNESS_SESSION
         else -> throw IllegalArgumentException(

--- a/packages/health_connector_hc_android/android/src/main/kotlin/com/phamtunglam/health_connector_hc_android/pigeon/HealthConnectorHCAndroidApi.g.kt
+++ b/packages/health_connector_hc_android/android/src/main/kotlin/com/phamtunglam/health_connector_hc_android/pigeon/HealthConnectorHCAndroidApi.g.kt
@@ -714,30 +714,32 @@ enum class HealthDataTypeDto(val raw: Int) {
   HYDRATION(12),
   /** Heart rate series record data. */
   HEART_RATE_SERIES_RECORD(13),
+  /** Cycling pedaling cadence series record data. */
+  CYCLING_PEDALING_CADENCE_SERIES_RECORD(14),
   /** Sexual activity data. */
-  SEXUAL_ACTIVITY(14),
+  SEXUAL_ACTIVITY(15),
   /** Sleep session data. */
-  SLEEP_SESSION(15),
+  SLEEP_SESSION(16),
   /** Combined nutrition record with all nutrients. */
-  NUTRITION(16),
+  NUTRITION(17),
   /** Resting heart rate data. */
-  RESTING_HEART_RATE(17),
+  RESTING_HEART_RATE(18),
   /** Composite blood pressure data (systolic + diastolic). */
-  BLOOD_PRESSURE(18),
+  BLOOD_PRESSURE(19),
   /** Oxygen saturation data. */
-  OXYGEN_SATURATION(19),
+  OXYGEN_SATURATION(20),
   /** Power data. */
-  POWER_SERIES(20),
+  POWER_SERIES(21),
   /** Respiratory rate data. */
-  RESPIRATORY_RATE(21),
+  RESPIRATORY_RATE(22),
   /** VO2 max (maximal oxygen uptake) data. */
-  VO2MAX(22),
+  VO2MAX(23),
   /** Blood glucose data. */
-  BLOOD_GLUCOSE(23),
+  BLOOD_GLUCOSE(24),
   /** Speed data. */
-  SPEED_SERIES(24),
+  SPEED_SERIES(25),
   /** Mindfulness session data. */
-  MINDFULNESS_SESSION(25);
+  MINDFULNESS_SESSION(26);
 
   companion object {
     fun ofRaw(raw: Int): HealthDataTypeDto? {
@@ -2412,6 +2414,104 @@ data class HeartRateSeriesRecordDto (
 }
 
 /**
+ * Represents a single cycling pedaling cadence measurement.
+ *
+ * This is a platform-agnostic value class used within cycling pedaling
+ * cadence records.
+ * It contains a timestamp and RPM value without ID or metadata.
+ *
+ * Generated class from Pigeon that represents data sent in messages.
+ */
+data class CyclingPedalingCadenceMeasurementDto (
+  /** Timestamp in milliseconds since epoch (UTC). */
+  val time: Long,
+  /** Cycling cadence value in revolutions per minute (RPM). */
+  val revolutionsPerMinute: NumberDto
+)
+ {
+  companion object {
+    fun fromList(pigeonVar_list: List<Any?>): CyclingPedalingCadenceMeasurementDto {
+      val time = pigeonVar_list[0] as Long
+      val revolutionsPerMinute = pigeonVar_list[1] as NumberDto
+      return CyclingPedalingCadenceMeasurementDto(time, revolutionsPerMinute)
+    }
+  }
+  fun toList(): List<Any?> {
+    return listOf(
+      time,
+      revolutionsPerMinute,
+    )
+  }
+  override fun equals(other: Any?): Boolean {
+    if (other !is CyclingPedalingCadenceMeasurementDto) {
+      return false
+    }
+    if (this === other) {
+      return true
+    }
+    return HealthConnectorHCAndroidApiPigeonUtils.deepEquals(toList(), other.toList())  }
+
+  override fun hashCode(): Int = toList().hashCode()
+}
+
+/**
+ * Represents a cycling pedaling cadence series record.
+ *
+ * Generated class from Pigeon that represents data sent in messages.
+ */
+data class CyclingPedalingCadenceSeriesRecordDto (
+  /** Platform-assigned unique identifier. Null if not yet synced. */
+  val id: String? = null,
+  /** Start time in milliseconds since epoch (UTC). */
+  val startTime: Long,
+  /** End time in milliseconds since epoch (UTC). */
+  val endTime: Long,
+  /** Start timezone offset in seconds. Null if unknown. */
+  val startZoneOffsetSeconds: Long? = null,
+  /** End timezone offset in seconds. Null if unknown. */
+  val endZoneOffsetSeconds: Long? = null,
+  /** Metadata for this record. */
+  val metadata: MetadataDto,
+  /** List of cadence measurements. */
+  val samples: List<CyclingPedalingCadenceMeasurementDto>
+) : HealthRecordDto()
+ {
+  companion object {
+    fun fromList(pigeonVar_list: List<Any?>): CyclingPedalingCadenceSeriesRecordDto {
+      val id = pigeonVar_list[0] as String?
+      val startTime = pigeonVar_list[1] as Long
+      val endTime = pigeonVar_list[2] as Long
+      val startZoneOffsetSeconds = pigeonVar_list[3] as Long?
+      val endZoneOffsetSeconds = pigeonVar_list[4] as Long?
+      val metadata = pigeonVar_list[5] as MetadataDto
+      val samples = pigeonVar_list[6] as List<CyclingPedalingCadenceMeasurementDto>
+      return CyclingPedalingCadenceSeriesRecordDto(id, startTime, endTime, startZoneOffsetSeconds, endZoneOffsetSeconds, metadata, samples)
+    }
+  }
+  fun toList(): List<Any?> {
+    return listOf(
+      id,
+      startTime,
+      endTime,
+      startZoneOffsetSeconds,
+      endZoneOffsetSeconds,
+      metadata,
+      samples,
+    )
+  }
+  override fun equals(other: Any?): Boolean {
+    if (other !is CyclingPedalingCadenceSeriesRecordDto) {
+      return false
+    }
+    if (this === other) {
+      return true
+    }
+    return HealthConnectorHCAndroidApiPigeonUtils.deepEquals(toList(), other.toList())  }
+
+  override fun hashCode(): Int = toList().hashCode()
+}
+
+/**
  * Represents a single speed measurement within a [SpeedSeriesRecordDto].
  *
  * Generated class from Pigeon that represents data sent in messages.
@@ -3994,120 +4094,130 @@ private open class HealthConnectorHCAndroidApiPigeonCodec : StandardMessageCodec
       }
       196.toByte() -> {
         return (readValue(buffer) as? List<Any?>)?.let {
-          SpeedMeasurementDto.fromList(it)
+          CyclingPedalingCadenceMeasurementDto.fromList(it)
         }
       }
       197.toByte() -> {
         return (readValue(buffer) as? List<Any?>)?.let {
-          SpeedSeriesRecordDto.fromList(it)
+          CyclingPedalingCadenceSeriesRecordDto.fromList(it)
         }
       }
       198.toByte() -> {
         return (readValue(buffer) as? List<Any?>)?.let {
-          PowerMeasurementDto.fromList(it)
+          SpeedMeasurementDto.fromList(it)
         }
       }
       199.toByte() -> {
         return (readValue(buffer) as? List<Any?>)?.let {
-          PowerSeriesRecordDto.fromList(it)
+          SpeedSeriesRecordDto.fromList(it)
         }
       }
       200.toByte() -> {
         return (readValue(buffer) as? List<Any?>)?.let {
-          SleepStageDto.fromList(it)
+          PowerMeasurementDto.fromList(it)
         }
       }
       201.toByte() -> {
         return (readValue(buffer) as? List<Any?>)?.let {
-          SleepSessionRecordDto.fromList(it)
+          PowerSeriesRecordDto.fromList(it)
         }
       }
       202.toByte() -> {
         return (readValue(buffer) as? List<Any?>)?.let {
-          SexualActivityRecordDto.fromList(it)
+          SleepStageDto.fromList(it)
         }
       }
       203.toByte() -> {
         return (readValue(buffer) as? List<Any?>)?.let {
-          ExerciseSessionRecordDto.fromList(it)
+          SleepSessionRecordDto.fromList(it)
         }
       }
       204.toByte() -> {
         return (readValue(buffer) as? List<Any?>)?.let {
-          MindfulnessSessionRecordDto.fromList(it)
+          SexualActivityRecordDto.fromList(it)
         }
       }
       205.toByte() -> {
         return (readValue(buffer) as? List<Any?>)?.let {
-          NutritionRecordDto.fromList(it)
+          ExerciseSessionRecordDto.fromList(it)
         }
       }
       206.toByte() -> {
         return (readValue(buffer) as? List<Any?>)?.let {
-          HealthPlatformFeaturePermissionRequestResultDto.fromList(it)
+          MindfulnessSessionRecordDto.fromList(it)
         }
       }
       207.toByte() -> {
         return (readValue(buffer) as? List<Any?>)?.let {
-          HealthDataPermissionRequestDto.fromList(it)
+          NutritionRecordDto.fromList(it)
         }
       }
       208.toByte() -> {
         return (readValue(buffer) as? List<Any?>)?.let {
-          HealthDataPermissionRequestResultDto.fromList(it)
+          HealthPlatformFeaturePermissionRequestResultDto.fromList(it)
         }
       }
       209.toByte() -> {
         return (readValue(buffer) as? List<Any?>)?.let {
-          HealthPlatformFeaturePermissionRequest.fromList(it)
+          HealthDataPermissionRequestDto.fromList(it)
         }
       }
       210.toByte() -> {
         return (readValue(buffer) as? List<Any?>)?.let {
-          PermissionRequestsDto.fromList(it)
+          HealthDataPermissionRequestResultDto.fromList(it)
         }
       }
       211.toByte() -> {
         return (readValue(buffer) as? List<Any?>)?.let {
-          PermissionRequestsResponseDto.fromList(it)
+          HealthPlatformFeaturePermissionRequest.fromList(it)
         }
       }
       212.toByte() -> {
         return (readValue(buffer) as? List<Any?>)?.let {
-          CommonAggregateRequestDto.fromList(it)
+          PermissionRequestsDto.fromList(it)
         }
       }
       213.toByte() -> {
         return (readValue(buffer) as? List<Any?>)?.let {
-          BloodPressureAggregateRequestDto.fromList(it)
+          PermissionRequestsResponseDto.fromList(it)
         }
       }
       214.toByte() -> {
         return (readValue(buffer) as? List<Any?>)?.let {
-          DeleteRecordsByIdsRequestDto.fromList(it)
+          CommonAggregateRequestDto.fromList(it)
         }
       }
       215.toByte() -> {
         return (readValue(buffer) as? List<Any?>)?.let {
-          DeleteRecordsByTimeRangeRequestDto.fromList(it)
+          BloodPressureAggregateRequestDto.fromList(it)
         }
       }
       216.toByte() -> {
         return (readValue(buffer) as? List<Any?>)?.let {
-          ReadRecordRequestDto.fromList(it)
+          DeleteRecordsByIdsRequestDto.fromList(it)
         }
       }
       217.toByte() -> {
         return (readValue(buffer) as? List<Any?>)?.let {
-          ReadRecordsRequestDto.fromList(it)
+          DeleteRecordsByTimeRangeRequestDto.fromList(it)
         }
       }
       218.toByte() -> {
         return (readValue(buffer) as? List<Any?>)?.let {
-          ReadRecordsResponseDto.fromList(it)
+          ReadRecordRequestDto.fromList(it)
         }
       }
       219.toByte() -> {
+        return (readValue(buffer) as? List<Any?>)?.let {
+          ReadRecordsRequestDto.fromList(it)
+        }
+      }
+      220.toByte() -> {
+        return (readValue(buffer) as? List<Any?>)?.let {
+          ReadRecordsResponseDto.fromList(it)
+        }
+      }
+      221.toByte() -> {
         return (readValue(buffer) as? List<Any?>)?.let {
           HealthConnectorConfigDto.fromList(it)
         }
@@ -4385,100 +4495,108 @@ private open class HealthConnectorHCAndroidApiPigeonCodec : StandardMessageCodec
         stream.write(195)
         writeValue(stream, value.toList())
       }
-      is SpeedMeasurementDto -> {
+      is CyclingPedalingCadenceMeasurementDto -> {
         stream.write(196)
         writeValue(stream, value.toList())
       }
-      is SpeedSeriesRecordDto -> {
+      is CyclingPedalingCadenceSeriesRecordDto -> {
         stream.write(197)
         writeValue(stream, value.toList())
       }
-      is PowerMeasurementDto -> {
+      is SpeedMeasurementDto -> {
         stream.write(198)
         writeValue(stream, value.toList())
       }
-      is PowerSeriesRecordDto -> {
+      is SpeedSeriesRecordDto -> {
         stream.write(199)
         writeValue(stream, value.toList())
       }
-      is SleepStageDto -> {
+      is PowerMeasurementDto -> {
         stream.write(200)
         writeValue(stream, value.toList())
       }
-      is SleepSessionRecordDto -> {
+      is PowerSeriesRecordDto -> {
         stream.write(201)
         writeValue(stream, value.toList())
       }
-      is SexualActivityRecordDto -> {
+      is SleepStageDto -> {
         stream.write(202)
         writeValue(stream, value.toList())
       }
-      is ExerciseSessionRecordDto -> {
+      is SleepSessionRecordDto -> {
         stream.write(203)
         writeValue(stream, value.toList())
       }
-      is MindfulnessSessionRecordDto -> {
+      is SexualActivityRecordDto -> {
         stream.write(204)
         writeValue(stream, value.toList())
       }
-      is NutritionRecordDto -> {
+      is ExerciseSessionRecordDto -> {
         stream.write(205)
         writeValue(stream, value.toList())
       }
-      is HealthPlatformFeaturePermissionRequestResultDto -> {
+      is MindfulnessSessionRecordDto -> {
         stream.write(206)
         writeValue(stream, value.toList())
       }
-      is HealthDataPermissionRequestDto -> {
+      is NutritionRecordDto -> {
         stream.write(207)
         writeValue(stream, value.toList())
       }
-      is HealthDataPermissionRequestResultDto -> {
+      is HealthPlatformFeaturePermissionRequestResultDto -> {
         stream.write(208)
         writeValue(stream, value.toList())
       }
-      is HealthPlatformFeaturePermissionRequest -> {
+      is HealthDataPermissionRequestDto -> {
         stream.write(209)
         writeValue(stream, value.toList())
       }
-      is PermissionRequestsDto -> {
+      is HealthDataPermissionRequestResultDto -> {
         stream.write(210)
         writeValue(stream, value.toList())
       }
-      is PermissionRequestsResponseDto -> {
+      is HealthPlatformFeaturePermissionRequest -> {
         stream.write(211)
         writeValue(stream, value.toList())
       }
-      is CommonAggregateRequestDto -> {
+      is PermissionRequestsDto -> {
         stream.write(212)
         writeValue(stream, value.toList())
       }
-      is BloodPressureAggregateRequestDto -> {
+      is PermissionRequestsResponseDto -> {
         stream.write(213)
         writeValue(stream, value.toList())
       }
-      is DeleteRecordsByIdsRequestDto -> {
+      is CommonAggregateRequestDto -> {
         stream.write(214)
         writeValue(stream, value.toList())
       }
-      is DeleteRecordsByTimeRangeRequestDto -> {
+      is BloodPressureAggregateRequestDto -> {
         stream.write(215)
         writeValue(stream, value.toList())
       }
-      is ReadRecordRequestDto -> {
+      is DeleteRecordsByIdsRequestDto -> {
         stream.write(216)
         writeValue(stream, value.toList())
       }
-      is ReadRecordsRequestDto -> {
+      is DeleteRecordsByTimeRangeRequestDto -> {
         stream.write(217)
         writeValue(stream, value.toList())
       }
-      is ReadRecordsResponseDto -> {
+      is ReadRecordRequestDto -> {
         stream.write(218)
         writeValue(stream, value.toList())
       }
-      is HealthConnectorConfigDto -> {
+      is ReadRecordsRequestDto -> {
         stream.write(219)
+        writeValue(stream, value.toList())
+      }
+      is ReadRecordsResponseDto -> {
+        stream.write(220)
+        writeValue(stream, value.toList())
+      }
+      is HealthConnectorConfigDto -> {
+        stream.write(221)
         writeValue(stream, value.toList())
       }
       else -> super.writeValue(stream, value)

--- a/packages/health_connector_hc_android/lib/src/mappers/health_data_type_mappers.dart
+++ b/packages/health_connector_hc_android/lib/src/mappers/health_data_type_mappers.dart
@@ -11,6 +11,8 @@ import 'package:health_connector_core/health_connector_core_internal.dart'
         CholesterolNutrientDataType,
         CrossCountrySkiingDistanceDataType,
         CyclingDistanceDataType,
+        CyclingPedalingCadenceMeasurementRecordHealthDataType,
+        CyclingPedalingCadenceSeriesRecordHealthDataType,
         CyclingPowerDataType,
         DietaryFiberNutrientDataType,
         DistanceHealthDataType,
@@ -118,6 +120,8 @@ extension HealthDataTypeDtoToDomain on HealthDataTypeDto {
         return HealthDataType.wheelchairPushes;
       case HealthDataTypeDto.heartRateSeriesRecord:
         return HealthDataType.heartRateSeriesRecord;
+      case HealthDataTypeDto.cyclingPedalingCadenceSeriesRecord:
+        return HealthDataType.cyclingPedalingCadenceSeriesRecord;
       case HealthDataTypeDto.sexualActivity:
         return HealthDataType.sexualActivity;
       case HealthDataTypeDto.sleepSession:
@@ -181,6 +185,8 @@ extension HealthDataTypeToDto on HealthDataType<HealthRecord, MeasurementUnit> {
         return HealthDataTypeDto.wheelchairPushes;
       case HeartRateSeriesRecordHealthDataType _:
         return HealthDataTypeDto.heartRateSeriesRecord;
+      case CyclingPedalingCadenceSeriesRecordHealthDataType _:
+        return HealthDataTypeDto.cyclingPedalingCadenceSeriesRecord;
       case SexualActivityDataType _:
         return HealthDataTypeDto.sexualActivity;
       case SleepSessionHealthDataType _:
@@ -249,6 +255,12 @@ extension HealthDataTypeToDto on HealthDataType<HealthRecord, MeasurementUnit> {
           '$HeartRateMeasurementRecordHealthDataType is not '
           'supported on Android Health Connect. '
           'Use $HeartRateSeriesRecordHealthDataType instead.',
+        );
+      case CyclingPedalingCadenceMeasurementRecordHealthDataType _:
+        throw UnsupportedError(
+          '$CyclingPedalingCadenceMeasurementRecordHealthDataType is not '
+          'supported on Android Health Connect. '
+          'Use $CyclingPedalingCadenceSeriesRecordHealthDataType instead.',
         );
       case SystolicBloodPressureHealthDataType _:
         throw UnsupportedError(

--- a/packages/health_connector_hc_android/lib/src/mappers/health_record_mappers/cycling_pedaling_cadence_measurement_mappers.dart
+++ b/packages/health_connector_hc_android/lib/src/mappers/health_record_mappers/cycling_pedaling_cadence_measurement_mappers.dart
@@ -1,0 +1,34 @@
+import 'package:health_connector_core/health_connector_core_internal.dart'
+    show CyclingPedalingCadenceMeasurement, sinceV2_2_0;
+import 'package:health_connector_hc_android/src/mappers/measurement_unit_mappers/measurement_unit_mapper.dart';
+import 'package:health_connector_hc_android/src/pigeon/health_connector_hc_android_api.g.dart'
+    show CyclingPedalingCadenceMeasurementDto;
+import 'package:meta/meta.dart' show internal;
+
+/// Converts [CyclingPedalingCadenceMeasurement] to
+/// [CyclingPedalingCadenceMeasurementDto].
+@sinceV2_2_0
+@internal
+extension CyclingPedalingCadenceMeasurementToDto
+    on CyclingPedalingCadenceMeasurement {
+  CyclingPedalingCadenceMeasurementDto toDto() {
+    return CyclingPedalingCadenceMeasurementDto(
+      time: time.millisecondsSinceEpoch,
+      revolutionsPerMinute: revolutionsPerMinute.toDto(),
+    );
+  }
+}
+
+/// Converts [CyclingPedalingCadenceMeasurementDto] to
+/// [CyclingPedalingCadenceMeasurement].
+@sinceV2_2_0
+@internal
+extension CyclingPedalingCadenceMeasurementDtoToDomain
+    on CyclingPedalingCadenceMeasurementDto {
+  CyclingPedalingCadenceMeasurement toDomain() {
+    return CyclingPedalingCadenceMeasurement(
+      time: DateTime.fromMillisecondsSinceEpoch(time, isUtc: true),
+      revolutionsPerMinute: revolutionsPerMinute.toDomain(),
+    );
+  }
+}

--- a/packages/health_connector_hc_android/lib/src/mappers/health_record_mappers/cycling_pedaling_cadence_series_record_mappers.dart
+++ b/packages/health_connector_hc_android/lib/src/mappers/health_record_mappers/cycling_pedaling_cadence_series_record_mappers.dart
@@ -1,0 +1,46 @@
+import 'package:health_connector_core/health_connector_core_internal.dart'
+    show CyclingPedalingCadenceSeriesRecord, HealthRecordId, sinceV2_2_0;
+import 'package:health_connector_hc_android/src/mappers/health_record_mappers/cycling_pedaling_cadence_measurement_mappers.dart';
+import 'package:health_connector_hc_android/src/mappers/health_record_mappers/health_record_id_mappers.dart';
+import 'package:health_connector_hc_android/src/mappers/metadata_mappers/metadata_mapper.dart';
+import 'package:health_connector_hc_android/src/pigeon/health_connector_hc_android_api.g.dart'
+    show CyclingPedalingCadenceSeriesRecordDto;
+import 'package:meta/meta.dart' show internal;
+
+/// Converts [CyclingPedalingCadenceSeriesRecord] to
+/// [CyclingPedalingCadenceSeriesRecordDto].
+@sinceV2_2_0
+@internal
+extension CyclingPedalingCadenceSeriesRecordToDto
+    on CyclingPedalingCadenceSeriesRecord {
+  CyclingPedalingCadenceSeriesRecordDto toDto() {
+    return CyclingPedalingCadenceSeriesRecordDto(
+      id: id.toDto(),
+      startTime: startTime.millisecondsSinceEpoch,
+      endTime: endTime.millisecondsSinceEpoch,
+      startZoneOffsetSeconds: startZoneOffsetSeconds,
+      endZoneOffsetSeconds: endZoneOffsetSeconds,
+      metadata: metadata.toDto(),
+      samples: samples.map((s) => s.toDto()).toList(),
+    );
+  }
+}
+
+/// Converts [CyclingPedalingCadenceSeriesRecordDto] to
+/// [CyclingPedalingCadenceSeriesRecord].
+@sinceV2_2_0
+@internal
+extension CyclingPedalingCadenceSeriesRecordDtoToDomain
+    on CyclingPedalingCadenceSeriesRecordDto {
+  CyclingPedalingCadenceSeriesRecord toDomain() {
+    return CyclingPedalingCadenceSeriesRecord(
+      id: id?.toDomain() ?? HealthRecordId.none,
+      startTime: DateTime.fromMillisecondsSinceEpoch(startTime, isUtc: true),
+      endTime: DateTime.fromMillisecondsSinceEpoch(endTime, isUtc: true),
+      startZoneOffsetSeconds: startZoneOffsetSeconds,
+      endZoneOffsetSeconds: endZoneOffsetSeconds,
+      metadata: metadata.toDomain(),
+      samples: samples.map((s) => s.toDomain()).toList(),
+    );
+  }
+}

--- a/packages/health_connector_hc_android/lib/src/mappers/health_record_mappers/health_record_mapper.dart
+++ b/packages/health_connector_hc_android/lib/src/mappers/health_record_mappers/health_record_mapper.dart
@@ -12,6 +12,8 @@ import 'package:health_connector_core/health_connector_core_internal.dart'
         HealthRecord,
         HeartRateMeasurementRecord,
         HeartRateSeriesRecord,
+        CyclingPedalingCadenceMeasurementRecord,
+        CyclingPedalingCadenceSeriesRecord,
         HeightRecord,
         HydrationRecord,
         LeanBodyMassRecord,
@@ -74,6 +76,7 @@ import 'package:health_connector_hc_android/src/mappers/health_record_mappers/bl
 import 'package:health_connector_hc_android/src/mappers/health_record_mappers/body_fat_percentage_record_mappers.dart';
 import 'package:health_connector_hc_android/src/mappers/health_record_mappers/body_temperature_record_mappers.dart';
 import 'package:health_connector_hc_android/src/mappers/health_record_mappers/cervical_mucus_record_mappers.dart';
+import 'package:health_connector_hc_android/src/mappers/health_record_mappers/cycling_pedaling_cadence_series_record_mappers.dart';
 import 'package:health_connector_hc_android/src/mappers/health_record_mappers/distance_record_mappers.dart';
 import 'package:health_connector_hc_android/src/mappers/health_record_mappers/exercise_session_record_mappers.dart';
 import 'package:health_connector_hc_android/src/mappers/health_record_mappers/floors_climbed_record_mappers.dart';
@@ -105,6 +108,7 @@ import 'package:health_connector_hc_android/src/pigeon/health_connector_hc_andro
         FloorsClimbedRecordDto,
         HealthRecordDto,
         HeartRateSeriesRecordDto,
+        CyclingPedalingCadenceSeriesRecordDto,
         HeightRecordDto,
         HydrationRecordDto,
         LeanBodyMassRecordDto,
@@ -202,6 +206,8 @@ extension HealthRecordToDto on HealthRecord {
         return WheelchairPushesRecordToDto(record).toDto();
       case final HeartRateSeriesRecord record:
         return HeartRateSeriesRecordToDto(record).toDto();
+      case final CyclingPedalingCadenceSeriesRecord record:
+        return CyclingPedalingCadenceSeriesRecordToDto(record).toDto();
       case final SexualActivityRecord record:
         return SexualActivityRecordToDto(record).toDto();
       case final SleepSessionRecord record:
@@ -419,6 +425,12 @@ extension HealthRecordToDto on HealthRecord {
           '$CyclingPowerRecord is iOS-only and not supported on '
           'Android Health Connect. Use $PowerSeriesRecord instead.',
         );
+      case final CyclingPedalingCadenceMeasurementRecord _:
+        throw UnsupportedError(
+          '$CyclingPedalingCadenceMeasurementRecord is not supported on '
+          'Android Health Connect. '
+          'Use $CyclingPedalingCadenceSeriesRecord instead.',
+        );
       case final PowerSeriesRecord record:
         return PowerSeriesRecordToDto(record).toDto();
       case final SpeedSeriesRecord record:
@@ -464,6 +476,8 @@ extension HealthRecordDtoToDomain on HealthRecordDto {
         return WheelchairPushesRecordDtoToDomain(dto).toDomain();
       case final HeartRateSeriesRecordDto dto:
         return HeartRateSeriesRecordDtoToDomain(dto).toDomain();
+      case final CyclingPedalingCadenceSeriesRecordDto dto:
+        return CyclingPedalingCadenceSeriesRecordDtoToDomain(dto).toDomain();
       case final SexualActivityRecordDto dto:
         return SexualActivityRecordDtoToDomain(dto).toDomain();
       case final SleepSessionRecordDto dto:

--- a/packages/health_connector_hc_android/lib/src/mappers/request_and_response_mappers/aggregate_request_mapper.dart
+++ b/packages/health_connector_hc_android/lib/src/mappers/request_and_response_mappers/aggregate_request_mapper.dart
@@ -15,6 +15,8 @@ import 'package:health_connector_core/health_connector_core_internal.dart'
         CervicalMucusDataType,
         CrossCountrySkiingDistanceDataType,
         CyclingDistanceDataType,
+        CyclingPedalingCadenceMeasurementRecordHealthDataType,
+        CyclingPedalingCadenceSeriesRecordHealthDataType,
         CyclingPowerDataType,
         DistanceHealthDataType,
         DownhillSnowSportsDistanceDataType,
@@ -150,6 +152,8 @@ extension AggregateRequestDtoMapper<
           case FloorsClimbedHealthDataType _:
           case HeartRateMeasurementRecordHealthDataType _:
           case HeartRateSeriesRecordHealthDataType _:
+          case CyclingPedalingCadenceMeasurementRecordHealthDataType _:
+          case CyclingPedalingCadenceSeriesRecordHealthDataType _:
           case HeightHealthDataType _:
           case HydrationHealthDataType _:
           case LeanBodyMassHealthDataType _:

--- a/packages/health_connector_hc_android/lib/src/pigeon/health_connector_hc_android_api.g.dart
+++ b/packages/health_connector_hc_android/lib/src/pigeon/health_connector_hc_android_api.g.dart
@@ -578,6 +578,9 @@ enum HealthDataTypeDto {
   /// Heart rate series record data.
   heartRateSeriesRecord,
 
+  /// Cycling pedaling cadence series record data.
+  cyclingPedalingCadenceSeriesRecord,
+
   /// Sexual activity data.
   sexualActivity,
 
@@ -2814,6 +2817,141 @@ class HeartRateSeriesRecordDto extends HealthRecordDto {
   int get hashCode => Object.hashAll(_toList());
 }
 
+/// Represents a single cycling pedaling cadence measurement.
+///
+/// This is a platform-agnostic value class used within cycling pedaling
+/// cadence records.
+/// It contains a timestamp and RPM value without ID or metadata.
+class CyclingPedalingCadenceMeasurementDto {
+  CyclingPedalingCadenceMeasurementDto({
+    required this.time,
+    required this.revolutionsPerMinute,
+  });
+
+  /// Timestamp in milliseconds since epoch (UTC).
+  int time;
+
+  /// Cycling cadence value in revolutions per minute (RPM).
+  NumberDto revolutionsPerMinute;
+
+  List<Object?> _toList() {
+    return <Object?>[
+      time,
+      revolutionsPerMinute,
+    ];
+  }
+
+  Object encode() {
+    return _toList();
+  }
+
+  static CyclingPedalingCadenceMeasurementDto decode(Object result) {
+    result as List<Object?>;
+    return CyclingPedalingCadenceMeasurementDto(
+      time: result[0]! as int,
+      revolutionsPerMinute: result[1]! as NumberDto,
+    );
+  }
+
+  @override
+  // ignore: avoid_equals_and_hash_code_on_mutable_classes
+  bool operator ==(Object other) {
+    if (other is! CyclingPedalingCadenceMeasurementDto ||
+        other.runtimeType != runtimeType) {
+      return false;
+    }
+    if (identical(this, other)) {
+      return true;
+    }
+    return _deepEquals(encode(), other.encode());
+  }
+
+  @override
+  // ignore: avoid_equals_and_hash_code_on_mutable_classes
+  int get hashCode => Object.hashAll(_toList());
+}
+
+/// Represents a cycling pedaling cadence series record.
+class CyclingPedalingCadenceSeriesRecordDto extends HealthRecordDto {
+  CyclingPedalingCadenceSeriesRecordDto({
+    this.id,
+    required this.startTime,
+    required this.endTime,
+    this.startZoneOffsetSeconds,
+    this.endZoneOffsetSeconds,
+    required this.metadata,
+    required this.samples,
+  });
+
+  /// Platform-assigned unique identifier. Null if not yet synced.
+  String? id;
+
+  /// Start time in milliseconds since epoch (UTC).
+  int startTime;
+
+  /// End time in milliseconds since epoch (UTC).
+  int endTime;
+
+  /// Start timezone offset in seconds. Null if unknown.
+  int? startZoneOffsetSeconds;
+
+  /// End timezone offset in seconds. Null if unknown.
+  int? endZoneOffsetSeconds;
+
+  /// Metadata for this record.
+  MetadataDto metadata;
+
+  /// List of cadence measurements.
+  List<CyclingPedalingCadenceMeasurementDto> samples;
+
+  List<Object?> _toList() {
+    return <Object?>[
+      id,
+      startTime,
+      endTime,
+      startZoneOffsetSeconds,
+      endZoneOffsetSeconds,
+      metadata,
+      samples,
+    ];
+  }
+
+  Object encode() {
+    return _toList();
+  }
+
+  static CyclingPedalingCadenceSeriesRecordDto decode(Object result) {
+    result as List<Object?>;
+    return CyclingPedalingCadenceSeriesRecordDto(
+      id: result[0] as String?,
+      startTime: result[1]! as int,
+      endTime: result[2]! as int,
+      startZoneOffsetSeconds: result[3] as int?,
+      endZoneOffsetSeconds: result[4] as int?,
+      metadata: result[5]! as MetadataDto,
+      samples: (result[6] as List<Object?>?)!
+          .cast<CyclingPedalingCadenceMeasurementDto>(),
+    );
+  }
+
+  @override
+  // ignore: avoid_equals_and_hash_code_on_mutable_classes
+  bool operator ==(Object other) {
+    if (other is! CyclingPedalingCadenceSeriesRecordDto ||
+        other.runtimeType != runtimeType) {
+      return false;
+    }
+    if (identical(this, other)) {
+      return true;
+    }
+    return _deepEquals(encode(), other.encode());
+  }
+
+  @override
+  // ignore: avoid_equals_and_hash_code_on_mutable_classes
+  int get hashCode => Object.hashAll(_toList());
+}
+
 /// Represents a single speed measurement within a [SpeedSeriesRecordDto].
 class SpeedMeasurementDto {
   SpeedMeasurementDto({
@@ -4712,77 +4850,83 @@ class _PigeonCodec extends StandardMessageCodec {
     } else if (value is HeartRateSeriesRecordDto) {
       buffer.putUint8(195);
       writeValue(buffer, value.encode());
-    } else if (value is SpeedMeasurementDto) {
+    } else if (value is CyclingPedalingCadenceMeasurementDto) {
       buffer.putUint8(196);
       writeValue(buffer, value.encode());
-    } else if (value is SpeedSeriesRecordDto) {
+    } else if (value is CyclingPedalingCadenceSeriesRecordDto) {
       buffer.putUint8(197);
       writeValue(buffer, value.encode());
-    } else if (value is PowerMeasurementDto) {
+    } else if (value is SpeedMeasurementDto) {
       buffer.putUint8(198);
       writeValue(buffer, value.encode());
-    } else if (value is PowerSeriesRecordDto) {
+    } else if (value is SpeedSeriesRecordDto) {
       buffer.putUint8(199);
       writeValue(buffer, value.encode());
-    } else if (value is SleepStageDto) {
+    } else if (value is PowerMeasurementDto) {
       buffer.putUint8(200);
       writeValue(buffer, value.encode());
-    } else if (value is SleepSessionRecordDto) {
+    } else if (value is PowerSeriesRecordDto) {
       buffer.putUint8(201);
       writeValue(buffer, value.encode());
-    } else if (value is SexualActivityRecordDto) {
+    } else if (value is SleepStageDto) {
       buffer.putUint8(202);
       writeValue(buffer, value.encode());
-    } else if (value is ExerciseSessionRecordDto) {
+    } else if (value is SleepSessionRecordDto) {
       buffer.putUint8(203);
       writeValue(buffer, value.encode());
-    } else if (value is MindfulnessSessionRecordDto) {
+    } else if (value is SexualActivityRecordDto) {
       buffer.putUint8(204);
       writeValue(buffer, value.encode());
-    } else if (value is NutritionRecordDto) {
+    } else if (value is ExerciseSessionRecordDto) {
       buffer.putUint8(205);
       writeValue(buffer, value.encode());
-    } else if (value is HealthPlatformFeaturePermissionRequestResultDto) {
+    } else if (value is MindfulnessSessionRecordDto) {
       buffer.putUint8(206);
       writeValue(buffer, value.encode());
-    } else if (value is HealthDataPermissionRequestDto) {
+    } else if (value is NutritionRecordDto) {
       buffer.putUint8(207);
       writeValue(buffer, value.encode());
-    } else if (value is HealthDataPermissionRequestResultDto) {
+    } else if (value is HealthPlatformFeaturePermissionRequestResultDto) {
       buffer.putUint8(208);
       writeValue(buffer, value.encode());
-    } else if (value is HealthPlatformFeaturePermissionRequest) {
+    } else if (value is HealthDataPermissionRequestDto) {
       buffer.putUint8(209);
       writeValue(buffer, value.encode());
-    } else if (value is PermissionRequestsDto) {
+    } else if (value is HealthDataPermissionRequestResultDto) {
       buffer.putUint8(210);
       writeValue(buffer, value.encode());
-    } else if (value is PermissionRequestsResponseDto) {
+    } else if (value is HealthPlatformFeaturePermissionRequest) {
       buffer.putUint8(211);
       writeValue(buffer, value.encode());
-    } else if (value is CommonAggregateRequestDto) {
+    } else if (value is PermissionRequestsDto) {
       buffer.putUint8(212);
       writeValue(buffer, value.encode());
-    } else if (value is BloodPressureAggregateRequestDto) {
+    } else if (value is PermissionRequestsResponseDto) {
       buffer.putUint8(213);
       writeValue(buffer, value.encode());
-    } else if (value is DeleteRecordsByIdsRequestDto) {
+    } else if (value is CommonAggregateRequestDto) {
       buffer.putUint8(214);
       writeValue(buffer, value.encode());
-    } else if (value is DeleteRecordsByTimeRangeRequestDto) {
+    } else if (value is BloodPressureAggregateRequestDto) {
       buffer.putUint8(215);
       writeValue(buffer, value.encode());
-    } else if (value is ReadRecordRequestDto) {
+    } else if (value is DeleteRecordsByIdsRequestDto) {
       buffer.putUint8(216);
       writeValue(buffer, value.encode());
-    } else if (value is ReadRecordsRequestDto) {
+    } else if (value is DeleteRecordsByTimeRangeRequestDto) {
       buffer.putUint8(217);
       writeValue(buffer, value.encode());
-    } else if (value is ReadRecordsResponseDto) {
+    } else if (value is ReadRecordRequestDto) {
       buffer.putUint8(218);
       writeValue(buffer, value.encode());
-    } else if (value is HealthConnectorConfigDto) {
+    } else if (value is ReadRecordsRequestDto) {
       buffer.putUint8(219);
+      writeValue(buffer, value.encode());
+    } else if (value is ReadRecordsResponseDto) {
+      buffer.putUint8(220);
+      writeValue(buffer, value.encode());
+    } else if (value is HealthConnectorConfigDto) {
+      buffer.putUint8(221);
       writeValue(buffer, value.encode());
     } else {
       super.writeValue(buffer, value);
@@ -4975,56 +5119,60 @@ class _PigeonCodec extends StandardMessageCodec {
       case 195:
         return HeartRateSeriesRecordDto.decode(readValue(buffer)!);
       case 196:
-        return SpeedMeasurementDto.decode(readValue(buffer)!);
+        return CyclingPedalingCadenceMeasurementDto.decode(readValue(buffer)!);
       case 197:
-        return SpeedSeriesRecordDto.decode(readValue(buffer)!);
+        return CyclingPedalingCadenceSeriesRecordDto.decode(readValue(buffer)!);
       case 198:
-        return PowerMeasurementDto.decode(readValue(buffer)!);
+        return SpeedMeasurementDto.decode(readValue(buffer)!);
       case 199:
-        return PowerSeriesRecordDto.decode(readValue(buffer)!);
+        return SpeedSeriesRecordDto.decode(readValue(buffer)!);
       case 200:
-        return SleepStageDto.decode(readValue(buffer)!);
+        return PowerMeasurementDto.decode(readValue(buffer)!);
       case 201:
-        return SleepSessionRecordDto.decode(readValue(buffer)!);
+        return PowerSeriesRecordDto.decode(readValue(buffer)!);
       case 202:
-        return SexualActivityRecordDto.decode(readValue(buffer)!);
+        return SleepStageDto.decode(readValue(buffer)!);
       case 203:
-        return ExerciseSessionRecordDto.decode(readValue(buffer)!);
+        return SleepSessionRecordDto.decode(readValue(buffer)!);
       case 204:
-        return MindfulnessSessionRecordDto.decode(readValue(buffer)!);
+        return SexualActivityRecordDto.decode(readValue(buffer)!);
       case 205:
-        return NutritionRecordDto.decode(readValue(buffer)!);
+        return ExerciseSessionRecordDto.decode(readValue(buffer)!);
       case 206:
+        return MindfulnessSessionRecordDto.decode(readValue(buffer)!);
+      case 207:
+        return NutritionRecordDto.decode(readValue(buffer)!);
+      case 208:
         return HealthPlatformFeaturePermissionRequestResultDto.decode(
           readValue(buffer)!,
         );
-      case 207:
-        return HealthDataPermissionRequestDto.decode(readValue(buffer)!);
-      case 208:
-        return HealthDataPermissionRequestResultDto.decode(readValue(buffer)!);
       case 209:
+        return HealthDataPermissionRequestDto.decode(readValue(buffer)!);
+      case 210:
+        return HealthDataPermissionRequestResultDto.decode(readValue(buffer)!);
+      case 211:
         return HealthPlatformFeaturePermissionRequest.decode(
           readValue(buffer)!,
         );
-      case 210:
-        return PermissionRequestsDto.decode(readValue(buffer)!);
-      case 211:
-        return PermissionRequestsResponseDto.decode(readValue(buffer)!);
       case 212:
-        return CommonAggregateRequestDto.decode(readValue(buffer)!);
+        return PermissionRequestsDto.decode(readValue(buffer)!);
       case 213:
-        return BloodPressureAggregateRequestDto.decode(readValue(buffer)!);
+        return PermissionRequestsResponseDto.decode(readValue(buffer)!);
       case 214:
-        return DeleteRecordsByIdsRequestDto.decode(readValue(buffer)!);
+        return CommonAggregateRequestDto.decode(readValue(buffer)!);
       case 215:
-        return DeleteRecordsByTimeRangeRequestDto.decode(readValue(buffer)!);
+        return BloodPressureAggregateRequestDto.decode(readValue(buffer)!);
       case 216:
-        return ReadRecordRequestDto.decode(readValue(buffer)!);
+        return DeleteRecordsByIdsRequestDto.decode(readValue(buffer)!);
       case 217:
-        return ReadRecordsRequestDto.decode(readValue(buffer)!);
+        return DeleteRecordsByTimeRangeRequestDto.decode(readValue(buffer)!);
       case 218:
-        return ReadRecordsResponseDto.decode(readValue(buffer)!);
+        return ReadRecordRequestDto.decode(readValue(buffer)!);
       case 219:
+        return ReadRecordsRequestDto.decode(readValue(buffer)!);
+      case 220:
+        return ReadRecordsResponseDto.decode(readValue(buffer)!);
+      case 221:
         return HealthConnectorConfigDto.decode(readValue(buffer)!);
       default:
         return super.readValueOfType(type, buffer);

--- a/packages/health_connector_hc_android/pigeons/health_connector_hc_android_api.dart
+++ b/packages/health_connector_hc_android/pigeons/health_connector_hc_android_api.dart
@@ -696,6 +696,9 @@ enum HealthDataTypeDto {
   /// Heart rate series record data.
   heartRateSeriesRecord,
 
+  /// Cycling pedaling cadence series record data.
+  cyclingPedalingCadenceSeriesRecord,
+
   /// Sexual activity data.
   sexualActivity,
 
@@ -1338,6 +1341,58 @@ class HeartRateSeriesRecordDto extends HealthRecordDto {
 
   /// Timezone offset in seconds for end time (optional).
   final int? endZoneOffsetSeconds;
+}
+
+/// Represents a single cycling pedaling cadence measurement.
+///
+/// This is a platform-agnostic value class used within cycling pedaling
+/// cadence records.
+/// It contains a timestamp and RPM value without ID or metadata.
+class CyclingPedalingCadenceMeasurementDto {
+  CyclingPedalingCadenceMeasurementDto({
+    required this.time,
+    required this.revolutionsPerMinute,
+  });
+
+  /// Timestamp in milliseconds since epoch (UTC).
+  final int time;
+
+  /// Cycling cadence value in revolutions per minute (RPM).
+  final NumberDto revolutionsPerMinute;
+}
+
+/// Represents a cycling pedaling cadence series record.
+class CyclingPedalingCadenceSeriesRecordDto extends HealthRecordDto {
+  CyclingPedalingCadenceSeriesRecordDto({
+    required this.id,
+    required this.startTime,
+    required this.endTime,
+    required this.metadata,
+    required this.samples,
+    this.startZoneOffsetSeconds,
+    this.endZoneOffsetSeconds,
+  });
+
+  /// Platform-assigned unique identifier. Null if not yet synced.
+  final String? id;
+
+  /// Start time in milliseconds since epoch (UTC).
+  final int startTime;
+
+  /// End time in milliseconds since epoch (UTC).
+  final int endTime;
+
+  /// Start timezone offset in seconds. Null if unknown.
+  final int? startZoneOffsetSeconds;
+
+  /// End timezone offset in seconds. Null if unknown.
+  final int? endZoneOffsetSeconds;
+
+  /// Metadata for this record.
+  final MetadataDto metadata;
+
+  /// List of cadence measurements.
+  final List<CyclingPedalingCadenceMeasurementDto> samples;
 }
 
 /// Represents a single speed measurement within a [SpeedSeriesRecordDto].

--- a/packages/health_connector_hk_ios/ios/health_connector_hk_ios/Sources/health_connector_hk_ios/handlers/HealthRecordHandlerRegistry.swift
+++ b/packages/health_connector_hk_ios/ios/health_connector_hk_ios/Sources/health_connector_hk_ios/handlers/HealthRecordHandlerRegistry.swift
@@ -90,6 +90,7 @@ final class HealthRecordHandlerRegistry: @unchecked Sendable {
         register(CervicalMucusHandler(healthStore: healthStore))
         register(LeanBodyMassHandler(healthStore: healthStore))
         register(HeartRateHandler(healthStore: healthStore))
+        register(CyclingPedalingCadenceHandler(healthStore: healthStore))
         register(RestingHeartRateHandler(healthStore: healthStore))
         register(SexualActivityHandler(healthStore: healthStore))
         register(SleepStageHandler(healthStore: healthStore))

--- a/packages/health_connector_hk_ios/ios/health_connector_hk_ios/Sources/health_connector_hk_ios/handlers/health_record_handlers/CyclingPedalingCadenceHandler.swift
+++ b/packages/health_connector_hk_ios/ios/health_connector_hk_ios/Sources/health_connector_hk_ios/handlers/health_record_handlers/CyclingPedalingCadenceHandler.swift
@@ -1,0 +1,29 @@
+import Foundation
+import HealthKit
+
+/// Handler for cycling pedaling cadence measurement data (instant quantity type)
+final class CyclingPedalingCadenceHandler: @unchecked Sendable,
+    ReadableHealthRecordHandler,
+    WritableHealthRecordHandler,
+    DeletableHealthRecordHandler,
+    AggregatableQuantityHealthRecordHandler
+{
+    typealias RecordDto = CyclingPedalingCadenceMeasurementRecordDto
+    typealias SampleType = HKQuantitySample
+    typealias AggregatedResultMeasurementUnitDto = NumberDto
+
+    let healthStore: HKHealthStore
+
+    init(healthStore: HKHealthStore) {
+        self.healthStore = healthStore
+    }
+
+    static let dataType: HealthDataTypeDto = .cyclingPedalingCadenceMeasurementRecord
+
+    static let supportedAggregationMetrics: Set<AggregationMetricDto> = [.min, .max, .avg]
+
+    func convertQuantity(_ quantity: HKQuantity) throws -> NumberDto {
+        let rpm = quantity.doubleValue(for: HKUnit.count().unitDivided(by: .minute()))
+        return NumberDto(value: rpm)
+    }
+}

--- a/packages/health_connector_hk_ios/ios/health_connector_hk_ios/Sources/health_connector_hk_ios/mappers/HealthDataTypeMapper.swift
+++ b/packages/health_connector_hk_ios/ios/health_connector_hk_ios/Sources/health_connector_hk_ios/mappers/HealthDataTypeMapper.swift
@@ -127,6 +127,18 @@ extension HealthDataTypeDto {
                     context: ["dataType": "cyclingPower", "minimumIOSVersion": "17.0"]
                 )
             }
+        case .cyclingPedalingCadenceMeasurementRecord:
+            if #available(iOS 17.0, *) {
+                try HKQuantityType.make(from: .cyclingCadence)
+            } else {
+                throw HealthConnectorError.unsupportedOperation(
+                    message: "Cycling pedaling cadence is only supported on iOS 17.0 and later",
+                    context: [
+                        "dataType": "cyclingPedalingCadenceMeasurementRecord",
+                        "minimumIOSVersion": "17.0",
+                    ]
+                )
+            }
         case .swimmingDistance:
             try HKQuantityType.make(from: .distanceSwimming)
         case .wheelchairDistance:

--- a/packages/health_connector_hk_ios/ios/health_connector_hk_ios/Sources/health_connector_hk_ios/mappers/PermissionMapper.swift
+++ b/packages/health_connector_hk_ios/ios/health_connector_hk_ios/Sources/health_connector_hk_ios/mappers/PermissionMapper.swift
@@ -21,6 +21,7 @@ extension HealthDataPermissionDto {
              .distance,
              .cyclingDistance,
              .cyclingPower,
+             .cyclingPedalingCadenceMeasurementRecord,
              .swimmingDistance,
              .wheelchairDistance,
              .walkingRunningDistance,

--- a/packages/health_connector_hk_ios/ios/health_connector_hk_ios/Sources/health_connector_hk_ios/mappers/health_record_mappers/CyclingPedalingCadenceMeasurementRecordMapper.swift
+++ b/packages/health_connector_hk_ios/ios/health_connector_hk_ios/Sources/health_connector_hk_ios/mappers/health_record_mappers/CyclingPedalingCadenceMeasurementRecordMapper.swift
@@ -1,0 +1,94 @@
+import Foundation
+import HealthKit
+
+extension CyclingPedalingCadenceMeasurementRecordDto {
+    /// Converts this DTO to a HealthKit `HKQuantitySample`.
+    ///
+    /// - Throws: An error if the quantity type cannot be created.
+    func toHealthKit() throws -> HKQuantitySample {
+        if #available(iOS 17.0, *) {
+            let type = try HKQuantityType.make(from: .cyclingCadence)
+
+            // Cycling pedaling cadence is measured in revolutions per minute (count/minute)
+            let unit = HKUnit.count().unitDivided(by: .minute())
+            let quantity = HKQuantity(
+                unit: unit, doubleValue: measurement.revolutionsPerMinute.toDouble()
+            )
+            let date = Date(millisecondsSince1970: measurement.time)
+
+            // Create builder with timezone offset
+            var builder = try MetadataBuilder(
+                from: metadata,
+                startTimeZoneOffset: zoneOffsetSeconds
+            )
+
+            return HKQuantitySample(
+                type: type,
+                quantity: quantity,
+                start: date,
+                end: date, // Instant records have same start and end
+                device: builder.healthDevice,
+                metadata: builder.metadataDict
+            )
+        } else {
+            throw HealthConnectorError.unsupportedOperation(
+                message: "Cycling pedaling cadence is only supported on iOS 17.0 and later",
+                context: ["dataType": "cyclingPedalingCadence", "minimumIOSVersion": "17.0"]
+            )
+        }
+    }
+}
+
+extension HKQuantitySample {
+    /// Converts this HealthKit sample to a `CyclingPedalingCadenceMeasurementRecordDto`.
+    ///
+    /// - Throws: `HealthConnectorError.invalidArgument` if this sample is not a cycling cadence sample.
+    func toCyclingPedalingCadenceMeasurementRecordDto() throws
+        -> CyclingPedalingCadenceMeasurementRecordDto
+    {
+        if #available(iOS 17.0, *) {
+            guard quantityType.identifier == HKQuantityTypeIdentifier.cyclingCadence.rawValue else {
+                throw HealthConnectorError.invalidArgument(
+                    message:
+                    "Expected cycling cadence quantity type, got \(quantityType.identifier)",
+                    context: [
+                        "expected": HKQuantityTypeIdentifier.cyclingCadence.rawValue,
+                        "actual": quantityType.identifier,
+                    ]
+                )
+            }
+
+            // Cycling pedaling cadence is in revolutions per minute (count/minute)
+            let unit = HKUnit.count().unitDivided(by: .minute())
+            let rpmValue = quantity.doubleValue(for: unit)
+
+            let measurement = CyclingPedalingCadenceMeasurementDto(
+                time: startDate.millisecondsSince1970,
+                revolutionsPerMinute: NumberDto(value: rpmValue)
+            )
+
+            // Create builder from HK metadata with source and device
+            var builder = MetadataBuilder(
+                fromHKMetadata: metadata ?? [:],
+                source: sourceRevision.source,
+                device: device
+            )
+
+            // Extract timezone offset from metadata
+            let zoneOffset = StartTimeZoneOffsetKey.read(from: builder.metadataDict)
+
+            return try CyclingPedalingCadenceMeasurementRecordDto(
+                id: uuid.uuidString,
+                time: startDate.millisecondsSince1970,
+                metadata: builder.toMetadataDto(),
+                measurement: measurement,
+                zoneOffsetSeconds: zoneOffset
+            )
+        } else {
+            throw HealthConnectorError.unsupportedOperation(
+                message: "Cycling pedaling cadence is only supported on iOS 17.0 and later",
+                context: ["dataType": "cyclingPedalingCadence", "minimumIOSVersion": "17.0"]
+            )
+        }
+    }
+}

--- a/packages/health_connector_hk_ios/ios/health_connector_hk_ios/Sources/health_connector_hk_ios/mappers/health_record_mappers/HealthRecordMapper.swift
+++ b/packages/health_connector_hk_ios/ios/health_connector_hk_ios/Sources/health_connector_hk_ios/mappers/health_record_mappers/HealthRecordMapper.swift
@@ -61,6 +61,8 @@ extension HealthRecordDto {
             return try dto.toHealthKit()
         case let dto as CyclingPowerRecordDto:
             return try dto.toHealthKit()
+        case let dto as CyclingPedalingCadenceMeasurementRecordDto:
+            return try dto.toHealthKit()
         case let dto as ExerciseSessionRecordDto:
             return try dto.toHealthKit()
         case let dto as MindfulnessSessionRecordDto:
@@ -232,6 +234,8 @@ extension HKQuantitySample {
             try toSpeedActivityRecordDto(speedActivityType: .stairDescent)
         case .cyclingPower:
             try toCyclingPowerRecordDto()
+        case .cyclingPedalingCadenceMeasurementRecord:
+            try toCyclingPedalingCadenceMeasurementRecordDto()
         default:
             throw HealthConnectorError.invalidArgument(
                 message: "Unsupported health data type for HKQuantitySample",

--- a/packages/health_connector_hk_ios/ios/health_connector_hk_ios/Sources/health_connector_hk_ios/pigeon/HealthConnectorHKIOSApi.g.swift
+++ b/packages/health_connector_hk_ios/ios/health_connector_hk_ios/Sources/health_connector_hk_ios/pigeon/HealthConnectorHKIOSApi.g.swift
@@ -672,106 +672,108 @@ public enum HealthDataTypeDto: Int {
   case hydration = 22
   /// Heart rate measurement record data (iOS HealthKit).
   case heartRateMeasurementRecord = 23
+  /// Cycling pedaling cadence measurement record data (iOS HealthKit).
+  case cyclingPedalingCadenceMeasurementRecord = 24
   /// Sleep stage record data (iOS HealthKit).
-  case sleepStageRecord = 24
+  case sleepStageRecord = 25
   /// Sexual activity data.
-  case sexualActivity = 25
+  case sexualActivity = 26
   /// Walking speed data.
-  case walkingSpeed = 26
+  case walkingSpeed = 27
   /// Running speed data.
-  case runningSpeed = 27
+  case runningSpeed = 28
   /// Stair ascent speed data.
-  case stairAscentSpeed = 28
+  case stairAscentSpeed = 29
   /// Stair descent speed data.
-  case stairDescentSpeed = 29
+  case stairDescentSpeed = 30
   /// Energy nutrient data (calories consumed).
-  case energyNutrient = 30
+  case energyNutrient = 31
   /// Caffeine nutrient data.
-  case caffeine = 31
+  case caffeine = 32
   /// Protein nutrient data.
-  case protein = 32
+  case protein = 33
   /// Total carbohydrate nutrient data.
-  case totalCarbohydrate = 33
+  case totalCarbohydrate = 34
   /// Total fat nutrient data.
-  case totalFat = 34
+  case totalFat = 35
   /// Saturated fat nutrient data.
-  case saturatedFat = 35
+  case saturatedFat = 36
   /// Monounsaturated fat nutrient data.
-  case monounsaturatedFat = 36
+  case monounsaturatedFat = 37
   /// Polyunsaturated fat nutrient data.
-  case polyunsaturatedFat = 37
+  case polyunsaturatedFat = 38
   /// Cholesterol nutrient data.
-  case cholesterol = 38
+  case cholesterol = 39
   /// Dietary fiber nutrient data.
-  case dietaryFiber = 39
+  case dietaryFiber = 40
   /// Sugar nutrient data.
-  case sugar = 40
+  case sugar = 41
   /// Vitamin A nutrient data.
-  case vitaminA = 41
+  case vitaminA = 42
   /// Vitamin B6 nutrient data.
-  case vitaminB6 = 42
+  case vitaminB6 = 43
   /// Vitamin B12 nutrient data.
-  case vitaminB12 = 43
+  case vitaminB12 = 44
   /// Vitamin C nutrient data.
-  case vitaminC = 44
+  case vitaminC = 45
   /// Vitamin D nutrient data.
-  case vitaminD = 45
+  case vitaminD = 46
   /// Vitamin E nutrient data.
-  case vitaminE = 46
+  case vitaminE = 47
   /// Vitamin K nutrient data.
-  case vitaminK = 47
+  case vitaminK = 48
   /// Thiamin (Vitamin B1) nutrient data.
-  case thiamin = 48
+  case thiamin = 49
   /// Riboflavin (Vitamin B2) nutrient data.
-  case riboflavin = 49
+  case riboflavin = 50
   /// Niacin (Vitamin B3) nutrient data.
-  case niacin = 50
+  case niacin = 51
   /// Folate (Vitamin B9) nutrient data.
-  case folate = 51
+  case folate = 52
   /// Biotin (Vitamin B7) nutrient data.
-  case biotin = 52
+  case biotin = 53
   /// Pantothenic acid (Vitamin B5) nutrient data.
-  case pantothenicAcid = 53
+  case pantothenicAcid = 54
   /// Calcium nutrient data.
-  case calcium = 54
+  case calcium = 55
   /// Iron nutrient data.
-  case iron = 55
+  case iron = 56
   /// Magnesium nutrient data.
-  case magnesium = 56
+  case magnesium = 57
   /// Manganese nutrient data.
-  case manganese = 57
+  case manganese = 58
   /// Phosphorus nutrient data.
-  case phosphorus = 58
+  case phosphorus = 59
   /// Potassium nutrient data.
-  case potassium = 59
+  case potassium = 60
   /// Selenium nutrient data.
-  case selenium = 60
+  case selenium = 61
   /// Sodium nutrient data.
-  case sodium = 61
+  case sodium = 62
   /// Zinc nutrient data.
-  case zinc = 62
+  case zinc = 63
   /// Combined nutrition record (HKCorrelation.food).
-  case nutrition = 63
+  case nutrition = 64
   /// Resting heart rate data.
-  case restingHeartRate = 64
+  case restingHeartRate = 65
   /// Composite blood pressure (HKCorrelationType.bloodPressure).
-  case bloodPressure = 65
+  case bloodPressure = 66
   /// Systolic blood pressure (HKQuantityType.bloodPressureSystolic).
-  case systolicBloodPressure = 66
+  case systolicBloodPressure = 67
   /// Diastolic blood pressure (HKQuantityType.bloodPressureDiastolic).
-  case diastolicBloodPressure = 67
+  case diastolicBloodPressure = 68
   /// Oxygen saturation data.
-  case oxygenSaturation = 68
+  case oxygenSaturation = 69
   /// Respiratory rate data.
-  case respiratoryRate = 69
+  case respiratoryRate = 70
   /// VO2 max (maximal oxygen uptake) data.
-  case vo2Max = 70
+  case vo2Max = 71
   /// Blood glucose data.
-  case bloodGlucose = 71
+  case bloodGlucose = 72
   /// Exercise session data.
-  case exerciseSession = 72
+  case exerciseSession = 73
   /// Mindfulness session data.
-  case mindfulnessSession = 73
+  case mindfulnessSession = 74
 }
 
 /// Aggregation metric types for health data queries.
@@ -2722,6 +2724,91 @@ public struct HeartRateMeasurementRecordDto: HealthRecordDto {
     ]
   }
   public static func == (lhs: HeartRateMeasurementRecordDto, rhs: HeartRateMeasurementRecordDto) -> Bool {
+    return deepEqualsHealthConnectorHKIOSApi(lhs.toList(), rhs.toList())  }
+  public func hash(into hasher: inout Hasher) {
+    deepHashHealthConnectorHKIOSApi(value: toList(), hasher: &hasher)
+  }
+}
+
+/// Represents a single cycling pedaling cadence measurement.
+///
+/// This is a platform-agnostic value class used within cycling pedaling
+/// cadence records.
+/// It contains a timestamp and RPM value without ID or metadata.
+///
+/// Generated class from Pigeon that represents data sent in messages.
+public struct CyclingPedalingCadenceMeasurementDto: Hashable {
+  /// Timestamp in milliseconds since epoch (UTC).
+  var time: Int64
+  /// Cycling cadence value in revolutions per minute (RPM).
+  var revolutionsPerMinute: NumberDto
+
+
+  // swift-format-ignore: AlwaysUseLowerCamelCase
+  static func fromList(_ pigeonVar_list: [Any?]) -> CyclingPedalingCadenceMeasurementDto? {
+    let time = pigeonVar_list[0] as! Int64
+    let revolutionsPerMinute = pigeonVar_list[1] as! NumberDto
+
+    return CyclingPedalingCadenceMeasurementDto(
+      time: time,
+      revolutionsPerMinute: revolutionsPerMinute
+    )
+  }
+  func toList() -> [Any?] {
+    return [
+      time,
+      revolutionsPerMinute,
+    ]
+  }
+  public static func == (lhs: CyclingPedalingCadenceMeasurementDto, rhs: CyclingPedalingCadenceMeasurementDto) -> Bool {
+    return deepEqualsHealthConnectorHKIOSApi(lhs.toList(), rhs.toList())  }
+  public func hash(into hasher: inout Hasher) {
+    deepHashHealthConnectorHKIOSApi(value: toList(), hasher: &hasher)
+  }
+}
+
+/// Represents a cycling pedaling cadence measurement record (iOS HealthKit).
+///
+/// Generated class from Pigeon that represents data sent in messages.
+public struct CyclingPedalingCadenceMeasurementRecordDto: HealthRecordDto {
+  /// Platform-assigned unique identifier.
+  var id: String? = nil
+  /// Time in milliseconds since epoch (UTC).
+  var time: Int64
+  /// Metadata for this record.
+  var metadata: MetadataDto
+  /// The cadence measurement.
+  var measurement: CyclingPedalingCadenceMeasurementDto
+  /// Timezone offset in seconds. Null if unknown.
+  var zoneOffsetSeconds: Int64? = nil
+
+
+  // swift-format-ignore: AlwaysUseLowerCamelCase
+  static func fromList(_ pigeonVar_list: [Any?]) -> CyclingPedalingCadenceMeasurementRecordDto? {
+    let id: String? = nilOrValue(pigeonVar_list[0])
+    let time = pigeonVar_list[1] as! Int64
+    let metadata = pigeonVar_list[2] as! MetadataDto
+    let measurement = pigeonVar_list[3] as! CyclingPedalingCadenceMeasurementDto
+    let zoneOffsetSeconds: Int64? = nilOrValue(pigeonVar_list[4])
+
+    return CyclingPedalingCadenceMeasurementRecordDto(
+      id: id,
+      time: time,
+      metadata: metadata,
+      measurement: measurement,
+      zoneOffsetSeconds: zoneOffsetSeconds
+    )
+  }
+  func toList() -> [Any?] {
+    return [
+      id,
+      time,
+      metadata,
+      measurement,
+      zoneOffsetSeconds,
+    ]
+  }
+  public static func == (lhs: CyclingPedalingCadenceMeasurementRecordDto, rhs: CyclingPedalingCadenceMeasurementRecordDto) -> Bool {
     return deepEqualsHealthConnectorHKIOSApi(lhs.toList(), rhs.toList())  }
   public func hash(into hasher: inout Hasher) {
     deepHashHealthConnectorHKIOSApi(value: toList(), hasher: &hasher)
@@ -5406,96 +5493,100 @@ private class HealthConnectorHKIOSApiPigeonCodecReader: FlutterStandardReader {
     case 200:
       return HeartRateMeasurementRecordDto.fromList(self.readValue() as! [Any?])
     case 201:
-      return SleepStageRecordDto.fromList(self.readValue() as! [Any?])
+      return CyclingPedalingCadenceMeasurementDto.fromList(self.readValue() as! [Any?])
     case 202:
-      return SexualActivityRecordDto.fromList(self.readValue() as! [Any?])
+      return CyclingPedalingCadenceMeasurementRecordDto.fromList(self.readValue() as! [Any?])
     case 203:
-      return EnergyNutrientRecordDto.fromList(self.readValue() as! [Any?])
+      return SleepStageRecordDto.fromList(self.readValue() as! [Any?])
     case 204:
-      return CaffeineNutrientRecordDto.fromList(self.readValue() as! [Any?])
+      return SexualActivityRecordDto.fromList(self.readValue() as! [Any?])
     case 205:
-      return ProteinNutrientRecordDto.fromList(self.readValue() as! [Any?])
+      return EnergyNutrientRecordDto.fromList(self.readValue() as! [Any?])
     case 206:
-      return TotalCarbohydrateNutrientRecordDto.fromList(self.readValue() as! [Any?])
+      return CaffeineNutrientRecordDto.fromList(self.readValue() as! [Any?])
     case 207:
-      return TotalFatNutrientRecordDto.fromList(self.readValue() as! [Any?])
+      return ProteinNutrientRecordDto.fromList(self.readValue() as! [Any?])
     case 208:
-      return SaturatedFatNutrientRecordDto.fromList(self.readValue() as! [Any?])
+      return TotalCarbohydrateNutrientRecordDto.fromList(self.readValue() as! [Any?])
     case 209:
-      return MonounsaturatedFatNutrientRecordDto.fromList(self.readValue() as! [Any?])
+      return TotalFatNutrientRecordDto.fromList(self.readValue() as! [Any?])
     case 210:
-      return PolyunsaturatedFatNutrientRecordDto.fromList(self.readValue() as! [Any?])
+      return SaturatedFatNutrientRecordDto.fromList(self.readValue() as! [Any?])
     case 211:
-      return CholesterolNutrientRecordDto.fromList(self.readValue() as! [Any?])
+      return MonounsaturatedFatNutrientRecordDto.fromList(self.readValue() as! [Any?])
     case 212:
-      return DietaryFiberNutrientRecordDto.fromList(self.readValue() as! [Any?])
+      return PolyunsaturatedFatNutrientRecordDto.fromList(self.readValue() as! [Any?])
     case 213:
-      return SugarNutrientRecordDto.fromList(self.readValue() as! [Any?])
+      return CholesterolNutrientRecordDto.fromList(self.readValue() as! [Any?])
     case 214:
-      return VitaminANutrientRecordDto.fromList(self.readValue() as! [Any?])
+      return DietaryFiberNutrientRecordDto.fromList(self.readValue() as! [Any?])
     case 215:
-      return VitaminB6NutrientRecordDto.fromList(self.readValue() as! [Any?])
+      return SugarNutrientRecordDto.fromList(self.readValue() as! [Any?])
     case 216:
-      return VitaminB12NutrientRecordDto.fromList(self.readValue() as! [Any?])
+      return VitaminANutrientRecordDto.fromList(self.readValue() as! [Any?])
     case 217:
-      return VitaminCNutrientRecordDto.fromList(self.readValue() as! [Any?])
+      return VitaminB6NutrientRecordDto.fromList(self.readValue() as! [Any?])
     case 218:
-      return VitaminDNutrientRecordDto.fromList(self.readValue() as! [Any?])
+      return VitaminB12NutrientRecordDto.fromList(self.readValue() as! [Any?])
     case 219:
-      return VitaminENutrientRecordDto.fromList(self.readValue() as! [Any?])
+      return VitaminCNutrientRecordDto.fromList(self.readValue() as! [Any?])
     case 220:
-      return VitaminKNutrientRecordDto.fromList(self.readValue() as! [Any?])
+      return VitaminDNutrientRecordDto.fromList(self.readValue() as! [Any?])
     case 221:
-      return ThiaminNutrientRecordDto.fromList(self.readValue() as! [Any?])
+      return VitaminENutrientRecordDto.fromList(self.readValue() as! [Any?])
     case 222:
-      return RiboflavinNutrientRecordDto.fromList(self.readValue() as! [Any?])
+      return VitaminKNutrientRecordDto.fromList(self.readValue() as! [Any?])
     case 223:
-      return NiacinNutrientRecordDto.fromList(self.readValue() as! [Any?])
+      return ThiaminNutrientRecordDto.fromList(self.readValue() as! [Any?])
     case 224:
-      return FolateNutrientRecordDto.fromList(self.readValue() as! [Any?])
+      return RiboflavinNutrientRecordDto.fromList(self.readValue() as! [Any?])
     case 225:
-      return BiotinNutrientRecordDto.fromList(self.readValue() as! [Any?])
+      return NiacinNutrientRecordDto.fromList(self.readValue() as! [Any?])
     case 226:
-      return PantothenicAcidNutrientRecordDto.fromList(self.readValue() as! [Any?])
+      return FolateNutrientRecordDto.fromList(self.readValue() as! [Any?])
     case 227:
-      return CalciumNutrientRecordDto.fromList(self.readValue() as! [Any?])
+      return BiotinNutrientRecordDto.fromList(self.readValue() as! [Any?])
     case 228:
-      return IronNutrientRecordDto.fromList(self.readValue() as! [Any?])
+      return PantothenicAcidNutrientRecordDto.fromList(self.readValue() as! [Any?])
     case 229:
-      return MagnesiumNutrientRecordDto.fromList(self.readValue() as! [Any?])
+      return CalciumNutrientRecordDto.fromList(self.readValue() as! [Any?])
     case 230:
-      return ManganeseNutrientRecordDto.fromList(self.readValue() as! [Any?])
+      return IronNutrientRecordDto.fromList(self.readValue() as! [Any?])
     case 231:
-      return PhosphorusNutrientRecordDto.fromList(self.readValue() as! [Any?])
+      return MagnesiumNutrientRecordDto.fromList(self.readValue() as! [Any?])
     case 232:
-      return PotassiumNutrientRecordDto.fromList(self.readValue() as! [Any?])
+      return ManganeseNutrientRecordDto.fromList(self.readValue() as! [Any?])
     case 233:
-      return SeleniumNutrientRecordDto.fromList(self.readValue() as! [Any?])
+      return PhosphorusNutrientRecordDto.fromList(self.readValue() as! [Any?])
     case 234:
-      return SodiumNutrientRecordDto.fromList(self.readValue() as! [Any?])
+      return PotassiumNutrientRecordDto.fromList(self.readValue() as! [Any?])
     case 235:
-      return ZincNutrientRecordDto.fromList(self.readValue() as! [Any?])
+      return SeleniumNutrientRecordDto.fromList(self.readValue() as! [Any?])
     case 236:
-      return NutritionRecordDto.fromList(self.readValue() as! [Any?])
+      return SodiumNutrientRecordDto.fromList(self.readValue() as! [Any?])
     case 237:
-      return HealthDataPermissionRequestResultDto.fromList(self.readValue() as! [Any?])
+      return ZincNutrientRecordDto.fromList(self.readValue() as! [Any?])
     case 238:
-      return PermissionsRequestDto.fromList(self.readValue() as! [Any?])
+      return NutritionRecordDto.fromList(self.readValue() as! [Any?])
     case 239:
-      return PermissionsRequestResponseDto.fromList(self.readValue() as! [Any?])
+      return HealthDataPermissionRequestResultDto.fromList(self.readValue() as! [Any?])
     case 240:
-      return AggregateRequestDto.fromList(self.readValue() as! [Any?])
+      return PermissionsRequestDto.fromList(self.readValue() as! [Any?])
     case 241:
-      return DeleteRecordsByIdsRequestDto.fromList(self.readValue() as! [Any?])
+      return PermissionsRequestResponseDto.fromList(self.readValue() as! [Any?])
     case 242:
-      return DeleteRecordsByTimeRangeRequestDto.fromList(self.readValue() as! [Any?])
+      return AggregateRequestDto.fromList(self.readValue() as! [Any?])
     case 243:
-      return ReadRecordRequestDto.fromList(self.readValue() as! [Any?])
+      return DeleteRecordsByIdsRequestDto.fromList(self.readValue() as! [Any?])
     case 244:
-      return ReadRecordsRequestDto.fromList(self.readValue() as! [Any?])
+      return DeleteRecordsByTimeRangeRequestDto.fromList(self.readValue() as! [Any?])
     case 245:
-      return ReadRecordsResponseDto.fromList(self.readValue() as! [Any?])
+      return ReadRecordRequestDto.fromList(self.readValue() as! [Any?])
     case 246:
+      return ReadRecordsRequestDto.fromList(self.readValue() as! [Any?])
+    case 247:
+      return ReadRecordsResponseDto.fromList(self.readValue() as! [Any?])
+    case 248:
       return HealthConnectorConfigDto.fromList(self.readValue() as! [Any?])
     default:
       return super.readValue(ofType: type)
@@ -5721,143 +5812,149 @@ private class HealthConnectorHKIOSApiPigeonCodecWriter: FlutterStandardWriter {
     } else if let value = value as? HeartRateMeasurementRecordDto {
       super.writeByte(200)
       super.writeValue(value.toList())
-    } else if let value = value as? SleepStageRecordDto {
+    } else if let value = value as? CyclingPedalingCadenceMeasurementDto {
       super.writeByte(201)
       super.writeValue(value.toList())
-    } else if let value = value as? SexualActivityRecordDto {
+    } else if let value = value as? CyclingPedalingCadenceMeasurementRecordDto {
       super.writeByte(202)
       super.writeValue(value.toList())
-    } else if let value = value as? EnergyNutrientRecordDto {
+    } else if let value = value as? SleepStageRecordDto {
       super.writeByte(203)
       super.writeValue(value.toList())
-    } else if let value = value as? CaffeineNutrientRecordDto {
+    } else if let value = value as? SexualActivityRecordDto {
       super.writeByte(204)
       super.writeValue(value.toList())
-    } else if let value = value as? ProteinNutrientRecordDto {
+    } else if let value = value as? EnergyNutrientRecordDto {
       super.writeByte(205)
       super.writeValue(value.toList())
-    } else if let value = value as? TotalCarbohydrateNutrientRecordDto {
+    } else if let value = value as? CaffeineNutrientRecordDto {
       super.writeByte(206)
       super.writeValue(value.toList())
-    } else if let value = value as? TotalFatNutrientRecordDto {
+    } else if let value = value as? ProteinNutrientRecordDto {
       super.writeByte(207)
       super.writeValue(value.toList())
-    } else if let value = value as? SaturatedFatNutrientRecordDto {
+    } else if let value = value as? TotalCarbohydrateNutrientRecordDto {
       super.writeByte(208)
       super.writeValue(value.toList())
-    } else if let value = value as? MonounsaturatedFatNutrientRecordDto {
+    } else if let value = value as? TotalFatNutrientRecordDto {
       super.writeByte(209)
       super.writeValue(value.toList())
-    } else if let value = value as? PolyunsaturatedFatNutrientRecordDto {
+    } else if let value = value as? SaturatedFatNutrientRecordDto {
       super.writeByte(210)
       super.writeValue(value.toList())
-    } else if let value = value as? CholesterolNutrientRecordDto {
+    } else if let value = value as? MonounsaturatedFatNutrientRecordDto {
       super.writeByte(211)
       super.writeValue(value.toList())
-    } else if let value = value as? DietaryFiberNutrientRecordDto {
+    } else if let value = value as? PolyunsaturatedFatNutrientRecordDto {
       super.writeByte(212)
       super.writeValue(value.toList())
-    } else if let value = value as? SugarNutrientRecordDto {
+    } else if let value = value as? CholesterolNutrientRecordDto {
       super.writeByte(213)
       super.writeValue(value.toList())
-    } else if let value = value as? VitaminANutrientRecordDto {
+    } else if let value = value as? DietaryFiberNutrientRecordDto {
       super.writeByte(214)
       super.writeValue(value.toList())
-    } else if let value = value as? VitaminB6NutrientRecordDto {
+    } else if let value = value as? SugarNutrientRecordDto {
       super.writeByte(215)
       super.writeValue(value.toList())
-    } else if let value = value as? VitaminB12NutrientRecordDto {
+    } else if let value = value as? VitaminANutrientRecordDto {
       super.writeByte(216)
       super.writeValue(value.toList())
-    } else if let value = value as? VitaminCNutrientRecordDto {
+    } else if let value = value as? VitaminB6NutrientRecordDto {
       super.writeByte(217)
       super.writeValue(value.toList())
-    } else if let value = value as? VitaminDNutrientRecordDto {
+    } else if let value = value as? VitaminB12NutrientRecordDto {
       super.writeByte(218)
       super.writeValue(value.toList())
-    } else if let value = value as? VitaminENutrientRecordDto {
+    } else if let value = value as? VitaminCNutrientRecordDto {
       super.writeByte(219)
       super.writeValue(value.toList())
-    } else if let value = value as? VitaminKNutrientRecordDto {
+    } else if let value = value as? VitaminDNutrientRecordDto {
       super.writeByte(220)
       super.writeValue(value.toList())
-    } else if let value = value as? ThiaminNutrientRecordDto {
+    } else if let value = value as? VitaminENutrientRecordDto {
       super.writeByte(221)
       super.writeValue(value.toList())
-    } else if let value = value as? RiboflavinNutrientRecordDto {
+    } else if let value = value as? VitaminKNutrientRecordDto {
       super.writeByte(222)
       super.writeValue(value.toList())
-    } else if let value = value as? NiacinNutrientRecordDto {
+    } else if let value = value as? ThiaminNutrientRecordDto {
       super.writeByte(223)
       super.writeValue(value.toList())
-    } else if let value = value as? FolateNutrientRecordDto {
+    } else if let value = value as? RiboflavinNutrientRecordDto {
       super.writeByte(224)
       super.writeValue(value.toList())
-    } else if let value = value as? BiotinNutrientRecordDto {
+    } else if let value = value as? NiacinNutrientRecordDto {
       super.writeByte(225)
       super.writeValue(value.toList())
-    } else if let value = value as? PantothenicAcidNutrientRecordDto {
+    } else if let value = value as? FolateNutrientRecordDto {
       super.writeByte(226)
       super.writeValue(value.toList())
-    } else if let value = value as? CalciumNutrientRecordDto {
+    } else if let value = value as? BiotinNutrientRecordDto {
       super.writeByte(227)
       super.writeValue(value.toList())
-    } else if let value = value as? IronNutrientRecordDto {
+    } else if let value = value as? PantothenicAcidNutrientRecordDto {
       super.writeByte(228)
       super.writeValue(value.toList())
-    } else if let value = value as? MagnesiumNutrientRecordDto {
+    } else if let value = value as? CalciumNutrientRecordDto {
       super.writeByte(229)
       super.writeValue(value.toList())
-    } else if let value = value as? ManganeseNutrientRecordDto {
+    } else if let value = value as? IronNutrientRecordDto {
       super.writeByte(230)
       super.writeValue(value.toList())
-    } else if let value = value as? PhosphorusNutrientRecordDto {
+    } else if let value = value as? MagnesiumNutrientRecordDto {
       super.writeByte(231)
       super.writeValue(value.toList())
-    } else if let value = value as? PotassiumNutrientRecordDto {
+    } else if let value = value as? ManganeseNutrientRecordDto {
       super.writeByte(232)
       super.writeValue(value.toList())
-    } else if let value = value as? SeleniumNutrientRecordDto {
+    } else if let value = value as? PhosphorusNutrientRecordDto {
       super.writeByte(233)
       super.writeValue(value.toList())
-    } else if let value = value as? SodiumNutrientRecordDto {
+    } else if let value = value as? PotassiumNutrientRecordDto {
       super.writeByte(234)
       super.writeValue(value.toList())
-    } else if let value = value as? ZincNutrientRecordDto {
+    } else if let value = value as? SeleniumNutrientRecordDto {
       super.writeByte(235)
       super.writeValue(value.toList())
-    } else if let value = value as? NutritionRecordDto {
+    } else if let value = value as? SodiumNutrientRecordDto {
       super.writeByte(236)
       super.writeValue(value.toList())
-    } else if let value = value as? HealthDataPermissionRequestResultDto {
+    } else if let value = value as? ZincNutrientRecordDto {
       super.writeByte(237)
       super.writeValue(value.toList())
-    } else if let value = value as? PermissionsRequestDto {
+    } else if let value = value as? NutritionRecordDto {
       super.writeByte(238)
       super.writeValue(value.toList())
-    } else if let value = value as? PermissionsRequestResponseDto {
+    } else if let value = value as? HealthDataPermissionRequestResultDto {
       super.writeByte(239)
       super.writeValue(value.toList())
-    } else if let value = value as? AggregateRequestDto {
+    } else if let value = value as? PermissionsRequestDto {
       super.writeByte(240)
       super.writeValue(value.toList())
-    } else if let value = value as? DeleteRecordsByIdsRequestDto {
+    } else if let value = value as? PermissionsRequestResponseDto {
       super.writeByte(241)
       super.writeValue(value.toList())
-    } else if let value = value as? DeleteRecordsByTimeRangeRequestDto {
+    } else if let value = value as? AggregateRequestDto {
       super.writeByte(242)
       super.writeValue(value.toList())
-    } else if let value = value as? ReadRecordRequestDto {
+    } else if let value = value as? DeleteRecordsByIdsRequestDto {
       super.writeByte(243)
       super.writeValue(value.toList())
-    } else if let value = value as? ReadRecordsRequestDto {
+    } else if let value = value as? DeleteRecordsByTimeRangeRequestDto {
       super.writeByte(244)
       super.writeValue(value.toList())
-    } else if let value = value as? ReadRecordsResponseDto {
+    } else if let value = value as? ReadRecordRequestDto {
       super.writeByte(245)
       super.writeValue(value.toList())
-    } else if let value = value as? HealthConnectorConfigDto {
+    } else if let value = value as? ReadRecordsRequestDto {
       super.writeByte(246)
+      super.writeValue(value.toList())
+    } else if let value = value as? ReadRecordsResponseDto {
+      super.writeByte(247)
+      super.writeValue(value.toList())
+    } else if let value = value as? HealthConnectorConfigDto {
+      super.writeByte(248)
       super.writeValue(value.toList())
     } else {
       super.writeValue(value)

--- a/packages/health_connector_hk_ios/ios/health_connector_hk_ios/Sources/health_connector_hk_ios/utils/HealthConnectorDtoExtensions.swift
+++ b/packages/health_connector_hk_ios/ios/health_connector_hk_ios/Sources/health_connector_hk_ios/utils/HealthConnectorDtoExtensions.swift
@@ -46,6 +46,8 @@ extension HealthRecordDto {
             record.id
         case let record as MindfulnessSessionRecordDto:
             record.id
+        case let record as CyclingPedalingCadenceMeasurementRecordDto:
+            record.id
         default:
             nil
         }
@@ -193,6 +195,8 @@ extension HealthRecordDto {
                 return .cervicalMucus
             case is MindfulnessSessionRecordDto:
                 return .mindfulnessSession
+            case is CyclingPedalingCadenceMeasurementRecordDto:
+                return .cyclingPedalingCadenceMeasurementRecord
             default:
                 throw HealthConnectorError.invalidArgument(
                     message: "Unimplemented HealthRecordDto type: \(type(of: self))")
@@ -329,6 +333,8 @@ extension HealthRecordDto {
             return dto.endTime
         case let dto as MindfulnessSessionRecordDto:
             return dto.endTime
+        case let dto as CyclingPedalingCadenceMeasurementRecordDto:
+            return dto.time
         case let dto as CyclingPowerRecordDto:
             return dto.time
         case let dto as SexualActivityRecordDto:

--- a/packages/health_connector_hk_ios/ios/health_connector_hk_ios/Sources/health_connector_hk_ios/utils/HealthKitExtensions.swift
+++ b/packages/health_connector_hk_ios/ios/health_connector_hk_ios/Sources/health_connector_hk_ios/utils/HealthKitExtensions.swift
@@ -196,6 +196,8 @@ extension HKSample {
                     switch identifier {
                     case HKQuantityTypeIdentifier.cyclingPower.rawValue:
                         return .cyclingPower
+                    case HKQuantityTypeIdentifier.cyclingCadence.rawValue:
+                        return .cyclingPedalingCadenceMeasurementRecord
                     default:
                         break
                     }

--- a/packages/health_connector_hk_ios/lib/src/mappers/health_data_type_mappers.dart
+++ b/packages/health_connector_hk_ios/lib/src/mappers/health_data_type_mappers.dart
@@ -6,6 +6,8 @@ import 'package:health_connector_core/health_connector_core_internal.dart'
         CervicalMucusDataType,
         CrossCountrySkiingDistanceDataType,
         CyclingDistanceDataType,
+        CyclingPedalingCadenceMeasurementRecordHealthDataType,
+        CyclingPedalingCadenceSeriesRecordHealthDataType,
         CyclingPowerDataType,
         DistanceHealthDataType,
         DownhillSnowSportsDistanceDataType,
@@ -118,6 +120,8 @@ extension HealthDataTypeDtoToDomain on HealthDataTypeDto {
         return HealthDataType.wheelchairPushes;
       case HealthDataTypeDto.heartRateMeasurementRecord:
         return HealthDataType.heartRateMeasurementRecord;
+      case HealthDataTypeDto.cyclingPedalingCadenceMeasurementRecord:
+        return HealthDataType.cyclingPedalingCadenceMeasurementRecord;
       case HealthDataTypeDto.sleepStageRecord:
         return HealthDataType.sleepStageRecord;
       case HealthDataTypeDto.sexualActivity:
@@ -276,6 +280,8 @@ extension HealthDataTypeToDto on HealthDataType<HealthRecord, MeasurementUnit> {
         return HealthDataTypeDto.wheelchairPushes;
       case HeartRateMeasurementRecordHealthDataType _:
         return HealthDataTypeDto.heartRateMeasurementRecord;
+      case CyclingPedalingCadenceMeasurementRecordHealthDataType _:
+        return HealthDataTypeDto.cyclingPedalingCadenceMeasurementRecord;
       case SleepStageHealthDataType _:
         return HealthDataTypeDto.sleepStageRecord;
       case SexualActivityDataType _:
@@ -422,6 +428,12 @@ extension HealthDataTypeToDto on HealthDataType<HealthRecord, MeasurementUnit> {
         throw UnsupportedError(
           '$HeartRateSeriesRecordHealthDataType is not supported on iOS. '
           'Use $HeartRateMeasurementRecordHealthDataType instead.',
+        );
+      case CyclingPedalingCadenceSeriesRecordHealthDataType _:
+        throw UnsupportedError(
+          '$CyclingPedalingCadenceSeriesRecordHealthDataType is not '
+          'supported on iOS HealthKit. '
+          'Use $CyclingPedalingCadenceMeasurementRecordHealthDataType instead.',
         );
     }
   }

--- a/packages/health_connector_hk_ios/lib/src/mappers/health_record_mappers/cycling_pedaling_cadence_measurement_mappers.dart
+++ b/packages/health_connector_hk_ios/lib/src/mappers/health_record_mappers/cycling_pedaling_cadence_measurement_mappers.dart
@@ -1,0 +1,34 @@
+import 'package:health_connector_core/health_connector_core_internal.dart'
+    show CyclingPedalingCadenceMeasurement, sinceV2_2_0;
+import 'package:health_connector_hk_ios/src/mappers/measurement_unit_mappers/measurement_unit_mapper.dart';
+import 'package:health_connector_hk_ios/src/pigeon/health_connector_hk_ios_api.g.dart'
+    show CyclingPedalingCadenceMeasurementDto;
+import 'package:meta/meta.dart' show internal;
+
+/// Converts [CyclingPedalingCadenceMeasurement] to
+/// [CyclingPedalingCadenceMeasurementDto].
+@sinceV2_2_0
+@internal
+extension CyclingPedalingCadenceMeasurementToDto
+    on CyclingPedalingCadenceMeasurement {
+  CyclingPedalingCadenceMeasurementDto toDto() {
+    return CyclingPedalingCadenceMeasurementDto(
+      time: time.millisecondsSinceEpoch,
+      revolutionsPerMinute: revolutionsPerMinute.toDto(),
+    );
+  }
+}
+
+/// Converts [CyclingPedalingCadenceMeasurementDto] to
+/// [CyclingPedalingCadenceMeasurement].
+@sinceV2_2_0
+@internal
+extension CyclingPedalingCadenceMeasurementDtoToDomain
+    on CyclingPedalingCadenceMeasurementDto {
+  CyclingPedalingCadenceMeasurement toDomain() {
+    return CyclingPedalingCadenceMeasurement(
+      time: DateTime.fromMillisecondsSinceEpoch(time, isUtc: true),
+      revolutionsPerMinute: revolutionsPerMinute.toDomain(),
+    );
+  }
+}

--- a/packages/health_connector_hk_ios/lib/src/mappers/health_record_mappers/cycling_pedaling_cadence_measurement_record_mappers.dart
+++ b/packages/health_connector_hk_ios/lib/src/mappers/health_record_mappers/cycling_pedaling_cadence_measurement_record_mappers.dart
@@ -1,0 +1,39 @@
+import 'package:health_connector_core/health_connector_core_internal.dart'
+    show CyclingPedalingCadenceMeasurementRecord, HealthRecordId, sinceV2_2_0;
+import 'package:health_connector_hk_ios/src/mappers/health_record_mappers/cycling_pedaling_cadence_measurement_mappers.dart';
+import 'package:health_connector_hk_ios/src/mappers/health_record_mappers/health_record_id_mappers.dart';
+import 'package:health_connector_hk_ios/src/mappers/metadata_mappers/metadata_mapper.dart';
+import 'package:health_connector_hk_ios/src/pigeon/health_connector_hk_ios_api.g.dart'
+    show CyclingPedalingCadenceMeasurementRecordDto;
+import 'package:meta/meta.dart' show internal;
+
+/// Converts [CyclingPedalingCadenceMeasurementRecord] to
+/// [CyclingPedalingCadenceMeasurementRecordDto].
+@sinceV2_2_0
+@internal
+extension CyclingPedalingCadenceMeasurementRecordToDto
+    on CyclingPedalingCadenceMeasurementRecord {
+  CyclingPedalingCadenceMeasurementRecordDto toDto() {
+    return CyclingPedalingCadenceMeasurementRecordDto(
+      id: id.toDto(),
+      time: measurement.time.millisecondsSinceEpoch,
+      metadata: metadata.toDto(),
+      measurement: measurement.toDto(),
+    );
+  }
+}
+
+/// Converts [CyclingPedalingCadenceMeasurementRecordDto] to
+/// [CyclingPedalingCadenceMeasurementRecord].
+@sinceV2_2_0
+@internal
+extension CyclingPedalingCadenceMeasurementRecordDtoToDomain
+    on CyclingPedalingCadenceMeasurementRecordDto {
+  CyclingPedalingCadenceMeasurementRecord toDomain() {
+    return CyclingPedalingCadenceMeasurementRecord(
+      id: id?.toDomain() ?? HealthRecordId.none,
+      metadata: metadata.toDomain(),
+      measurement: measurement.toDomain(),
+    );
+  }
+}

--- a/packages/health_connector_hk_ios/lib/src/mappers/health_record_mappers/health_record_mapper.dart
+++ b/packages/health_connector_hk_ios/lib/src/mappers/health_record_mappers/health_record_mapper.dart
@@ -9,6 +9,8 @@ import 'package:health_connector_core/health_connector_core_internal.dart'
         CaffeineNutrientRecord,
         CalciumNutrientRecord,
         CholesterolNutrientRecord,
+        CyclingPedalingCadenceMeasurementRecord,
+        CyclingPedalingCadenceSeriesRecord,
         CyclingPowerRecord,
         DietaryFiberNutrientRecord,
         DiastolicBloodPressureRecord,
@@ -74,6 +76,7 @@ import 'package:health_connector_hk_ios/src/mappers/health_record_mappers/blood_
 import 'package:health_connector_hk_ios/src/mappers/health_record_mappers/body_fat_percentage_record_mappers.dart';
 import 'package:health_connector_hk_ios/src/mappers/health_record_mappers/body_temperature_record_mappers.dart';
 import 'package:health_connector_hk_ios/src/mappers/health_record_mappers/cervical_mucus_record_mappers.dart';
+import 'package:health_connector_hk_ios/src/mappers/health_record_mappers/cycling_pedaling_cadence_measurement_record_mappers.dart';
 import 'package:health_connector_hk_ios/src/mappers/health_record_mappers/cycling_power_record_mappers.dart';
 import 'package:health_connector_hk_ios/src/mappers/health_record_mappers/diastolic_blood_pressure_record_mappers.dart';
 import 'package:health_connector_hk_ios/src/mappers/health_record_mappers/distance_activity_record_mappers.dart';
@@ -107,6 +110,7 @@ import 'package:health_connector_hk_ios/src/pigeon/health_connector_hk_ios_api.g
         CaffeineNutrientRecordDto,
         CalciumNutrientRecordDto,
         CholesterolNutrientRecordDto,
+        CyclingPedalingCadenceMeasurementRecordDto,
         CyclingPowerRecordDto,
         DiastolicBloodPressureRecordDto,
         DietaryFiberNutrientRecordDto,
@@ -237,6 +241,8 @@ extension HealthRecordToDto on HealthRecord {
         return WheelchairPushesRecordToDto(record).toDto();
       case final HeartRateMeasurementRecord record:
         return HeartRateMeasurementRecordToDto(record).toDto();
+      case final CyclingPedalingCadenceMeasurementRecord record:
+        return CyclingPedalingCadenceMeasurementRecordToDto(record).toDto();
       case final SexualActivityRecord record:
         return SexualActivityRecordToDto(record).toDto();
       case final SleepStageRecord record:
@@ -340,6 +346,11 @@ extension HealthRecordToDto on HealthRecord {
           '$HeartRateSeriesRecord is not supported on iOS HealthKit. '
           'Use $HeartRateMeasurementRecord instead.',
         );
+      case final CyclingPedalingCadenceSeriesRecord _:
+        throw UnsupportedError(
+          '$CyclingPedalingCadenceSeriesRecord is not supported on iOS '
+          'HealthKit. Use $CyclingPedalingCadenceMeasurementRecord instead.',
+        );
       case final SleepSessionRecord _:
         throw UnsupportedError(
           '$SleepSessionRecord is not supported on iOS HealthKit. '
@@ -396,6 +407,10 @@ extension HealthRecordDtoToDomain on HealthRecordDto {
         return WheelchairPushesRecordDtoToDomain(dto).toDomain();
       case final HeartRateMeasurementRecordDto dto:
         return HeartRateMeasurementRecordDtoToDomain(dto).toDomain();
+      case final CyclingPedalingCadenceMeasurementRecordDto dto:
+        return CyclingPedalingCadenceMeasurementRecordDtoToDomain(
+          dto,
+        ).toDomain();
       case final SexualActivityRecordDto dto:
         return SexualActivityRecordDtoToDomain(dto).toDomain();
       case final SleepStageRecordDto dto:

--- a/packages/health_connector_hk_ios/lib/src/pigeon/health_connector_hk_ios_api.g.dart
+++ b/packages/health_connector_hk_ios/lib/src/pigeon/health_connector_hk_ios_api.g.dart
@@ -690,6 +690,9 @@ enum HealthDataTypeDto {
   /// Heart rate measurement record data (iOS HealthKit).
   heartRateMeasurementRecord,
 
+  /// Cycling pedaling cadence measurement record data (iOS HealthKit).
+  cyclingPedalingCadenceMeasurementRecord,
+
   /// Sleep stage record data (iOS HealthKit).
   sleepStageRecord,
 
@@ -3541,6 +3544,128 @@ class HeartRateMeasurementRecordDto extends HealthRecordDto {
   // ignore: avoid_equals_and_hash_code_on_mutable_classes
   bool operator ==(Object other) {
     if (other is! HeartRateMeasurementRecordDto ||
+        other.runtimeType != runtimeType) {
+      return false;
+    }
+    if (identical(this, other)) {
+      return true;
+    }
+    return _deepEquals(encode(), other.encode());
+  }
+
+  @override
+  // ignore: avoid_equals_and_hash_code_on_mutable_classes
+  int get hashCode => Object.hashAll(_toList());
+}
+
+/// Represents a single cycling pedaling cadence measurement.
+///
+/// This is a platform-agnostic value class used within cycling pedaling
+/// cadence records.
+/// It contains a timestamp and RPM value without ID or metadata.
+class CyclingPedalingCadenceMeasurementDto {
+  CyclingPedalingCadenceMeasurementDto({
+    required this.time,
+    required this.revolutionsPerMinute,
+  });
+
+  /// Timestamp in milliseconds since epoch (UTC).
+  int time;
+
+  /// Cycling cadence value in revolutions per minute (RPM).
+  NumberDto revolutionsPerMinute;
+
+  List<Object?> _toList() {
+    return <Object?>[
+      time,
+      revolutionsPerMinute,
+    ];
+  }
+
+  Object encode() {
+    return _toList();
+  }
+
+  static CyclingPedalingCadenceMeasurementDto decode(Object result) {
+    result as List<Object?>;
+    return CyclingPedalingCadenceMeasurementDto(
+      time: result[0]! as int,
+      revolutionsPerMinute: result[1]! as NumberDto,
+    );
+  }
+
+  @override
+  // ignore: avoid_equals_and_hash_code_on_mutable_classes
+  bool operator ==(Object other) {
+    if (other is! CyclingPedalingCadenceMeasurementDto ||
+        other.runtimeType != runtimeType) {
+      return false;
+    }
+    if (identical(this, other)) {
+      return true;
+    }
+    return _deepEquals(encode(), other.encode());
+  }
+
+  @override
+  // ignore: avoid_equals_and_hash_code_on_mutable_classes
+  int get hashCode => Object.hashAll(_toList());
+}
+
+/// Represents a cycling pedaling cadence measurement record (iOS HealthKit).
+class CyclingPedalingCadenceMeasurementRecordDto extends HealthRecordDto {
+  CyclingPedalingCadenceMeasurementRecordDto({
+    this.id,
+    required this.time,
+    required this.metadata,
+    required this.measurement,
+    this.zoneOffsetSeconds,
+  });
+
+  /// Platform-assigned unique identifier.
+  String? id;
+
+  /// Time in milliseconds since epoch (UTC).
+  int time;
+
+  /// Metadata for this record.
+  MetadataDto metadata;
+
+  /// The cadence measurement.
+  CyclingPedalingCadenceMeasurementDto measurement;
+
+  /// Timezone offset in seconds. Null if unknown.
+  int? zoneOffsetSeconds;
+
+  List<Object?> _toList() {
+    return <Object?>[
+      id,
+      time,
+      metadata,
+      measurement,
+      zoneOffsetSeconds,
+    ];
+  }
+
+  Object encode() {
+    return _toList();
+  }
+
+  static CyclingPedalingCadenceMeasurementRecordDto decode(Object result) {
+    result as List<Object?>;
+    return CyclingPedalingCadenceMeasurementRecordDto(
+      id: result[0] as String?,
+      time: result[1]! as int,
+      metadata: result[2]! as MetadataDto,
+      measurement: result[3]! as CyclingPedalingCadenceMeasurementDto,
+      zoneOffsetSeconds: result[4] as int?,
+    );
+  }
+
+  @override
+  // ignore: avoid_equals_and_hash_code_on_mutable_classes
+  bool operator ==(Object other) {
+    if (other is! CyclingPedalingCadenceMeasurementRecordDto ||
         other.runtimeType != runtimeType) {
       return false;
     }
@@ -7159,143 +7284,149 @@ class _PigeonCodec extends StandardMessageCodec {
     } else if (value is HeartRateMeasurementRecordDto) {
       buffer.putUint8(200);
       writeValue(buffer, value.encode());
-    } else if (value is SleepStageRecordDto) {
+    } else if (value is CyclingPedalingCadenceMeasurementDto) {
       buffer.putUint8(201);
       writeValue(buffer, value.encode());
-    } else if (value is SexualActivityRecordDto) {
+    } else if (value is CyclingPedalingCadenceMeasurementRecordDto) {
       buffer.putUint8(202);
       writeValue(buffer, value.encode());
-    } else if (value is EnergyNutrientRecordDto) {
+    } else if (value is SleepStageRecordDto) {
       buffer.putUint8(203);
       writeValue(buffer, value.encode());
-    } else if (value is CaffeineNutrientRecordDto) {
+    } else if (value is SexualActivityRecordDto) {
       buffer.putUint8(204);
       writeValue(buffer, value.encode());
-    } else if (value is ProteinNutrientRecordDto) {
+    } else if (value is EnergyNutrientRecordDto) {
       buffer.putUint8(205);
       writeValue(buffer, value.encode());
-    } else if (value is TotalCarbohydrateNutrientRecordDto) {
+    } else if (value is CaffeineNutrientRecordDto) {
       buffer.putUint8(206);
       writeValue(buffer, value.encode());
-    } else if (value is TotalFatNutrientRecordDto) {
+    } else if (value is ProteinNutrientRecordDto) {
       buffer.putUint8(207);
       writeValue(buffer, value.encode());
-    } else if (value is SaturatedFatNutrientRecordDto) {
+    } else if (value is TotalCarbohydrateNutrientRecordDto) {
       buffer.putUint8(208);
       writeValue(buffer, value.encode());
-    } else if (value is MonounsaturatedFatNutrientRecordDto) {
+    } else if (value is TotalFatNutrientRecordDto) {
       buffer.putUint8(209);
       writeValue(buffer, value.encode());
-    } else if (value is PolyunsaturatedFatNutrientRecordDto) {
+    } else if (value is SaturatedFatNutrientRecordDto) {
       buffer.putUint8(210);
       writeValue(buffer, value.encode());
-    } else if (value is CholesterolNutrientRecordDto) {
+    } else if (value is MonounsaturatedFatNutrientRecordDto) {
       buffer.putUint8(211);
       writeValue(buffer, value.encode());
-    } else if (value is DietaryFiberNutrientRecordDto) {
+    } else if (value is PolyunsaturatedFatNutrientRecordDto) {
       buffer.putUint8(212);
       writeValue(buffer, value.encode());
-    } else if (value is SugarNutrientRecordDto) {
+    } else if (value is CholesterolNutrientRecordDto) {
       buffer.putUint8(213);
       writeValue(buffer, value.encode());
-    } else if (value is VitaminANutrientRecordDto) {
+    } else if (value is DietaryFiberNutrientRecordDto) {
       buffer.putUint8(214);
       writeValue(buffer, value.encode());
-    } else if (value is VitaminB6NutrientRecordDto) {
+    } else if (value is SugarNutrientRecordDto) {
       buffer.putUint8(215);
       writeValue(buffer, value.encode());
-    } else if (value is VitaminB12NutrientRecordDto) {
+    } else if (value is VitaminANutrientRecordDto) {
       buffer.putUint8(216);
       writeValue(buffer, value.encode());
-    } else if (value is VitaminCNutrientRecordDto) {
+    } else if (value is VitaminB6NutrientRecordDto) {
       buffer.putUint8(217);
       writeValue(buffer, value.encode());
-    } else if (value is VitaminDNutrientRecordDto) {
+    } else if (value is VitaminB12NutrientRecordDto) {
       buffer.putUint8(218);
       writeValue(buffer, value.encode());
-    } else if (value is VitaminENutrientRecordDto) {
+    } else if (value is VitaminCNutrientRecordDto) {
       buffer.putUint8(219);
       writeValue(buffer, value.encode());
-    } else if (value is VitaminKNutrientRecordDto) {
+    } else if (value is VitaminDNutrientRecordDto) {
       buffer.putUint8(220);
       writeValue(buffer, value.encode());
-    } else if (value is ThiaminNutrientRecordDto) {
+    } else if (value is VitaminENutrientRecordDto) {
       buffer.putUint8(221);
       writeValue(buffer, value.encode());
-    } else if (value is RiboflavinNutrientRecordDto) {
+    } else if (value is VitaminKNutrientRecordDto) {
       buffer.putUint8(222);
       writeValue(buffer, value.encode());
-    } else if (value is NiacinNutrientRecordDto) {
+    } else if (value is ThiaminNutrientRecordDto) {
       buffer.putUint8(223);
       writeValue(buffer, value.encode());
-    } else if (value is FolateNutrientRecordDto) {
+    } else if (value is RiboflavinNutrientRecordDto) {
       buffer.putUint8(224);
       writeValue(buffer, value.encode());
-    } else if (value is BiotinNutrientRecordDto) {
+    } else if (value is NiacinNutrientRecordDto) {
       buffer.putUint8(225);
       writeValue(buffer, value.encode());
-    } else if (value is PantothenicAcidNutrientRecordDto) {
+    } else if (value is FolateNutrientRecordDto) {
       buffer.putUint8(226);
       writeValue(buffer, value.encode());
-    } else if (value is CalciumNutrientRecordDto) {
+    } else if (value is BiotinNutrientRecordDto) {
       buffer.putUint8(227);
       writeValue(buffer, value.encode());
-    } else if (value is IronNutrientRecordDto) {
+    } else if (value is PantothenicAcidNutrientRecordDto) {
       buffer.putUint8(228);
       writeValue(buffer, value.encode());
-    } else if (value is MagnesiumNutrientRecordDto) {
+    } else if (value is CalciumNutrientRecordDto) {
       buffer.putUint8(229);
       writeValue(buffer, value.encode());
-    } else if (value is ManganeseNutrientRecordDto) {
+    } else if (value is IronNutrientRecordDto) {
       buffer.putUint8(230);
       writeValue(buffer, value.encode());
-    } else if (value is PhosphorusNutrientRecordDto) {
+    } else if (value is MagnesiumNutrientRecordDto) {
       buffer.putUint8(231);
       writeValue(buffer, value.encode());
-    } else if (value is PotassiumNutrientRecordDto) {
+    } else if (value is ManganeseNutrientRecordDto) {
       buffer.putUint8(232);
       writeValue(buffer, value.encode());
-    } else if (value is SeleniumNutrientRecordDto) {
+    } else if (value is PhosphorusNutrientRecordDto) {
       buffer.putUint8(233);
       writeValue(buffer, value.encode());
-    } else if (value is SodiumNutrientRecordDto) {
+    } else if (value is PotassiumNutrientRecordDto) {
       buffer.putUint8(234);
       writeValue(buffer, value.encode());
-    } else if (value is ZincNutrientRecordDto) {
+    } else if (value is SeleniumNutrientRecordDto) {
       buffer.putUint8(235);
       writeValue(buffer, value.encode());
-    } else if (value is NutritionRecordDto) {
+    } else if (value is SodiumNutrientRecordDto) {
       buffer.putUint8(236);
       writeValue(buffer, value.encode());
-    } else if (value is HealthDataPermissionRequestResultDto) {
+    } else if (value is ZincNutrientRecordDto) {
       buffer.putUint8(237);
       writeValue(buffer, value.encode());
-    } else if (value is PermissionsRequestDto) {
+    } else if (value is NutritionRecordDto) {
       buffer.putUint8(238);
       writeValue(buffer, value.encode());
-    } else if (value is PermissionsRequestResponseDto) {
+    } else if (value is HealthDataPermissionRequestResultDto) {
       buffer.putUint8(239);
       writeValue(buffer, value.encode());
-    } else if (value is AggregateRequestDto) {
+    } else if (value is PermissionsRequestDto) {
       buffer.putUint8(240);
       writeValue(buffer, value.encode());
-    } else if (value is DeleteRecordsByIdsRequestDto) {
+    } else if (value is PermissionsRequestResponseDto) {
       buffer.putUint8(241);
       writeValue(buffer, value.encode());
-    } else if (value is DeleteRecordsByTimeRangeRequestDto) {
+    } else if (value is AggregateRequestDto) {
       buffer.putUint8(242);
       writeValue(buffer, value.encode());
-    } else if (value is ReadRecordRequestDto) {
+    } else if (value is DeleteRecordsByIdsRequestDto) {
       buffer.putUint8(243);
       writeValue(buffer, value.encode());
-    } else if (value is ReadRecordsRequestDto) {
+    } else if (value is DeleteRecordsByTimeRangeRequestDto) {
       buffer.putUint8(244);
       writeValue(buffer, value.encode());
-    } else if (value is ReadRecordsResponseDto) {
+    } else if (value is ReadRecordRequestDto) {
       buffer.putUint8(245);
       writeValue(buffer, value.encode());
-    } else if (value is HealthConnectorConfigDto) {
+    } else if (value is ReadRecordsRequestDto) {
       buffer.putUint8(246);
+      writeValue(buffer, value.encode());
+    } else if (value is ReadRecordsResponseDto) {
+      buffer.putUint8(247);
+      writeValue(buffer, value.encode());
+    } else if (value is HealthConnectorConfigDto) {
+      buffer.putUint8(248);
       writeValue(buffer, value.encode());
     } else {
       super.writeValue(buffer, value);
@@ -7492,96 +7623,102 @@ class _PigeonCodec extends StandardMessageCodec {
       case 200:
         return HeartRateMeasurementRecordDto.decode(readValue(buffer)!);
       case 201:
-        return SleepStageRecordDto.decode(readValue(buffer)!);
+        return CyclingPedalingCadenceMeasurementDto.decode(readValue(buffer)!);
       case 202:
-        return SexualActivityRecordDto.decode(readValue(buffer)!);
+        return CyclingPedalingCadenceMeasurementRecordDto.decode(
+          readValue(buffer)!,
+        );
       case 203:
-        return EnergyNutrientRecordDto.decode(readValue(buffer)!);
+        return SleepStageRecordDto.decode(readValue(buffer)!);
       case 204:
-        return CaffeineNutrientRecordDto.decode(readValue(buffer)!);
+        return SexualActivityRecordDto.decode(readValue(buffer)!);
       case 205:
-        return ProteinNutrientRecordDto.decode(readValue(buffer)!);
+        return EnergyNutrientRecordDto.decode(readValue(buffer)!);
       case 206:
-        return TotalCarbohydrateNutrientRecordDto.decode(readValue(buffer)!);
+        return CaffeineNutrientRecordDto.decode(readValue(buffer)!);
       case 207:
-        return TotalFatNutrientRecordDto.decode(readValue(buffer)!);
+        return ProteinNutrientRecordDto.decode(readValue(buffer)!);
       case 208:
-        return SaturatedFatNutrientRecordDto.decode(readValue(buffer)!);
+        return TotalCarbohydrateNutrientRecordDto.decode(readValue(buffer)!);
       case 209:
-        return MonounsaturatedFatNutrientRecordDto.decode(readValue(buffer)!);
+        return TotalFatNutrientRecordDto.decode(readValue(buffer)!);
       case 210:
-        return PolyunsaturatedFatNutrientRecordDto.decode(readValue(buffer)!);
+        return SaturatedFatNutrientRecordDto.decode(readValue(buffer)!);
       case 211:
-        return CholesterolNutrientRecordDto.decode(readValue(buffer)!);
+        return MonounsaturatedFatNutrientRecordDto.decode(readValue(buffer)!);
       case 212:
-        return DietaryFiberNutrientRecordDto.decode(readValue(buffer)!);
+        return PolyunsaturatedFatNutrientRecordDto.decode(readValue(buffer)!);
       case 213:
-        return SugarNutrientRecordDto.decode(readValue(buffer)!);
+        return CholesterolNutrientRecordDto.decode(readValue(buffer)!);
       case 214:
-        return VitaminANutrientRecordDto.decode(readValue(buffer)!);
+        return DietaryFiberNutrientRecordDto.decode(readValue(buffer)!);
       case 215:
-        return VitaminB6NutrientRecordDto.decode(readValue(buffer)!);
+        return SugarNutrientRecordDto.decode(readValue(buffer)!);
       case 216:
-        return VitaminB12NutrientRecordDto.decode(readValue(buffer)!);
+        return VitaminANutrientRecordDto.decode(readValue(buffer)!);
       case 217:
-        return VitaminCNutrientRecordDto.decode(readValue(buffer)!);
+        return VitaminB6NutrientRecordDto.decode(readValue(buffer)!);
       case 218:
-        return VitaminDNutrientRecordDto.decode(readValue(buffer)!);
+        return VitaminB12NutrientRecordDto.decode(readValue(buffer)!);
       case 219:
-        return VitaminENutrientRecordDto.decode(readValue(buffer)!);
+        return VitaminCNutrientRecordDto.decode(readValue(buffer)!);
       case 220:
-        return VitaminKNutrientRecordDto.decode(readValue(buffer)!);
+        return VitaminDNutrientRecordDto.decode(readValue(buffer)!);
       case 221:
-        return ThiaminNutrientRecordDto.decode(readValue(buffer)!);
+        return VitaminENutrientRecordDto.decode(readValue(buffer)!);
       case 222:
-        return RiboflavinNutrientRecordDto.decode(readValue(buffer)!);
+        return VitaminKNutrientRecordDto.decode(readValue(buffer)!);
       case 223:
-        return NiacinNutrientRecordDto.decode(readValue(buffer)!);
+        return ThiaminNutrientRecordDto.decode(readValue(buffer)!);
       case 224:
-        return FolateNutrientRecordDto.decode(readValue(buffer)!);
+        return RiboflavinNutrientRecordDto.decode(readValue(buffer)!);
       case 225:
-        return BiotinNutrientRecordDto.decode(readValue(buffer)!);
+        return NiacinNutrientRecordDto.decode(readValue(buffer)!);
       case 226:
-        return PantothenicAcidNutrientRecordDto.decode(readValue(buffer)!);
+        return FolateNutrientRecordDto.decode(readValue(buffer)!);
       case 227:
-        return CalciumNutrientRecordDto.decode(readValue(buffer)!);
+        return BiotinNutrientRecordDto.decode(readValue(buffer)!);
       case 228:
-        return IronNutrientRecordDto.decode(readValue(buffer)!);
+        return PantothenicAcidNutrientRecordDto.decode(readValue(buffer)!);
       case 229:
-        return MagnesiumNutrientRecordDto.decode(readValue(buffer)!);
+        return CalciumNutrientRecordDto.decode(readValue(buffer)!);
       case 230:
-        return ManganeseNutrientRecordDto.decode(readValue(buffer)!);
+        return IronNutrientRecordDto.decode(readValue(buffer)!);
       case 231:
-        return PhosphorusNutrientRecordDto.decode(readValue(buffer)!);
+        return MagnesiumNutrientRecordDto.decode(readValue(buffer)!);
       case 232:
-        return PotassiumNutrientRecordDto.decode(readValue(buffer)!);
+        return ManganeseNutrientRecordDto.decode(readValue(buffer)!);
       case 233:
-        return SeleniumNutrientRecordDto.decode(readValue(buffer)!);
+        return PhosphorusNutrientRecordDto.decode(readValue(buffer)!);
       case 234:
-        return SodiumNutrientRecordDto.decode(readValue(buffer)!);
+        return PotassiumNutrientRecordDto.decode(readValue(buffer)!);
       case 235:
-        return ZincNutrientRecordDto.decode(readValue(buffer)!);
+        return SeleniumNutrientRecordDto.decode(readValue(buffer)!);
       case 236:
-        return NutritionRecordDto.decode(readValue(buffer)!);
+        return SodiumNutrientRecordDto.decode(readValue(buffer)!);
       case 237:
-        return HealthDataPermissionRequestResultDto.decode(readValue(buffer)!);
+        return ZincNutrientRecordDto.decode(readValue(buffer)!);
       case 238:
-        return PermissionsRequestDto.decode(readValue(buffer)!);
+        return NutritionRecordDto.decode(readValue(buffer)!);
       case 239:
-        return PermissionsRequestResponseDto.decode(readValue(buffer)!);
+        return HealthDataPermissionRequestResultDto.decode(readValue(buffer)!);
       case 240:
-        return AggregateRequestDto.decode(readValue(buffer)!);
+        return PermissionsRequestDto.decode(readValue(buffer)!);
       case 241:
-        return DeleteRecordsByIdsRequestDto.decode(readValue(buffer)!);
+        return PermissionsRequestResponseDto.decode(readValue(buffer)!);
       case 242:
-        return DeleteRecordsByTimeRangeRequestDto.decode(readValue(buffer)!);
+        return AggregateRequestDto.decode(readValue(buffer)!);
       case 243:
-        return ReadRecordRequestDto.decode(readValue(buffer)!);
+        return DeleteRecordsByIdsRequestDto.decode(readValue(buffer)!);
       case 244:
-        return ReadRecordsRequestDto.decode(readValue(buffer)!);
+        return DeleteRecordsByTimeRangeRequestDto.decode(readValue(buffer)!);
       case 245:
-        return ReadRecordsResponseDto.decode(readValue(buffer)!);
+        return ReadRecordRequestDto.decode(readValue(buffer)!);
       case 246:
+        return ReadRecordsRequestDto.decode(readValue(buffer)!);
+      case 247:
+        return ReadRecordsResponseDto.decode(readValue(buffer)!);
+      case 248:
         return HealthConnectorConfigDto.decode(readValue(buffer)!);
       default:
         return super.readValueOfType(type, buffer);

--- a/packages/health_connector_hk_ios/pigeons/health_connector_hk_ios_api.dart
+++ b/packages/health_connector_hk_ios/pigeons/health_connector_hk_ios_api.dart
@@ -838,6 +838,9 @@ enum HealthDataTypeDto {
   /// Heart rate measurement record data (iOS HealthKit).
   heartRateMeasurementRecord,
 
+  /// Cycling pedaling cadence measurement record data (iOS HealthKit).
+  cyclingPedalingCadenceMeasurementRecord,
+
   /// Sleep stage record data (iOS HealthKit).
   sleepStageRecord,
 
@@ -1804,6 +1807,50 @@ class HeartRateMeasurementRecordDto extends HealthRecordDto {
   final HeartRateMeasurementDto measurement;
 
   /// Timezone offset in seconds for measurement time (optional).
+  final int? zoneOffsetSeconds;
+}
+
+/// Represents a single cycling pedaling cadence measurement.
+///
+/// This is a platform-agnostic value class used within cycling pedaling
+/// cadence records.
+/// It contains a timestamp and RPM value without ID or metadata.
+class CyclingPedalingCadenceMeasurementDto {
+  CyclingPedalingCadenceMeasurementDto({
+    required this.time,
+    required this.revolutionsPerMinute,
+  });
+
+  /// Timestamp in milliseconds since epoch (UTC).
+  final int time;
+
+  /// Cycling cadence value in revolutions per minute (RPM).
+  final NumberDto revolutionsPerMinute;
+}
+
+/// Represents a cycling pedaling cadence measurement record (iOS HealthKit).
+class CyclingPedalingCadenceMeasurementRecordDto extends HealthRecordDto {
+  CyclingPedalingCadenceMeasurementRecordDto({
+    required this.id,
+    required this.time,
+    required this.metadata,
+    required this.measurement,
+    this.zoneOffsetSeconds,
+  });
+
+  /// Platform-assigned unique identifier.
+  final String? id;
+
+  /// Time in milliseconds since epoch (UTC).
+  final int time;
+
+  /// Metadata for this record.
+  final MetadataDto metadata;
+
+  /// The cadence measurement.
+  final CyclingPedalingCadenceMeasurementDto measurement;
+
+  /// Timezone offset in seconds. Null if unknown.
   final int? zoneOffsetSeconds;
 }
 


### PR DESCRIPTION
### **PR Type**
Enhancement


___

### **Description**
- Add comprehensive support for cycling pedaling cadence data types across iOS HealthKit and Android Health Connect platforms

- Introduce `CyclingPedalingCadenceMeasurement` value class and two platform-specific record types:
  - `CyclingPedalingCadenceMeasurementRecord` for iOS instant measurements
  - `CyclingPedalingCadenceSeriesRecord` for Android series data with multiple samples

- Implement corresponding health data types with support for read, write, delete, and aggregation (avg/min/max) operations

- Add platform-specific mappers and handlers:
  - iOS: Swift mapper, handler, and HealthKit integration for `HKQuantitySample` with RPM unit (requires iOS 17.0+)
  - Android: Kotlin handler with Health Connect integration and permission mappings

- Update Pigeon API definitions and generated code for both platforms with new DTOs and enum values

- Integrate cycling cadence support into existing health record and data type mapper registries

- Add version 2.2.0 annotation constant for new APIs


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["CyclingPedalingCadenceMeasurement<br/>Value Class"] --> B["CyclingPedalingCadenceMeasurementRecord<br/>iOS Instant Record"]
  A --> C["CyclingPedalingCadenceSeriesRecord<br/>Android Series Record"]
  B --> D["iOS HealthKit<br/>HKQuantitySample"]
  C --> E["Android Health Connect<br/>Series Data"]
  B --> F["iOS Mappers<br/>& Handler"]
  C --> G["Android Mappers<br/>& Handler"]
  F --> H["HealthDataType<br/>Registry"]
  G --> H
  I["Pigeon API<br/>DTOs"] --> F
  I --> G
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><details><summary>37 files</summary><table>
<tr>
  <td>
    <details>
      <summary><strong>cycling_pedaling_cadence_measurement.dart</strong><dd><code>Add cycling pedaling cadence measurement value class</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/health_connector_core/lib/src/models/health_records/cycling_pedaling_cadence_measurement.dart

<ul><li>New immutable value class representing a single cycling pedaling <br>cadence measurement<br> <li> Contains timestamp and RPM value without ID or metadata<br> <li> Implements equality and hash code operators</ul>


</details>


  </td>
  <td><a href="https://github.com/fam-tung-lam/health_connector/pull/55/files#diff-c4044bb422c0bf5c29a7ee4170cef1f69ca483b4fa66a5ba8012e3b0e79b347b">+38/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>cycling_pedaling_cadence_measurement_record.dart</strong><dd><code>Add cycling pedaling cadence measurement record for iOS</code>&nbsp; &nbsp; </dd></summary>
<hr>

packages/health_connector_core/lib/src/models/health_records/cycling_pedaling_cadence_measurement_record.dart

<ul><li>New instant health record for iOS HealthKit cycling cadence <br>measurements<br> <li> Wraps <code>CyclingPedalingCadenceMeasurement</code> with metadata and ID<br> <li> Provides convenience getters for time and RPM values<br> <li> Includes <code>copyWith</code> method for immutable updates</ul>


</details>


  </td>
  <td><a href="https://github.com/fam-tung-lam/health_connector/pull/55/files#diff-b3565a3b3420b68ad9c0968a016342e779a1d06259f9bd9d31ca3e3156813f8a">+105/-0</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>cycling_pedaling_cadence_series_record.dart</strong><dd><code>Add cycling pedaling cadence series record for Android</code>&nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/health_connector_core/lib/src/models/health_records/cycling_pedaling_cadence_series_record.dart

<ul><li>New series health record for Android Health Connect cycling cadence <br>data<br> <li> Contains multiple cadence measurements over a time interval<br> <li> Provides computed properties for average, min, and max RPM<br> <li> Implements <code>copyWith</code> for immutable updates</ul>


</details>


  </td>
  <td><a href="https://github.com/fam-tung-lam/health_connector/pull/55/files#diff-b2a676e451478295bce978aad70fb282c517f9e8fdd028344079f4bf77249085">+161/-0</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>cycling_pedaling_cadence_measurement_record_health_data_type.dart</strong><dd><code>Add cycling cadence measurement health data type for iOS</code>&nbsp; </dd></summary>
<hr>

packages/health_connector_core/lib/src/models/health_data_types/cycling_pedaling_cadence_measurement_record_health_data_type.dart

<ul><li>New health data type for iOS cycling cadence measurements<br> <li> Supports read, write, delete, and aggregation (avg/min/max) operations<br> <li> iOS HealthKit only, not supported on Android<br> <li> Marked as available since version 2.2.0</ul>


</details>


  </td>
  <td><a href="https://github.com/fam-tung-lam/health_connector/pull/55/files#diff-060bd19e9479b6546dd02187b468e05fcada579fc73e9237e7fcfdba70681f11">+187/-0</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>cycling_pedaling_cadence_series_record_health_data_type.dart</strong><dd><code>Add cycling cadence series health data type for Android</code>&nbsp; &nbsp; </dd></summary>
<hr>

packages/health_connector_core/lib/src/models/health_data_types/cycling_pedaling_cadence_series_record_health_data_type.dart

<ul><li>New health data type for Android cycling cadence series records<br> <li> Supports read, write, delete, and aggregation (avg/min/max) operations<br> <li> Android Health Connect only, not supported on iOS<br> <li> Marked as available since version 2.2.0</ul>


</details>


  </td>
  <td><a href="https://github.com/fam-tung-lam/health_connector/pull/55/files#diff-2c74451f64b0c44401f1765f3f61b6e8612876f6b2856bd8114f5980015d2b4f">+173/-0</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>health_data_type.dart</strong><dd><code>Register cycling cadence data types in health data type registry</code></dd></summary>
<hr>

packages/health_connector_core/lib/src/models/health_data_types/health_data_type.dart

<ul><li>Added two new static constants for cycling cadence data types<br> <li> Imported new cycling cadence record classes<br> <li> Added part directives for new health data type files<br> <li> Updated <code>allValues</code> list to include new data types</ul>


</details>


  </td>
  <td><a href="https://github.com/fam-tung-lam/health_connector/pull/55/files#diff-a63f9d9a8b5068195f097bbbca8936cfb2e8902a5d761ee84275698bf196bb3a">+29/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>health_record.dart</strong><dd><code>Add cycling cadence record parts to health record module</code>&nbsp; </dd></summary>
<hr>

packages/health_connector_core/lib/src/models/health_records/health_record.dart

<ul><li>Added part directives for new cycling cadence record files<br> <li> Enables composition of cycling cadence records into health record <br>module</ul>


</details>


  </td>
  <td><a href="https://github.com/fam-tung-lam/health_connector/pull/55/files#diff-e6f4b4712636a917da8e259645e678d401aa3fb1c27198b9236e11a0192ee55d">+2/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>health_record_data_type_extension.dart</strong><dd><code>Map cycling cadence records to their health data types</code>&nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/health_connector_core/lib/src/utils/health_record_data_type_extension.dart

<ul><li>Added mapping from <code>CyclingPedalingCadenceSeriesRecord</code> to its health <br>data type<br> <li> Added mapping from <code>CyclingPedalingCadenceMeasurementRecord</code> to its <br>health data type</ul>


</details>


  </td>
  <td><a href="https://github.com/fam-tung-lam/health_connector/pull/55/files#diff-e10b12805d52a227284da241f3b9126f622d7ff177368acbc66af8131b53ffc6">+6/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>health_connector_core_internal.dart</strong><dd><code>Export cycling cadence measurement class</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/health_connector_core/lib/health_connector_core_internal.dart

<ul><li>Exported new <code>CyclingPedalingCadenceMeasurement</code> class for public API</ul>


</details>


  </td>
  <td><a href="https://github.com/fam-tung-lam/health_connector/pull/55/files#diff-cd65b5a6b07e61d8a2ec63aea578404dde6059d7cff5dd91a2404cc00f2f223f">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>since.dart</strong><dd><code>Add version 2.2.0 annotation constant</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/health_connector_core/lib/src/annotations/since.dart

<ul><li>Added new <code>sinceV2_2_0</code> annotation constant for APIs added in version <br>2.2.0</ul>


</details>


  </td>
  <td><a href="https://github.com/fam-tung-lam/health_connector/pull/55/files#diff-b7730b71358a0b35e832764dd21e745a98c16ce42707376ba09d7ba0399e5b6b">+3/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>health_connector_hk_ios_api.dart</strong><dd><code>Add cycling cadence DTOs to iOS Pigeon API definition</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/health_connector_hk_ios/pigeons/health_connector_hk_ios_api.dart

<ul><li>Added <code>cyclingPedalingCadenceMeasurementRecord</code> enum value to <br><code>HealthDataTypeDto</code><br> <li> Added <code>CyclingPedalingCadenceMeasurementDto</code> class for measurement data <br>transfer<br> <li> Added <code>CyclingPedalingCadenceMeasurementRecordDto</code> class for record data <br>transfer</ul>


</details>


  </td>
  <td><a href="https://github.com/fam-tung-lam/health_connector/pull/55/files#diff-2ba85ae98b6f41e793ad4b7c5e66ae028097b221f56db46e557be72d8645e2db">+47/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>health_connector_hk_ios_api.g.dart</strong><dd><code>Generate iOS Pigeon code for cycling cadence support</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/health_connector_hk_ios/lib/src/pigeon/health_connector_hk_ios_api.g.dart

<ul><li>Generated code for new cycling cadence measurement and record DTOs<br> <li> Added enum value for cycling cadence measurement record<br> <li> Updated codec serialization/deserialization with new type IDs (201, <br>202)<br> <li> Shifted existing type IDs for subsequent types</ul>


</details>


  </td>
  <td><a href="https://github.com/fam-tung-lam/health_connector/pull/55/files#diff-9ad05626e79e8f46ffae298de63c6a7c5722d1fb5648fbe2afd1f3120da342f0">+228/-91</a></td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>health_connector_hc_android_api.dart</strong><dd><code>Add cycling cadence DTOs to Android Pigeon API definition</code></dd></summary>
<hr>

packages/health_connector_hc_android/pigeons/health_connector_hc_android_api.dart

<ul><li>Added <code>cyclingPedalingCadenceSeriesRecord</code> enum value to <br><code>HealthDataTypeDto</code><br> <li> Added <code>CyclingPedalingCadenceMeasurementDto</code> class for measurement data <br>transfer<br> <li> Added <code>CyclingPedalingCadenceSeriesRecordDto</code> class for series record <br>data transfer</ul>


</details>


  </td>
  <td><a href="https://github.com/fam-tung-lam/health_connector/pull/55/files#diff-94b53bdf5324682c4271d77979aab294e56468fa03aed4e47f457cb47037cbf9">+55/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>health_connector_hc_android_api.g.dart</strong><dd><code>Generate Android Pigeon code for cycling cadence support</code>&nbsp; </dd></summary>
<hr>

packages/health_connector_hc_android/lib/src/pigeon/health_connector_hc_android_api.g.dart

<ul><li>Generated code for new cycling cadence measurement and series record <br>DTOs<br> <li> Added enum value for cycling cadence series record<br> <li> Updated codec serialization/deserialization with new type IDs (196, <br>197)<br> <li> Shifted existing type IDs for subsequent types</ul>


</details>


  </td>
  <td><a href="https://github.com/fam-tung-lam/health_connector/pull/55/files#diff-d756b64a1ed711851582d2a643d79e51d3b0456b5558db0d3352196bb92d9fcc">+195/-47</a></td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>cycling_pedaling_cadence_measurement_mappers.dart</strong><dd><code>Add cycling cadence measurement mappers for iOS</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/health_connector_hk_ios/lib/src/mappers/health_record_mappers/cycling_pedaling_cadence_measurement_mappers.dart

<ul><li>New mapper extensions for converting <code>CyclingPedalingCadenceMeasurement</code> <br>to/from DTO<br> <li> Handles time conversion from DateTime to milliseconds since epoch<br> <li> Handles RPM value conversion via <code>NumberDto</code></ul>


</details>


  </td>
  <td><a href="https://github.com/fam-tung-lam/health_connector/pull/55/files#diff-8d8df6f25564027ece03c4185c77f1fa89f50f3bd1a73f18e1ee1416442b5aef">+34/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>cycling_pedaling_cadence_measurement_record_mappers.dart</strong><dd><code>Add cycling cadence measurement record mappers for iOS</code>&nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/health_connector_hk_ios/lib/src/mappers/health_record_mappers/cycling_pedaling_cadence_measurement_record_mappers.dart

<ul><li>New mapper extensions for converting <br><code>CyclingPedalingCadenceMeasurementRecord</code> to/from DTO<br> <li> Handles record ID, metadata, and measurement conversion<br> <li> Preserves timezone offset information</ul>


</details>


  </td>
  <td><a href="https://github.com/fam-tung-lam/health_connector/pull/55/files#diff-faf479d9d7be864d68ef7fbc928409947d3d0e6098048b26597abd5ddc9be2cd">+39/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>cycling_pedaling_cadence_measurement_mappers.dart</strong><dd><code>Add cycling cadence measurement mappers for Android</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/health_connector_hc_android/lib/src/mappers/health_record_mappers/cycling_pedaling_cadence_measurement_mappers.dart

<ul><li>New mapper extensions for converting <code>CyclingPedalingCadenceMeasurement</code> <br>to/from DTO<br> <li> Handles time conversion from DateTime to milliseconds since epoch<br> <li> Handles RPM value conversion via <code>NumberDto</code></ul>


</details>


  </td>
  <td><a href="https://github.com/fam-tung-lam/health_connector/pull/55/files#diff-e37f58b4b0ce6ba2fa4bbc7f4528a3f268c7173cdce1895e24d0aab9f74bd870">+34/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>cycling_pedaling_cadence_series_record_mappers.dart</strong><dd><code>Add cycling cadence series record mappers for Android</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/health_connector_hc_android/lib/src/mappers/health_record_mappers/cycling_pedaling_cadence_series_record_mappers.dart

<ul><li>New mapper extensions for converting <br><code>CyclingPedalingCadenceSeriesRecord</code> to/from DTO<br> <li> Handles series record with multiple samples, time ranges, and timezone <br>offsets<br> <li> Maps sample list to/from DTO measurement list</ul>


</details>


  </td>
  <td><a href="https://github.com/fam-tung-lam/health_connector/pull/55/files#diff-4fff441be776ea7f31db9c17ca85d5565b2cb41bdc025522ac76c9279c718dd6">+46/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>health_record_mapper.dart</strong><dd><code>Integrate cycling cadence mappers into iOS health record mapper</code></dd></summary>
<hr>

packages/health_connector_hk_ios/lib/src/mappers/health_record_mappers/health_record_mapper.dart

<ul><li>Added imports for cycling cadence record types and mappers<br> <li> Added case handling for <code>CyclingPedalingCadenceMeasurementRecord</code> in <br><code>HealthRecordToDto</code> extension<br> <li> Added error handling for unsupported <br><code>CyclingPedalingCadenceSeriesRecord</code> on iOS<br> <li> Added case handling for <code>CyclingPedalingCadenceMeasurementRecordDto</code> in <br><code>HealthRecordDtoToDomain</code> extension</ul>


</details>


  </td>
  <td><a href="https://github.com/fam-tung-lam/health_connector/pull/55/files#diff-59d0fb8b80a308ae0936763493a0d34325670e41e6ff8fad4fdaa75e883141e7">+15/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>health_record_mapper.dart</strong><dd><code>Integrate cycling cadence mappers into Android health record mapper</code></dd></summary>
<hr>

packages/health_connector_hc_android/lib/src/mappers/health_record_mappers/health_record_mapper.dart

<ul><li>Added imports for cycling cadence record types and mappers<br> <li> Added case handling for <code>CyclingPedalingCadenceSeriesRecord</code> in <br><code>HealthRecordToDto</code> extension<br> <li> Added error handling for unsupported <br><code>CyclingPedalingCadenceMeasurementRecord</code> on Android<br> <li> Added case handling for <code>CyclingPedalingCadenceSeriesRecordDto</code> in <br><code>HealthRecordDtoToDomain</code> extension</ul>


</details>


  </td>
  <td><a href="https://github.com/fam-tung-lam/health_connector/pull/55/files#diff-a25ffea74b1a218846cbbe304a04d5dc1540607471cf2281f3d1b10c1b76124f">+14/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>health_data_type_mappers.dart</strong><dd><code>Integrate cycling cadence health data types into iOS mapper</code></dd></summary>
<hr>

packages/health_connector_hk_ios/lib/src/mappers/health_data_type_mappers.dart

<ul><li>Added imports for cycling cadence health data types<br> <li> Added case handling for <code>cyclingPedalingCadenceMeasurementRecord</code> in <br><code>HealthDataTypeDtoToDomain</code> extension<br> <li> Added case handling for <br><code>CyclingPedalingCadenceMeasurementRecordHealthDataType</code> in <br><code>HealthDataTypeToDto</code> extension<br> <li> Added error handling for unsupported <br><code>CyclingPedalingCadenceSeriesRecordHealthDataType</code> on iOS</ul>


</details>


  </td>
  <td><a href="https://github.com/fam-tung-lam/health_connector/pull/55/files#diff-6db3360a631b968136d46dc7cf3368e40eed4e14448803afd68bd6077e483b05">+12/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>health_data_type_mappers.dart</strong><dd><code>Integrate cycling cadence health data types into Android mapper</code></dd></summary>
<hr>

packages/health_connector_hc_android/lib/src/mappers/health_data_type_mappers.dart

<ul><li>Added imports for cycling cadence health data types<br> <li> Added case handling for <code>cyclingPedalingCadenceSeriesRecord</code> in <br><code>HealthDataTypeDtoToDomain</code> extension<br> <li> Added case handling for <br><code>CyclingPedalingCadenceSeriesRecordHealthDataType</code> in <br><code>HealthDataTypeToDto</code> extension<br> <li> Added error handling for unsupported <br><code>CyclingPedalingCadenceMeasurementRecordHealthDataType</code> on Android</ul>


</details>


  </td>
  <td><a href="https://github.com/fam-tung-lam/health_connector/pull/55/files#diff-0b9e5d0773ed274409d9e39de40bdf4ad88152ae2c90bc551d2bfc0bf0d13f53">+12/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>aggregate_request_mapper.dart</strong><dd><code>Support cycling cadence aggregation requests on Android</code>&nbsp; &nbsp; </dd></summary>
<hr>

packages/health_connector_hc_android/lib/src/mappers/request_and_response_mappers/aggregate_request_mapper.dart

<ul><li>Added imports for cycling cadence health data types<br> <li> Added case handling for both cycling cadence types in aggregation <br>request mapping</ul>


</details>


  </td>
  <td><a href="https://github.com/fam-tung-lam/health_connector/pull/55/files#diff-8492500425e410df1bfac0fd61cbd51d801bd9e29141ca13ab932d2ccd85ceaf">+4/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>CyclingPedalingCadenceMeasurementRecordMapper.swift</strong><dd><code>Add Swift mapper for cycling cadence measurements on iOS</code>&nbsp; </dd></summary>
<hr>

packages/health_connector_hk_ios/ios/health_connector_hk_ios/Sources/health_connector_hk_ios/mappers/health_record_mappers/CyclingPedalingCadenceMeasurementRecordMapper.swift

<ul><li>New Swift mapper for converting cycling cadence measurement records <br>to/from HealthKit<br> <li> Converts to <code>HKQuantitySample</code> with RPM unit (count/minute)<br> <li> Requires iOS 17.0 or later<br> <li> Handles metadata and timezone offset conversion</ul>


</details>


  </td>
  <td><a href="https://github.com/fam-tung-lam/health_connector/pull/55/files#diff-4a188ef51b3f38fcdf2f348a0347681ba14aa915f1297f87d02402e81f881131">+94/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>CyclingPedalingCadenceHandler.swift</strong><dd><code>Add cycling cadence handler for iOS HealthKit operations</code>&nbsp; </dd></summary>
<hr>

packages/health_connector_hk_ios/ios/health_connector_hk_ios/Sources/health_connector_hk_ios/handlers/health_record_handlers/CyclingPedalingCadenceHandler.swift

<ul><li>New handler for cycling cadence measurement records (instant quantity <br>type)<br> <li> Implements readable, writable, deletable, and aggregatable interfaces<br> <li> Supports min, max, and avg aggregation metrics<br> <li> Converts HealthKit quantities to RPM values</ul>


</details>


  </td>
  <td><a href="https://github.com/fam-tung-lam/health_connector/pull/55/files#diff-561e56cdb4b696a9c0c20f471d7d293d4029b679ac16166a023d1792fd79280f">+29/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>HealthConnectorDtoExtensions.swift</strong><dd><code>Add cycling cadence DTO extensions for iOS utilities</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/health_connector_hk_ios/ios/health_connector_hk_ios/Sources/health_connector_hk_ios/utils/HealthConnectorDtoExtensions.swift

<ul><li>Added ID extraction for <code>CyclingPedalingCadenceMeasurementRecordDto</code><br> <li> Added data type mapping for cycling cadence measurement records<br> <li> Added time extraction for cycling cadence measurement records</ul>


</details>


  </td>
  <td><a href="https://github.com/fam-tung-lam/health_connector/pull/55/files#diff-90d0c007e472618edd33163a9caafe80d4ea9d84f55c25b1c8075cb371a34287">+6/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>HealthRecordMapper.swift</strong><dd><code>Integrate cycling cadence into iOS health record mapper</code>&nbsp; &nbsp; </dd></summary>
<hr>

packages/health_connector_hk_ios/ios/health_connector_hk_ios/Sources/health_connector_hk_ios/mappers/health_record_mappers/HealthRecordMapper.swift

<ul><li>Added case handling for <code>CyclingPedalingCadenceMeasurementRecordDto</code> in <br>HealthKit conversion<br> <li> Added case handling for cycling cadence measurement record in <br>HKQuantitySample conversion</ul>


</details>


  </td>
  <td><a href="https://github.com/fam-tung-lam/health_connector/pull/55/files#diff-35b9e7b3d62e5cb54566ea2f201fe53433b28ac161abf3a47fbd7e4fbd1006e3">+4/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>HealthDataTypeMapper.swift</strong><dd><code>Add cycling cadence data type mapping for iOS</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/health_connector_hk_ios/ios/health_connector_hk_ios/Sources/health_connector_hk_ios/mappers/HealthDataTypeMapper.swift

<ul><li>Added case handling for <code>cyclingPedalingCadenceMeasurementRecord</code> data <br>type<br> <li> Validates iOS 17.0 minimum requirement for cycling cadence support</ul>


</details>


  </td>
  <td><a href="https://github.com/fam-tung-lam/health_connector/pull/55/files#diff-7d603469e29dfaa590f688e14dc316d94744728e659522148b9bec98110efe89">+12/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>HealthRecordHandlerRegistry.swift</strong><dd><code>Register cycling cadence handler in iOS handler registry</code>&nbsp; </dd></summary>
<hr>

packages/health_connector_hk_ios/ios/health_connector_hk_ios/Sources/health_connector_hk_ios/handlers/HealthRecordHandlerRegistry.swift

<ul><li>Registered new <code>CyclingPedalingCadenceHandler</code> in the handler registry</ul>


</details>


  </td>
  <td><a href="https://github.com/fam-tung-lam/health_connector/pull/55/files#diff-442a14ebe63740bb24123c460cd6f2c8a474f1425793aaad0037a80dfe9540e1">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>PermissionMapper.swift</strong><dd><code>Add cycling cadence to iOS permission mapper</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/health_connector_hk_ios/ios/health_connector_hk_ios/Sources/health_connector_hk_ios/mappers/PermissionMapper.swift

<ul><li>Added <code>cyclingPedalingCadenceMeasurementRecord</code> to the list of quantity <br>types for permission mapping</ul>


</details>


  </td>
  <td><a href="https://github.com/fam-tung-lam/health_connector/pull/55/files#diff-c8e19aebb547f44b885902ee5e16ad967277866c4f7ca80207a994c38fa3fd64">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>HealthConnectorHKIOSApi.g.swift</strong><dd><code>Add cycling pedaling cadence data types for iOS HealthKit</code></dd></summary>
<hr>

packages/health_connector_hk_ios/ios/health_connector_hk_ios/Sources/health_connector_hk_ios/pigeon/HealthConnectorHKIOSApi.g.swift

<ul><li>Added new enum case <code>cyclingPedalingCadenceMeasurementRecord</code> with value <br>24 to <code>HealthDataTypeDto</code><br> <li> Incremented all subsequent enum values by 1 to accommodate the new <br>data type<br> <li> Added two new struct definitions: <code>CyclingPedalingCadenceMeasurementDto</code> <br>and <code>CyclingPedalingCadenceMeasurementRecordDto</code> with <br>serialization/deserialization methods<br> <li> Updated codec reader and writer to handle the new data types with byte <br>codes 201 and 202, shifting all subsequent type codes</ul>


</details>


  </td>
  <td><a href="https://github.com/fam-tung-lam/health_connector/pull/55/files#diff-8915112a513087f5a784b5d07c5248abb8e74d47ec1c06089a3d9774f535f925">+238/-141</a></td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>HealthConnectorHCAndroidApi.g.kt</strong><dd><code>Add cycling pedaling cadence data types for Android Health Connect</code></dd></summary>
<hr>

packages/health_connector_hc_android/android/src/main/kotlin/com/phamtunglam/health_connector_hc_android/pigeon/HealthConnectorHCAndroidApi.g.kt

<ul><li>Added new enum case <code>CYCLING_PEDALING_CADENCE_SERIES_RECORD</code> with value <br>14 to <code>HealthDataTypeDto</code><br> <li> Incremented all subsequent enum values by 1 to accommodate the new <br>data type<br> <li> Added two new data classes: <code>CyclingPedalingCadenceMeasurementDto</code> and <br><code>CyclingPedalingCadenceSeriesRecordDto</code> with <br>serialization/deserialization methods<br> <li> Updated codec reader and writer to handle the new data types with byte <br>codes 196 and 197, shifting all subsequent type codes</ul>


</details>


  </td>
  <td><a href="https://github.com/fam-tung-lam/health_connector/pull/55/files#diff-e6f9aac35ab0f3a96117362ead91b0ee359674294103ce3b59a72675da86b028">+177/-59</a></td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>CyclingPedalingCadenceHandler.kt</strong><dd><code>Implement cycling pedaling cadence record handler</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/health_connector_hc_android/android/src/main/kotlin/com/phamtunglam/health_connector_hc_android/handlers/health_record_handlers/CyclingPedalingCadenceHandler.kt

<ul><li>Created new handler class <code>CyclingPedalingCadenceHandler</code> for cycling <br>pedaling cadence records<br> <li> Implements read, write, update, delete, and aggregation capabilities<br> <li> Maps aggregation metrics for average, minimum, and maximum RPM values<br> <li> Converts aggregated double values to <code>NumberDto</code> format</ul>


</details>


  </td>
  <td><a href="https://github.com/fam-tung-lam/health_connector/pull/55/files#diff-08dc00d2ab28be13249a5425755367be9d1ce6d89d00052398acff7bb9783d07">+46/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>HealthDataPermissionMapper.kt</strong><dd><code>Add cycling pedaling cadence permission mappings</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/health_connector_hc_android/android/src/main/kotlin/com/phamtunglam/health_connector_hc_android/mappers/permission_mappers/HealthDataPermissionMapper.kt

<ul><li>Added import for <code>CyclingPedalingCadenceRecord</code> from Health Connect<br> <li> Added permission mapping for <code>CYCLING_PEDALING_CADENCE_SERIES_RECORD</code> <br>data type supporting read and write access<br> <li> Added string-to-enum mapping for "CYCLING_CADENCE" permission string</ul>


</details>


  </td>
  <td><a href="https://github.com/fam-tung-lam/health_connector/pull/55/files#diff-53732ef1be9f71c35aec3d299fd6500f74bdde8040391f63aea57c4461193616">+14/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>HealthRecordHandlerRegistry.kt</strong><dd><code>Register cycling pedaling cadence handler</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/health_connector_hc_android/android/src/main/kotlin/com/phamtunglam/health_connector_hc_android/handlers/HealthRecordHandlerRegistry.kt

<ul><li>Added import for <code>CyclingPedalingCadenceHandler</code><br> <li> Registered <code>CyclingPedalingCadenceHandler</code> in the handler registry</ul>


</details>


  </td>
  <td><a href="https://github.com/fam-tung-lam/health_connector/pull/55/files#diff-8617d12bf79dc3b6bc33579867501744c23b8c9d36d0f6a57f647f8d8968d0a7">+2/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>HealthRecordIdMappers.kt</strong><dd><code>Add cycling pedaling cadence record ID mapping</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/health_connector_hc_android/android/src/main/kotlin/com/phamtunglam/health_connector_hc_android/mappers/health_record_mappers/HealthRecordIdMappers.kt

<ul><li>Added import for <code>CyclingPedalingCadenceSeriesRecordDto</code><br> <li> Added case handling for <code>CyclingPedalingCadenceSeriesRecordDto</code> in the <br>ID extraction extension</ul>


</details>


  </td>
  <td><a href="https://github.com/fam-tung-lam/health_connector/pull/55/files#diff-f1b5f546572492f6d31694db7f50589b2aa5385d1ab6fdd4609f58a7469a8a92">+2/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>HealthDataTypeMappers.kt</strong><dd><code>Add cycling pedaling cadence type mapping</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/health_connector_hc_android/android/src/main/kotlin/com/phamtunglam/health_connector_hc_android/mappers/HealthDataTypeMappers.kt

<ul><li>Added import for <code>CyclingPedalingCadenceRecord</code> from Health Connect<br> <li> Added mapping from <code>CYCLING_PEDALING_CADENCE_SERIES_RECORD</code> enum to <br><code>CyclingPedalingCadenceRecord</code> class</ul>


</details>


  </td>
  <td><a href="https://github.com/fam-tung-lam/health_connector/pull/55/files#diff-41f32ba89e720f4e9133ecbd6d58064b43af2e089e620906f2418ea1a59822c3">+2/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Additional files</strong></td><td><details><summary>15 files</summary><table>
<tr>
  <td><strong>app_texts.dart</strong></td>
  <td><a href="https://github.com/fam-tung-lam/health_connector/pull/55/files#diff-07b8e00f27991c2402b6645cc31d6c9841375152740ab1048854bd2f507adc41">+17/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>health_data_type_ui_extension.dart</strong></td>
  <td><a href="https://github.com/fam-tung-lam/health_connector/pull/55/files#diff-4f798626b9aa86635720cdbe71f346b9cd06099d9133be02bd223f8798c1277a">+14/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>measurement_unit_value_parser.dart</strong></td>
  <td><a href="https://github.com/fam-tung-lam/health_connector/pull/55/files#diff-ac7b697e877c3aea6173377bf5995c439eeaeb2eea0499f59b6c864beea80c30">+2/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>aggregate_health_data_change_notifier.dart</strong></td>
  <td><a href="https://github.com/fam-tung-lam/health_connector/pull/55/files#diff-979e43d586942a4803fec58091dd57411bb8b8962404d175522c81dfb116c967">+36/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>cycling_pedaling_cadence_series_record_samples_list.dart</strong></td>
  <td><a href="https://github.com/fam-tung-lam/health_connector/pull/55/files#diff-490e45d50208a4cb6f352e1ff9ee8071550b52758a048017a041c21bc2f73ab6">+34/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>health_record_list_tile.dart</strong></td>
  <td><a href="https://github.com/fam-tung-lam/health_connector/pull/55/files#diff-57decaab37c9c0e5974d2b5c3343d072c3ca1c624979eacfd7e806f41f09b97c">+12/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>cycling_pedaling_cadence_measurement_list_tile.dart</strong></td>
  <td><a href="https://github.com/fam-tung-lam/health_connector/pull/55/files#diff-7236084056dbbee33e94a21c1240514319810034e069160c53e703d9996625fd">+34/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>cycling_pedaling_cadence_series_list_tile.dart</strong></td>
  <td><a href="https://github.com/fam-tung-lam/health_connector/pull/55/files#diff-f8bd5e3680a4e036a9377b494f61c6b364cfa2574dfd4706492ce36ae235da58">+52/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>health_record_write_page.dart</strong></td>
  <td><a href="https://github.com/fam-tung-lam/health_connector/pull/55/files#diff-95359aee57dcc236b8fffbbde90f8dd07112fc4553b5b119d8a8346684615a96">+12/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>cycling_pedaling_cadence_measurements_write_form_field_group.dart</strong></td>
  <td><a href="https://github.com/fam-tung-lam/health_connector/pull/55/files#diff-5dbf1250d47964e10a2c1a2293f1dae3854e571fe560f5c564dcde841908250f">+67/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>cycling_pedaling_cadence_measurement_health_record_write_form.dart</strong></td>
  <td><a href="https://github.com/fam-tung-lam/health_connector/pull/55/files#diff-5e8ef11fec5624330798081d92181dc2e2cf871df4010f18363e6806f8eebd5f">+39/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>cycling_pedaling_cadence_series_health_record_write_form.dart</strong></td>
  <td><a href="https://github.com/fam-tung-lam/health_connector/pull/55/files#diff-7ef46c4af0fad752aae513e6a5d300c15e2ca1be5749eb4f3a275d0d5edf86b5">+52/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>CyclingPedalingCadenceRecordMappers.kt</strong></td>
  <td><a href="https://github.com/fam-tung-lam/health_connector/pull/55/files#diff-9bf2126b70cfbb3539e0f59968b2c1f066ce3720c2eb010c933cd337c53f733f">+48/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>HealthRecordMappers.kt</strong></td>
  <td><a href="https://github.com/fam-tung-lam/health_connector/pull/55/files#diff-b46acbc5c4bf7e37fa014b122641d13c24a6c469213d234d97727c0768b212b4">+5/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>HealthKitExtensions.swift</strong></td>
  <td><a href="https://github.com/fam-tung-lam/health_connector/pull/55/files#diff-bd36f05330e930c5bcdd68407566997ed46ee65e7c0ec92144aa2497079796fa">+2/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr></tbody></table>

</details>

___

