### PR TITLE
feat(health_connector,health_connector_core,health_connector_hc_android,health_connector_hk_ios): Add support for ovulation test result data type and record

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,86 +1,56 @@
-# Health Connector
+please see the adding new data type support guidance @ADDING_NEW_HEALTH_DATA_TYPE_GUIDE.md and add
+support for energy/calories burned types and records.
 
-<p align="center">
-  <img alt="Health Connector" width="200px" src="https://img.shields.io/badge/Health-Connector-2E8B57.svg?style=for-the-badge">
-</p>
+## Android Health Connect
 
-<p align="center">
-A unified, type-safe Flutter plugin for accessing health data across Android and iOS platforms.
-</p>
+### BasalMetabolicRateRecord (Android Health Connect Only)
 
-<p align="center">
-  <a title="Pub" href="https://pub.dev/packages/health_connector"><img src="https://img.shields.io/pub/v/health_connector.svg?style=popout"/></a>
-  <a title="Pub Points" href="https://pub.dev/packages/health_connector/score"><img src="https://img.shields.io/pub/points/health_connector?color=2E8B57&label=pub%20points"/></a>
-  <a title="License" href="https://github.com/fam-tung-lam/health_connector/blob/main/LICENSE"><img src="https://img.shields.io/github/license/fam-tung-lam/health_connector"/></a>
-</p>
+BasalMetabolicRateRecord in Health Connect represents BMR as a power value (for example kcal/day) at
+a given time, conceptually an instantaneous rate that can be treated as constant until updated.
 
----
+Health Connect API: [`BasalMetabolicRateRecord`](https://developer.android.com/reference/kotlin/androidx/health/connect/client/records/BasalMetabolicRateRecord)
 
-## 📖 Overview
+We will have a single type and record:
+- `BasalMetabolicRateRecord` class that is `InstantHealthRecord` and related `BasalMetabolicRateDataType` data type
 
-**Health Connector** provides a unified interface to access health data from **Android Health
-Connect** and **iOS HealthKit**. It abstracts platform differences while preserving
-platform-specific capabilities, offering a consistent API for reading, writing, updating, deleting,
-and aggregating health records.
+Use `Power` measurement unit.
 
----
+#### Supported Aggregation Metrics
 
-## 📦 Packages
+- SUM -> BasalMetabolicRateRecord.BASAL_CALORIES_TOTAL -> returns `Energy` (not `Power`) measurement unit.
 
-Health Connector is organized as a monorepo containing multiple packages:
+### TotalCaloriesBurnedRecord (Android Health Connect Only)
 
-### Core Packages
+Health Connect API: [`TotalCaloriesBurnedRecord`](https://developer.android.com/reference/kotlin/androidx/health/connect/client/records/TotalCaloriesBurnedRecord)
 
-- **[health_connector](packages/health_connector)** - Main facade package providing the unified API
-- **[health_connector_core](packages/health_connector_core)** - Core types, abstractions, and domain
-  models
-- **[health_connector_hc_android](packages/health_connector_hc_android)** - Android Health Connect
-  implementation
-- **[health_connector_hk_ios](packages/health_connector_hk_ios)** - iOS HealthKit implementation
+We will have a single type and record:
+- `TotalCaloriesBurnedRecord` class that is `IntervalHealthRecord` and related `TotalCaloriesBurnedDataType` data type
 
-### Utility Packages
+Use `Energy` measurement unit.
 
-- **[health_connector_lint](packages/health_connector_lint)** - Shared lint rules and analysis
-  options
-- **[health_connector_logger](packages/health_connector_logger)** - Structured logging utilities
+#### Supported Aggregation Metrics
+
+- SUM -> TotalCaloriesBurnedRecord.ENERGY_TOTAL -> returns `Energy` measurement unit.
 
 ---
 
-## 🤝 Contributing
+## iOS HealthKit
 
-Contributions are welcome! To contribute:
+### BasalEnergyBurnedRecord (iOS HealthKit Only)
 
-1. Fork the repository
-2. Create a feature branch (`git checkout -b feature/amazing-feature`)
-3. Commit your changes (`git commit -m 'Add amazing feature'`)
-4. Push to the branch (`git push origin feature/amazing-feature`)
-5. Open a Pull Request
+`HKQuantityTypeIdentifier.basalEnergyBurned` is a quantity type with cumulative aggregation style, 
+meaning samples represent an amount of energy over a time span with startDate and endDate.
 
-Before submitting:
+Each HKQuantitySample for this type is therefore an interval sample, representing total resting 
+energy burned during that period.
 
-- Ensure code follows the lint rules defined
-  in [health_connector_lint](packages/health_connector_lint)
-- Add tests for new functionality
-- Update documentation as needed
+HealthKit API: [`HKQuantityTypeIdentifier.basalenergyburned`](https://developer.apple.com/documentation/healthkit/hkquantitytypeidentifier/basalenergyburned)
 
-For major changes, please open an issue first to discuss what you would like to change.
+We will have a single type and record:
+- `BasalEnergyBurnedRecord` class that is `IntervalHealthRecord` and related `BasalEnergyBurnedDataType` data type
 
----
+Use `Energy` measurement unit.
 
-## 🐛 Issues & Feature Requests
+### Supported Aggregation Metrics
 
-Found a bug or have a feature request? Please open an issue on
-our [GitHub Issues](https://github.com/fam-tung-lam/health_connector/issues) page.
-
-When reporting issues, please include:
-
-- Device/OS information
-- Flutter and Dart versions
-- Steps to reproduce and logs
-- Expected vs actual behavior
-
----
-
-## 📄 License
-
-This project is licensed under the Apache-2.0 License - see the [LICENSE](LICENSE) file for details.
+- SUM -> HKStatisticsOptions.cumulativeSum -> returns `Energy` measurement unit.

--- a/examples/health_connector_toolbox/lib/src/common/constants/app_icons.dart
+++ b/examples/health_connector_toolbox/lib/src/common/constants/app_icons.dart
@@ -27,6 +27,7 @@ abstract final class AppIcons {
   static const IconData readMore = Icons.read_more;
   static const IconData calculate = Icons.calculate;
   static const IconData favorite = Icons.favorite;
+  static const IconData science = Icons.science;
   static const IconData bedtime = Icons.bedtime;
   static const IconData air = Icons.air;
   static const IconData fastfood = Icons.fastfood;

--- a/examples/health_connector_toolbox/lib/src/common/constants/app_texts.dart
+++ b/examples/health_connector_toolbox/lib/src/common/constants/app_texts.dart
@@ -113,6 +113,7 @@ abstract final class AppTexts {
       SleepSessionHealthDataType() => sleepSession,
       SleepStageHealthDataType() => sleepStage,
       SexualActivityDataType() => sexualActivity,
+      OvulationTestDataType() => ovulationTest,
       EnergyNutrientDataType() => energy,
       CaffeineNutrientDataType() => caffeine,
       ProteinNutrientDataType() => protein,
@@ -357,6 +358,9 @@ abstract final class AppTexts {
   static const String bloodPressureType = '$bloodPressure $type';
   static const String sexualActivity = 'Sexual Activity';
   static const String protectionUsed = 'Protection Used';
+  static const String ovulationTest = 'Ovulation Test';
+  static const String testResult = 'Test Result';
+  static const String selectTestResult = 'Select test result';
   static const String appearance = 'Appearance';
   static const String sensation = 'Sensation';
   static const String optional = 'Optional';
@@ -364,6 +368,12 @@ abstract final class AppTexts {
   // Sexual Activity Protection
   static const String protected = 'Protected';
   static const String unprotected = 'Unprotected';
+
+  // Ovulation Test Results
+  static const String negative = 'Negative';
+  static const String inconclusive = 'Inconclusive';
+  static const String high = 'High';
+  static const String positive = 'Positive';
 
   // Cervical Mucus
   static const String light = 'Light';
@@ -804,6 +814,10 @@ abstract final class AppTexts {
   // Cervical Mucus
   static const String cervicalMucusDescription =
       'Cervical mucus appearance and sensation observation';
+
+  // Ovulation Test
+  static const String ovulationTestDescription =
+      'Ovulation test results to track fertility cycles';
 
   // Respiratory and Oxygen
   static const String oxygenSaturationDescription =

--- a/examples/health_connector_toolbox/lib/src/common/utils/extensions/health_data_type_ui_extension.dart
+++ b/examples/health_connector_toolbox/lib/src/common/utils/extensions/health_data_type_ui_extension.dart
@@ -81,7 +81,8 @@ import 'package:health_connector/health_connector_internal.dart'
         CyclingPowerDataType,
         CyclingPedalingCadenceMeasurementRecordHealthDataType,
         CyclingPedalingCadenceSeriesRecordHealthDataType,
-        CervicalMucusDataType;
+        CervicalMucusDataType,
+        OvulationTestDataType;
 import 'package:health_connector_toolbox/src/common/constants/app_icons.dart';
 import 'package:health_connector_toolbox/src/common/constants/app_texts.dart';
 
@@ -127,6 +128,7 @@ extension HealthDataTypeUI on HealthDataType {
       SleepSessionHealthDataType _ => AppTexts.sleepSession,
       SleepStageHealthDataType _ => AppTexts.sleepStage,
       SexualActivityDataType _ => AppTexts.sexualActivity,
+      OvulationTestDataType _ => AppTexts.ovulationTest,
       OxygenSaturationHealthDataType _ => AppTexts.oxygenSaturation,
       NutritionHealthDataType _ => AppTexts.nutrition,
       EnergyNutrientDataType _ => AppTexts.energy,
@@ -275,6 +277,7 @@ extension HealthDataTypeUI on HealthDataType {
       ExerciseSessionHealthDataType _ => 'Period of physical activity',
       MindfulnessSessionDataType _ => 'Period of mindfulness practice',
       CervicalMucusDataType _ => AppTexts.cervicalMucusDescription,
+      OvulationTestDataType _ => AppTexts.ovulationTestDescription,
     };
   }
 
@@ -363,6 +366,7 @@ extension HealthDataTypeUI on HealthDataType {
       CyclingPowerDataType _ => AppIcons.power,
       ExerciseSessionHealthDataType _ => AppIcons.fitnessCenter,
       CervicalMucusDataType _ => AppIcons.waterDrop,
+      OvulationTestDataType _ => AppIcons.science,
       MindfulnessSessionDataType _ => AppIcons.selfImprovement,
     };
   }

--- a/examples/health_connector_toolbox/lib/src/common/utils/extensions/ovulation_test_result_type_extension.dart
+++ b/examples/health_connector_toolbox/lib/src/common/utils/extensions/ovulation_test_result_type_extension.dart
@@ -1,0 +1,16 @@
+import 'package:health_connector/health_connector_internal.dart'
+    show OvulationTestResultType;
+import 'package:health_connector_toolbox/src/common/constants/app_texts.dart';
+
+/// Extension methods for [OvulationTestResultType] to provide UI support.
+extension OvulationTestResultTypeExtension on OvulationTestResultType {
+  /// Returns a user-friendly display name for this ovulation test result.
+  String get displayName {
+    return switch (this) {
+      OvulationTestResultType.negative => AppTexts.negative,
+      OvulationTestResultType.inconclusive => AppTexts.inconclusive,
+      OvulationTestResultType.high => AppTexts.high,
+      OvulationTestResultType.positive => AppTexts.positive,
+    };
+  }
+}

--- a/examples/health_connector_toolbox/lib/src/common/utils/measurement_unit_value_parser.dart
+++ b/examples/health_connector_toolbox/lib/src/common/utils/measurement_unit_value_parser.dart
@@ -113,47 +113,51 @@ abstract class MeasurementUnitValueParser {
 
       // Complex/composite types that cannot be parsed from a single string value
       BloodPressureHealthDataType() => throw UnsupportedError(
-        'BloodPressure requires systolic and diastolic values, '
+        '$BloodPressureHealthDataType requires systolic and diastolic values, '
         'cannot be parsed from a single string input.',
       ),
       HeartRateSeriesRecordHealthDataType() => throw UnsupportedError(
-        'HeartRateSeries is a time series data type, '
+        '$HeartRateSeriesRecordHealthDataType is a time series data type, '
         'cannot be parsed from a single string input.',
       ),
       NutritionHealthDataType() => throw UnsupportedError(
-        'Nutrition requires multiple nutrient values, '
+        '$NutritionHealthDataType requires multiple nutrient values, '
         'cannot be parsed from a single string input.',
       ),
       SleepSessionHealthDataType() => throw UnsupportedError(
-        'SleepSession is a complex type with stages and times, '
+        '$SleepSessionHealthDataType is a complex type with stages and times, '
         'cannot be parsed from a single string input.',
       ),
       SleepStageHealthDataType() => throw UnsupportedError(
-        'SleepStage is part of SleepSession, '
+        '$SleepStageHealthDataType is part of SleepSession, '
         'cannot be parsed from a single string input.',
       ),
       SexualActivityDataType() => throw UnsupportedError(
-        'SexualActivity is a complex type with time and optional '
+        '$SexualActivityDataType is a complex type with time and optional '
         'protection info, cannot be parsed from a single string input.',
       ),
       SpeedSeriesDataType() => throw UnsupportedError(
-        'SpeedSeries is a time series data type, '
+        '$SpeedSeriesDataType is a time series data type, '
         'cannot be parsed from a single string input.',
       ),
       PowerSeriesDataType() => throw UnsupportedError(
-        'PowerSeries is a time series data type, '
+        '$PowerSeriesDataType is a time series data type, '
         'cannot be parsed from a single string input.',
       ),
       ExerciseSessionHealthDataType() => throw UnsupportedError(
-        'ExerciseSession is a complex type with exercise type and times, '
-        'not a simple numeric value. Cannot parse.',
+        '$ExerciseSessionHealthDataType is a complex type with exercise '
+        'type and times, not a simple numeric value. Cannot parse.',
       ),
       MindfulnessSessionDataType() => throw UnsupportedError(
-        'MindfulnessSession is a complex type with session type and times, '
-        'not a simple numeric value. Cannot parse.',
+        '$MindfulnessSessionDataType is a complex type with session '
+        'type and times, not a simple numeric value. Cannot parse.',
       ),
       CervicalMucusDataType() => throw UnsupportedError(
-        'CervicalMucus is a complex type with appearance and sensation, '
+        '$CervicalMucusDataType is a complex type with appearance and '
+        'sensation, cannot be parsed from a single string input.',
+      ),
+      OvulationTestDataType() => throw UnsupportedError(
+        '$OvulationTestDataType is a complex type with test result, '
         'cannot be parsed from a single string input.',
       ),
     };

--- a/examples/health_connector_toolbox/lib/src/features/aggregate_health_data/aggregate_health_data_change_notifier.dart
+++ b/examples/health_connector_toolbox/lib/src/features/aggregate_health_data/aggregate_health_data_change_notifier.dart
@@ -89,7 +89,8 @@ import 'package:health_connector/health_connector_internal.dart'
         LeanBodyMassHealthDataType,
         NutritionHealthDataType,
         SpeedSeriesDataType,
-        CervicalMucusDataType;
+        CervicalMucusDataType,
+        OvulationTestDataType;
 
 /// Manages state and operations for aggregating health data.
 ///
@@ -602,6 +603,9 @@ final class AggregateHealthDataChangeNotifier extends ChangeNotifier {
       ),
       CervicalMucusDataType() => throw UnsupportedError(
         'Cervical mucus does not support aggregation',
+      ),
+      OvulationTestDataType() => throw UnsupportedError(
+        'Ovulation test does not support aggregation',
       ),
     };
   }

--- a/examples/health_connector_toolbox/lib/src/features/read_health_records/widgets/health_record_list_tiles/health_record_list_tile.dart
+++ b/examples/health_connector_toolbox/lib/src/features/read_health_records/widgets/health_record_list_tiles/health_record_list_tile.dart
@@ -11,6 +11,7 @@ import 'package:health_connector_toolbox/src/features/read_health_records/widget
 import 'package:health_connector_toolbox/src/features/read_health_records/widgets/health_record_list_tiles/instant_health_record_list_tiles/heart_rate_measurement_list_tile.dart';
 import 'package:health_connector_toolbox/src/features/read_health_records/widgets/health_record_list_tiles/instant_health_record_list_tiles/mass_nutrient_list_tile.dart';
 import 'package:health_connector_toolbox/src/features/read_health_records/widgets/health_record_list_tiles/instant_health_record_list_tiles/nutrition_list_tile.dart';
+import 'package:health_connector_toolbox/src/features/read_health_records/widgets/health_record_list_tiles/instant_health_record_list_tiles/ovulation_test_list_tile.dart';
 import 'package:health_connector_toolbox/src/features/read_health_records/widgets/health_record_list_tiles/instant_health_record_list_tiles/respiratory_rate_list_tile.dart';
 import 'package:health_connector_toolbox/src/features/read_health_records/widgets/health_record_list_tiles/instant_health_record_list_tiles/sexual_activity_list_tile.dart';
 import 'package:health_connector_toolbox/src/features/read_health_records/widgets/health_record_list_tiles/instant_health_record_list_tiles/simple_instant_measurement_list_tile.dart';
@@ -272,6 +273,10 @@ final class HealthRecordListTile extends StatelessWidget {
         onDelete: onDelete,
       ),
       final CervicalMucusRecord r => CervicalMucusListTile(
+        record: r,
+        onDelete: onDelete,
+      ),
+      final OvulationTestRecord r => OvulationTestListTile(
         record: r,
         onDelete: onDelete,
       ),

--- a/examples/health_connector_toolbox/lib/src/features/read_health_records/widgets/health_record_list_tiles/instant_health_record_list_tiles/ovulation_test_list_tile.dart
+++ b/examples/health_connector_toolbox/lib/src/features/read_health_records/widgets/health_record_list_tiles/instant_health_record_list_tiles/ovulation_test_list_tile.dart
@@ -1,0 +1,76 @@
+import 'package:flutter/material.dart';
+import 'package:health_connector/health_connector_internal.dart';
+import 'package:health_connector_toolbox/src/common/constants/app_icons.dart';
+import 'package:health_connector_toolbox/src/common/constants/app_texts.dart';
+import 'package:health_connector_toolbox/src/common/utils/extensions/ovulation_test_result_type_extension.dart';
+import 'package:health_connector_toolbox/src/features/read_health_records/widgets/health_record_list_tiles/health_record_list_tile_subtitle.dart';
+import 'package:health_connector_toolbox/src/features/read_health_records/widgets/health_record_list_tiles/instant_health_record_list_tiles/instant_health_record_list_tile.dart';
+
+/// Widget for displaying ovulation test record tiles.
+final class OvulationTestListTile extends StatelessWidget {
+  const OvulationTestListTile({
+    required this.record,
+    required this.onDelete,
+    super.key,
+  });
+
+  final OvulationTestRecord record;
+  final VoidCallback onDelete;
+
+  @override
+  Widget build(BuildContext context) {
+    final resultText = record.result.displayName;
+
+    return InstantHealthRecordTile<OvulationTestRecord>(
+      record: record,
+      icon: AppIcons.science,
+      title: AppTexts.ovulationTest,
+      subtitleBuilder: (r, ctx) => HealthRecordListTileSubtitle.instant(
+        time: r.time,
+        recordingMethod: r.metadata.recordingMethod.name,
+      ),
+      detailRowsBuilder: (r, ctx) => [
+        _DetailRow(
+          label: AppTexts.testResult,
+          value: resultText,
+        ),
+      ],
+      onDelete: onDelete,
+    );
+  }
+}
+
+/// Helper widget for detail rows.
+class _DetailRow extends StatelessWidget {
+  const _DetailRow({
+    required this.label,
+    required this.value,
+  });
+
+  final String label;
+  final String value;
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: const EdgeInsets.symmetric(vertical: 4),
+      child: Row(
+        mainAxisAlignment: MainAxisAlignment.spaceBetween,
+        children: [
+          Text(
+            label,
+            style: Theme.of(context).textTheme.bodyMedium?.copyWith(
+              color: Theme.of(context).colorScheme.onSurfaceVariant,
+            ),
+          ),
+          Text(
+            value,
+            style: Theme.of(context).textTheme.bodyMedium?.copyWith(
+              fontWeight: FontWeight.w500,
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/examples/health_connector_toolbox/lib/src/features/write_health_record/pages/health_record_write_page.dart
+++ b/examples/health_connector_toolbox/lib/src/features/write_health_record/pages/health_record_write_page.dart
@@ -7,6 +7,7 @@ import 'package:health_connector_toolbox/src/common/widgets/loading_overlay.dart
 import 'package:health_connector_toolbox/src/features/write_health_record/widgets/write_forms/base_health_record_write_form.dart';
 import 'package:health_connector_toolbox/src/features/write_health_record/widgets/write_forms/custom_health_record_write_forms/blood_pressure_health_record_write_form.dart';
 import 'package:health_connector_toolbox/src/features/write_health_record/widgets/write_forms/custom_health_record_write_forms/cervical_mucus_health_record_write_form.dart';
+import 'package:health_connector_toolbox/src/features/write_health_record/widgets/write_forms/custom_health_record_write_forms/ovulation_test_health_record_write_form.dart';
 import 'package:health_connector_toolbox/src/features/write_health_record/widgets/write_forms/custom_health_record_write_forms/sexual_activity_health_record_write_form.dart';
 import 'package:health_connector_toolbox/src/features/write_health_record/widgets/write_forms/instant_health_record_write_forms/blood_glucose_health_record_write_form.dart';
 import 'package:health_connector_toolbox/src/features/write_health_record/widgets/write_forms/instant_health_record_write_forms/body_fat_percentage_health_record_write_form.dart';
@@ -190,6 +191,10 @@ class _HealthRecordWritePageState extends State<HealthRecordWritePage>
         onSubmit: _onSubmit,
       ),
       CervicalMucusDataType _ => CervicalMucusWriteForm(
+        healthPlatform: _notifier.healthPlatform,
+        onSubmit: _onSubmit,
+      ),
+      OvulationTestDataType _ => OvulationTestWriteForm(
         healthPlatform: _notifier.healthPlatform,
         onSubmit: _onSubmit,
       ),

--- a/examples/health_connector_toolbox/lib/src/features/write_health_record/widgets/write_forms/custom_health_record_write_forms/ovulation_test_health_record_write_form.dart
+++ b/examples/health_connector_toolbox/lib/src/features/write_health_record/widgets/write_forms/custom_health_record_write_forms/ovulation_test_health_record_write_form.dart
@@ -1,0 +1,52 @@
+import 'package:flutter/material.dart';
+import 'package:health_connector/health_connector_internal.dart';
+import 'package:health_connector_toolbox/src/common/constants/app_icons.dart';
+import 'package:health_connector_toolbox/src/common/constants/app_texts.dart';
+import 'package:health_connector_toolbox/src/common/utils/extensions/ovulation_test_result_type_extension.dart';
+import 'package:health_connector_toolbox/src/common/widgets/searchable_dropdown_menu_form_field.dart';
+import 'package:health_connector_toolbox/src/features/write_health_record/widgets/write_forms/base_health_record_write_form.dart';
+
+/// Form widget for ovulation test records.
+@immutable
+final class OvulationTestWriteForm extends BaseHealthRecordWriteForm {
+  const OvulationTestWriteForm({
+    required super.healthPlatform,
+    required super.onSubmit,
+    super.key,
+  });
+
+  @override
+  OvulationTestFormState createState() => OvulationTestFormState();
+}
+
+/// State for ovulation test form widget.
+final class OvulationTestFormState
+    extends BaseHealthRecordWriteFormState<OvulationTestWriteForm> {
+  OvulationTestResultType result = OvulationTestResultType.negative;
+
+  @override
+  List<Widget> buildFields(BuildContext context) {
+    return [
+      SearchableDropdownMenuFormField<OvulationTestResultType>(
+        labelText: AppTexts.testResult,
+        values: OvulationTestResultType.values,
+        initialValue: result,
+        onChanged: (value) => setState(() {
+          result = value ?? OvulationTestResultType.negative;
+        }),
+        displayNameBuilder: (type) => type.displayName,
+        prefixIcon: AppIcons.science,
+        hint: AppTexts.selectTestResult,
+      ),
+    ];
+  }
+
+  @override
+  HealthRecord buildRecord() {
+    return OvulationTestRecord(
+      time: startDateTime!,
+      metadata: metadata,
+      result: result,
+    );
+  }
+}

--- a/packages/health_connector_core/lib/src/models/health_data_types/health_data_type.dart
+++ b/packages/health_connector_core/lib/src/models/health_data_types/health_data_type.dart
@@ -42,6 +42,7 @@ import 'package:health_connector_core/src/models/health_records/health_record.da
         MonounsaturatedFatNutrientRecord,
         NiacinNutrientRecord,
         NutritionRecord,
+        OvulationTestRecord,
         OxygenSaturationRecord,
         PaddleSportsDistanceRecord,
         PantothenicAcidNutrientRecord,
@@ -160,6 +161,7 @@ part 'nutrient_data_types/vitamin_e_nutrient_data_type.dart';
 part 'nutrient_data_types/vitamin_k_nutrient_data_type.dart';
 part 'nutrient_data_types/vitamin_nutrient_data_type.dart';
 part 'nutrient_data_types/zinc_nutrient_data_type.dart';
+part 'ovulation_test_data_type.dart';
 part 'oxygen_saturation_health_data_type.dart';
 part 'power_data_types/cycling_power_data_type.dart';
 part 'power_data_types/power_series_data_type.dart';
@@ -517,6 +519,14 @@ sealed class HealthDataType<R extends HealthRecord, U extends MeasurementUnit>
   @sinceV1_3_0
   static const restingHeartRate = RestingHeartRateHealthDataType();
 
+  /// Ovulation test data type.
+  ///
+  /// Represents ovulation test results that detect hormonal changes to
+  /// identify fertility windows. Results can be negative, inconclusive,
+  /// high (estrogen surge), or positive (LH surge).
+  @sinceV2_2_0
+  static const ovulationTest = OvulationTestDataType();
+
   /// Oxygen saturation data type.
   ///
   /// Represents the percentage of oxygen-saturated hemoglobin relative
@@ -845,6 +855,7 @@ sealed class HealthDataType<R extends HealthRecord, U extends MeasurementUnit>
     monounsaturatedFat,
     niacin,
     nutrition,
+    ovulationTest,
     oxygenSaturation,
     powerSeries,
     cyclingPower,

--- a/packages/health_connector_core/lib/src/models/health_data_types/ovulation_test_data_type.dart
+++ b/packages/health_connector_core/lib/src/models/health_data_types/ovulation_test_data_type.dart
@@ -1,0 +1,134 @@
+part of 'health_data_type.dart';
+
+/// Ovulation test data type.
+///
+/// Ovulation test records track the results of tests that detect
+/// hormonal changes to identify fertility windows.
+///
+/// ## Platform Mapping
+///
+/// - **Android Health Connect**: [`OvulationTestRecord`](https://developer.android.com/reference/kotlin/androidx/health/connect/client/records/OvulationTestRecord)
+/// - **iOS HealthKit**: [`HKCategoryTypeIdentifier.ovulationTestResult`](https://developer.apple.com/documentation/healthkit/hkcategorytypeidentifier/ovulationtestresult)
+///
+/// ## Capabilities
+///
+/// - Readable: Query ovulation test records
+/// - Writeable: Write ovulation test records
+/// - Deletable: Delete records by IDs or time range
+/// - Aggregation: Not supported (categorical data)
+///
+/// ## Example
+///
+/// ```dart
+/// // Request permissions
+/// final permissions = [
+///   HealthDataType.ovulationTest.readPermission,
+///   HealthDataType.ovulationTest.writePermission,
+/// ];
+/// await connector.requestPermissions(permissions);
+///
+/// // Read records
+/// final request = HealthDataType.ovulationTest.readInTimeRange(
+///   startTime: DateTime.now().subtract(Duration(days: 30)),
+///   endTime: DateTime.now(),
+/// );
+/// final response = await connector.readRecords(request);
+///
+/// // Delete records by IDs
+/// final deleteRequest = HealthDataType.ovulationTest.deleteByIds([id1, id2]);
+/// await connector.deleteRecords(deleteRequest);
+///
+/// // Delete records in time range
+/// final deleteRangeRequest = HealthDataType.ovulationTest.deleteInTimeRange(
+///   startTime: DateTime.now().subtract(Duration(days: 30)),
+///   endTime: DateTime.now(),
+/// );
+/// await connector.deleteRecords(deleteRangeRequest);
+/// ```
+///
+/// ## See also
+///
+/// - [OvulationTestRecord]
+/// - [OvulationTestResultType]
+///
+/// {@category Health Data Types}
+@sinceV2_2_0
+@immutable
+final class OvulationTestDataType
+    extends HealthDataType<OvulationTestRecord, TimeDuration>
+    implements
+        ReadableHealthDataType<OvulationTestRecord>,
+        WriteableHealthDataType,
+        DeletableHealthDataType<OvulationTestRecord> {
+  /// Creates an ovulation test data type.
+  ///
+  /// This is a constant constructor used internally. To reference this data
+  /// type, use the singleton instance from [HealthDataType].
+  @internal
+  const OvulationTestDataType();
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is OvulationTestDataType && runtimeType == other.runtimeType;
+
+  @override
+  int get hashCode => runtimeType.hashCode;
+
+  @override
+  List<AggregationMetric> get supportedAggregationMetrics => [];
+
+  @override
+  HealthDataPermission get readPermission => HealthDataPermission.read(this);
+
+  @override
+  ReadRecordByIdRequest<OvulationTestRecord> readById(HealthRecordId id) {
+    return ReadRecordByIdRequest(dataType: this, id: id);
+  }
+
+  @override
+  ReadRecordsInTimeRangeRequest<OvulationTestRecord> readInTimeRange({
+    required DateTime startTime,
+    required DateTime endTime,
+    List<DataOrigin> dataOrigins = const [],
+    int pageSize = HealthConnectorConfigConstants.defaultPageSize,
+    String? pageToken,
+  }) {
+    return ReadRecordsInTimeRangeRequest(
+      dataType: this,
+      dataOrigins: dataOrigins,
+      startTime: startTime,
+      endTime: endTime,
+      pageSize: pageSize,
+      pageToken: pageToken,
+    );
+  }
+
+  @override
+  HealthDataPermission get writePermission => HealthDataPermission.write(this);
+
+  @override
+  List<Permission> get permissions => [readPermission, writePermission];
+
+  @override
+  DeleteRecordsByIdsRequest<OvulationTestRecord> deleteByIds(
+    List<HealthRecordId> recordIds,
+  ) {
+    return DeleteRecordsByIdsRequest(
+      dataType: this,
+      recordIds: recordIds,
+    );
+  }
+
+  @override
+  DeleteRecordsInTimeRangeRequest<OvulationTestRecord> deleteInTimeRange({
+    required DateTime startTime,
+    required DateTime endTime,
+  }) {
+    return DeleteRecordsInTimeRangeRequest(
+      dataType: this,
+      startTime: startTime,
+      endTime: endTime,
+    );
+  }
+}

--- a/packages/health_connector_core/lib/src/models/health_records/health_record.dart
+++ b/packages/health_connector_core/lib/src/models/health_records/health_record.dart
@@ -82,6 +82,8 @@ part 'nutrition_records/vitamin_e_nutrient_record.dart';
 part 'nutrition_records/vitamin_k_nutrient_record.dart';
 part 'nutrition_records/vitamin_nutrient_record.dart';
 part 'nutrition_records/zinc_nutrient_record.dart';
+part 'ovulation_test/ovulation_test_record.dart';
+part 'ovulation_test/ovulation_test_result_type.dart';
 part 'oxygen_saturation_record.dart';
 part 'power_records/cycling_power_record.dart';
 part 'power_records/power_series_record.dart';

--- a/packages/health_connector_core/lib/src/models/health_records/ovulation_test/ovulation_test_record.dart
+++ b/packages/health_connector_core/lib/src/models/health_records/ovulation_test/ovulation_test_record.dart
@@ -1,0 +1,96 @@
+part of '../health_record.dart';
+
+/// Represents an ovulation test result at a specific point in time.
+///
+/// An ovulation test record captures the result of a test that detects hormonal
+/// changes to identify fertility windows. Tests typically measure luteinizing
+/// hormone (LH) or estrogen levels.
+///
+/// ## Platform Mapping
+///
+/// - **Android Health Connect**: [`OvulationTestRecord`](https://developer.android.com/reference/kotlin/androidx/health/connect/client/records/OvulationTestRecord)
+/// - **iOS HealthKit**: [`HKCategoryTypeIdentifier.ovulationTestResult`](https://developer.apple.com/documentation/healthkit/hkcategorytypeidentifier/ovulationtestresult)
+///
+/// ## Example
+///
+/// ```dart
+/// final test = OvulationTestRecord(
+///   id: HealthRecordId.none,
+///   time: DateTime(2024, 1, 15, 8, 30),
+///   result: OvulationTestResultType.positive,
+///   metadata: Metadata.automaticallyRecorded(
+///     dataOrigin: DataOrigin(packageName: 'com.example.app'),
+///   ),
+/// );
+/// ```
+///
+/// ## See also
+///
+/// - [OvulationTestDataType]
+/// - [OvulationTestResultType]
+///
+/// {@category Health Records}
+@sinceV2_2_0
+@immutable
+final class OvulationTestRecord extends InstantHealthRecord {
+  /// Creates an ovulation test record.
+  ///
+  /// Records the result of an ovulation test at a specific [time].
+  /// The [result] indicates the test outcome (negative, inconclusive,
+  /// high, or positive).
+  ///
+  /// Use [metadata] to describe the data source. The timezone offset can be
+  /// provided via [zoneOffsetSeconds].
+  const OvulationTestRecord({
+    required super.time,
+    required super.metadata,
+    required this.result,
+    super.id = HealthRecordId.none,
+    super.zoneOffsetSeconds,
+  });
+
+  /// The ovulation test result.
+  ///
+  /// Indicates the outcome of the test:
+  /// - `negative`: No hormonal surge detected
+  /// - `inconclusive`: Unable to determine result
+  /// - `high`: Estrogen surge detected (approaching ovulation)
+  /// - `positive`: LH surge detected (peak fertility, ovulation imminent)
+  final OvulationTestResultType result;
+
+  /// Creates a copy with the given fields replaced with the new values.
+  OvulationTestRecord copyWith({
+    HealthRecordId? id,
+    Metadata? metadata,
+    DateTime? time,
+    int? zoneOffsetSeconds,
+    OvulationTestResultType? result,
+  }) {
+    return OvulationTestRecord(
+      id: id ?? this.id,
+      metadata: metadata ?? this.metadata,
+      time: time ?? this.time,
+      zoneOffsetSeconds: zoneOffsetSeconds ?? this.zoneOffsetSeconds,
+      result: result ?? this.result,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is OvulationTestRecord &&
+          runtimeType == other.runtimeType &&
+          id == other.id &&
+          metadata == other.metadata &&
+          time == other.time &&
+          zoneOffsetSeconds == other.zoneOffsetSeconds &&
+          result == other.result;
+
+  @override
+  int get hashCode =>
+      id.hashCode ^
+      metadata.hashCode ^
+      time.hashCode ^
+      zoneOffsetSeconds.hashCode ^
+      result.hashCode;
+}

--- a/packages/health_connector_core/lib/src/models/health_records/ovulation_test/ovulation_test_result_type.dart
+++ b/packages/health_connector_core/lib/src/models/health_records/ovulation_test/ovulation_test_result_type.dart
@@ -1,0 +1,29 @@
+part of '../health_record.dart';
+
+/// Represents the result of an ovulation test.
+///
+/// Ovulation tests detect hormonal changes to identify fertility windows.
+/// This enum provides four possible test results.
+///
+/// ## Platform Mapping
+///
+/// - **Android Health Connect**: Maps to
+///   `OvulationTestRecord.RESULT_*` constants
+/// - **iOS HealthKit**: Maps to
+///   `HKCategoryValueOvulationTestResult` enum values
+///
+/// {@category Health Records}
+@sinceV2_2_0
+enum OvulationTestResultType {
+  /// Test result is negative (no hormonal surge detected).
+  negative,
+
+  /// Test result is inconclusive (unable to determine).
+  inconclusive,
+
+  /// Test result shows high estrogen levels (estrogen surge detected).
+  high,
+
+  /// Test result is positive (LH surge detected, peak fertility).
+  positive,
+}

--- a/packages/health_connector_core/lib/src/utils/health_record_data_type_extension.dart
+++ b/packages/health_connector_core/lib/src/utils/health_record_data_type_extension.dart
@@ -32,117 +32,118 @@ extension HealthRecordDataTypeExtension on HealthRecord {
   HealthDataType<HealthRecord, MeasurementUnit> get dataType {
     return switch (this) {
       // Distance records
-      DistanceRecord() => HealthDataType.distance,
-      CyclingDistanceRecord() => HealthDataType.cyclingDistance,
-      SwimmingDistanceRecord() => HealthDataType.swimmingDistance,
-      WheelchairDistanceRecord() => HealthDataType.wheelchairDistance,
-      DownhillSnowSportsDistanceRecord() =>
+      DistanceRecord _ => HealthDataType.distance,
+      CyclingDistanceRecord _ => HealthDataType.cyclingDistance,
+      SwimmingDistanceRecord _ => HealthDataType.swimmingDistance,
+      WheelchairDistanceRecord _ => HealthDataType.wheelchairDistance,
+      DownhillSnowSportsDistanceRecord _ =>
         HealthDataType.downhillSnowSportsDistance,
-      RowingDistanceRecord() => HealthDataType.rowingDistance,
-      PaddleSportsDistanceRecord() => HealthDataType.paddleSportsDistance,
-      CrossCountrySkiingDistanceRecord() =>
+      RowingDistanceRecord _ => HealthDataType.rowingDistance,
+      PaddleSportsDistanceRecord _ => HealthDataType.paddleSportsDistance,
+      CrossCountrySkiingDistanceRecord _ =>
         HealthDataType.crossCountrySkiingDistance,
-      SkatingSportsDistanceRecord() => HealthDataType.skatingSportsDistance,
-      SixMinuteWalkTestDistanceRecord() =>
+      SkatingSportsDistanceRecord _ => HealthDataType.skatingSportsDistance,
+      SixMinuteWalkTestDistanceRecord _ =>
         HealthDataType.sixMinuteWalkTestDistance,
-      WalkingRunningDistanceRecord() => HealthDataType.walkingRunningDistance,
+      WalkingRunningDistanceRecord _ => HealthDataType.walkingRunningDistance,
 
       // Speed records
-      SpeedSeriesRecord() => HealthDataType.speedSeries,
-      WalkingSpeedRecord() => HealthDataType.walkingSpeed,
-      RunningSpeedRecord() => HealthDataType.runningSpeed,
-      StairAscentSpeedRecord() => HealthDataType.stairAscentSpeed,
-      StairDescentSpeedRecord() => HealthDataType.stairDescentSpeed,
+      SpeedSeriesRecord _ => HealthDataType.speedSeries,
+      WalkingSpeedRecord _ => HealthDataType.walkingSpeed,
+      RunningSpeedRecord _ => HealthDataType.runningSpeed,
+      StairAscentSpeedRecord _ => HealthDataType.stairAscentSpeed,
+      StairDescentSpeedRecord _ => HealthDataType.stairDescentSpeed,
 
       // Power records
-      PowerSeriesRecord() => HealthDataType.powerSeries,
-      CyclingPowerRecord() => HealthDataType.cyclingPower,
+      PowerSeriesRecord _ => HealthDataType.powerSeries,
+      CyclingPowerRecord _ => HealthDataType.cyclingPower,
 
       // Basic health records
-      StepsRecord() => HealthDataType.steps,
-      WeightRecord() => HealthDataType.weight,
-      HeightRecord() => HealthDataType.height,
-      BloodGlucoseRecord() => HealthDataType.bloodGlucose,
-      BodyFatPercentageRecord() => HealthDataType.bodyFatPercentage,
-      BodyTemperatureRecord() => HealthDataType.bodyTemperature,
-      CervicalMucusRecord() => HealthDataType.cervicalMucus,
-      ActiveCaloriesBurnedRecord() => HealthDataType.activeCaloriesBurned,
-      ExerciseSessionRecord() => HealthDataType.exerciseSession,
-      FloorsClimbedRecord() => HealthDataType.floorsClimbed,
-      WheelchairPushesRecord() => HealthDataType.wheelchairPushes,
-      LeanBodyMassRecord() => HealthDataType.leanBodyMass,
-      HydrationRecord() => HealthDataType.hydration,
+      StepsRecord _ => HealthDataType.steps,
+      WeightRecord _ => HealthDataType.weight,
+      HeightRecord _ => HealthDataType.height,
+      BloodGlucoseRecord _ => HealthDataType.bloodGlucose,
+      BodyFatPercentageRecord _ => HealthDataType.bodyFatPercentage,
+      BodyTemperatureRecord _ => HealthDataType.bodyTemperature,
+      CervicalMucusRecord _ => HealthDataType.cervicalMucus,
+      ActiveCaloriesBurnedRecord _ => HealthDataType.activeCaloriesBurned,
+      ExerciseSessionRecord _ => HealthDataType.exerciseSession,
+      FloorsClimbedRecord _ => HealthDataType.floorsClimbed,
+      WheelchairPushesRecord _ => HealthDataType.wheelchairPushes,
+      LeanBodyMassRecord _ => HealthDataType.leanBodyMass,
+      HydrationRecord _ => HealthDataType.hydration,
 
       // Blood pressure records
-      BloodPressureRecord() => HealthDataType.bloodPressure,
-      SystolicBloodPressureRecord() => HealthDataType.systolicBloodPressure,
-      DiastolicBloodPressureRecord() => HealthDataType.diastolicBloodPressure,
+      BloodPressureRecord _ => HealthDataType.bloodPressure,
+      SystolicBloodPressureRecord _ => HealthDataType.systolicBloodPressure,
+      DiastolicBloodPressureRecord _ => HealthDataType.diastolicBloodPressure,
 
       // Heart rate records
-      HeartRateSeriesRecord() => HealthDataType.heartRateSeriesRecord,
-      HeartRateMeasurementRecord() => HealthDataType.heartRateMeasurementRecord,
+      HeartRateSeriesRecord _ => HealthDataType.heartRateSeriesRecord,
+      HeartRateMeasurementRecord _ => HealthDataType.heartRateMeasurementRecord,
 
       // Cycling pedaling cadence records
-      CyclingPedalingCadenceSeriesRecord() =>
+      CyclingPedalingCadenceSeriesRecord _ =>
         HealthDataType.cyclingPedalingCadenceSeriesRecord,
-      CyclingPedalingCadenceMeasurementRecord() =>
+      CyclingPedalingCadenceMeasurementRecord _ =>
         HealthDataType.cyclingPedalingCadenceMeasurementRecord,
 
       // Sleep records
-      SleepSessionRecord() => HealthDataType.sleepSession,
-      SleepStageRecord() => HealthDataType.sleepStageRecord,
+      SleepSessionRecord _ => HealthDataType.sleepSession,
+      SleepStageRecord _ => HealthDataType.sleepStageRecord,
 
       // Sexual activity
-      SexualActivityRecord() => HealthDataType.sexualActivity,
+      SexualActivityRecord _ => HealthDataType.sexualActivity,
 
       // Mindfulness records
-      MindfulnessSessionRecord() => HealthDataType.mindfulnessSession,
+      MindfulnessSessionRecord _ => HealthDataType.mindfulnessSession,
 
       // Vital signs
-      RestingHeartRateRecord() => HealthDataType.restingHeartRate,
-      OxygenSaturationRecord() => HealthDataType.oxygenSaturation,
-      RespiratoryRateRecord() => HealthDataType.respiratoryRate,
-      Vo2MaxRecord() => HealthDataType.vo2Max,
+      RestingHeartRateRecord _ => HealthDataType.restingHeartRate,
+      OvulationTestRecord _ => HealthDataType.ovulationTest,
+      OxygenSaturationRecord _ => HealthDataType.oxygenSaturation,
+      RespiratoryRateRecord _ => HealthDataType.respiratoryRate,
+      Vo2MaxRecord _ => HealthDataType.vo2Max,
 
       // Nutrition records
-      NutritionRecord() => HealthDataType.nutrition,
-      EnergyNutrientRecord() => HealthDataType.energyNutrient,
-      CaffeineNutrientRecord() => HealthDataType.caffeine,
-      ProteinNutrientRecord() => HealthDataType.protein,
-      TotalCarbohydrateNutrientRecord() => HealthDataType.totalCarbohydrate,
-      TotalFatNutrientRecord() => HealthDataType.totalFat,
-      SaturatedFatNutrientRecord() => HealthDataType.saturatedFat,
-      MonounsaturatedFatNutrientRecord() => HealthDataType.monounsaturatedFat,
-      PolyunsaturatedFatNutrientRecord() => HealthDataType.polyunsaturatedFat,
-      CholesterolNutrientRecord() => HealthDataType.cholesterol,
-      DietaryFiberNutrientRecord() => HealthDataType.dietaryFiber,
-      SugarNutrientRecord() => HealthDataType.sugar,
+      NutritionRecord _ => HealthDataType.nutrition,
+      EnergyNutrientRecord _ => HealthDataType.energyNutrient,
+      CaffeineNutrientRecord _ => HealthDataType.caffeine,
+      ProteinNutrientRecord _ => HealthDataType.protein,
+      TotalCarbohydrateNutrientRecord _ => HealthDataType.totalCarbohydrate,
+      TotalFatNutrientRecord _ => HealthDataType.totalFat,
+      SaturatedFatNutrientRecord _ => HealthDataType.saturatedFat,
+      MonounsaturatedFatNutrientRecord _ => HealthDataType.monounsaturatedFat,
+      PolyunsaturatedFatNutrientRecord _ => HealthDataType.polyunsaturatedFat,
+      CholesterolNutrientRecord _ => HealthDataType.cholesterol,
+      DietaryFiberNutrientRecord _ => HealthDataType.dietaryFiber,
+      SugarNutrientRecord _ => HealthDataType.sugar,
 
       // Mineral nutrients
-      CalciumNutrientRecord() => HealthDataType.calcium,
-      IronNutrientRecord() => HealthDataType.iron,
-      MagnesiumNutrientRecord() => HealthDataType.magnesium,
-      ManganeseNutrientRecord() => HealthDataType.manganese,
-      PhosphorusNutrientRecord() => HealthDataType.phosphorus,
-      PotassiumNutrientRecord() => HealthDataType.potassium,
-      SeleniumNutrientRecord() => HealthDataType.selenium,
-      SodiumNutrientRecord() => HealthDataType.sodium,
-      ZincNutrientRecord() => HealthDataType.zinc,
+      CalciumNutrientRecord _ => HealthDataType.calcium,
+      IronNutrientRecord _ => HealthDataType.iron,
+      MagnesiumNutrientRecord _ => HealthDataType.magnesium,
+      ManganeseNutrientRecord _ => HealthDataType.manganese,
+      PhosphorusNutrientRecord _ => HealthDataType.phosphorus,
+      PotassiumNutrientRecord _ => HealthDataType.potassium,
+      SeleniumNutrientRecord _ => HealthDataType.selenium,
+      SodiumNutrientRecord _ => HealthDataType.sodium,
+      ZincNutrientRecord _ => HealthDataType.zinc,
 
       // Vitamin nutrients
-      VitaminANutrientRecord() => HealthDataType.vitaminA,
-      VitaminB6NutrientRecord() => HealthDataType.vitaminB6,
-      VitaminB12NutrientRecord() => HealthDataType.vitaminB12,
-      VitaminCNutrientRecord() => HealthDataType.vitaminC,
-      VitaminDNutrientRecord() => HealthDataType.vitaminD,
-      VitaminENutrientRecord() => HealthDataType.vitaminE,
-      VitaminKNutrientRecord() => HealthDataType.vitaminK,
-      ThiaminNutrientRecord() => HealthDataType.thiamin,
-      RiboflavinNutrientRecord() => HealthDataType.riboflavin,
-      NiacinNutrientRecord() => HealthDataType.niacin,
-      FolateNutrientRecord() => HealthDataType.folate,
-      BiotinNutrientRecord() => HealthDataType.biotin,
-      PantothenicAcidNutrientRecord() => HealthDataType.pantothenicAcid,
+      VitaminANutrientRecord _ => HealthDataType.vitaminA,
+      VitaminB6NutrientRecord _ => HealthDataType.vitaminB6,
+      VitaminB12NutrientRecord _ => HealthDataType.vitaminB12,
+      VitaminCNutrientRecord _ => HealthDataType.vitaminC,
+      VitaminDNutrientRecord _ => HealthDataType.vitaminD,
+      VitaminENutrientRecord _ => HealthDataType.vitaminE,
+      VitaminKNutrientRecord _ => HealthDataType.vitaminK,
+      ThiaminNutrientRecord _ => HealthDataType.thiamin,
+      RiboflavinNutrientRecord _ => HealthDataType.riboflavin,
+      NiacinNutrientRecord _ => HealthDataType.niacin,
+      FolateNutrientRecord _ => HealthDataType.folate,
+      BiotinNutrientRecord _ => HealthDataType.biotin,
+      PantothenicAcidNutrientRecord _ => HealthDataType.pantothenicAcid,
     };
   }
 }

--- a/packages/health_connector_hc_android/android/src/main/kotlin/com/phamtunglam/health_connector_hc_android/handlers/HealthRecordHandlerRegistry.kt
+++ b/packages/health_connector_hc_android/android/src/main/kotlin/com/phamtunglam/health_connector_hc_android/handlers/HealthRecordHandlerRegistry.kt
@@ -17,6 +17,7 @@ import com.phamtunglam.health_connector_hc_android.handlers.health_record_handle
 import com.phamtunglam.health_connector_hc_android.handlers.health_record_handlers.LeanBodyMassHandler
 import com.phamtunglam.health_connector_hc_android.handlers.health_record_handlers.MindfulnessSessionHandler
 import com.phamtunglam.health_connector_hc_android.handlers.health_record_handlers.NutritionHandler
+import com.phamtunglam.health_connector_hc_android.handlers.health_record_handlers.OvulationTestHandler
 import com.phamtunglam.health_connector_hc_android.handlers.health_record_handlers.OxygenSaturationHandler
 import com.phamtunglam.health_connector_hc_android.handlers.health_record_handlers.PowerSeriesHandler
 import com.phamtunglam.health_connector_hc_android.handlers.health_record_handlers.RespiratoryRateHandler
@@ -57,6 +58,7 @@ internal class HealthRecordHandlerRegistry(private val client: HealthConnectClie
             register(ExerciseSessionHandler(client))
             register(HydrationHandler(client))
             register(NutritionHandler(client))
+            register(OvulationTestHandler(client))
             register(PowerSeriesHandler(client))
             register(SexualActivityHandler(client))
             register(SleepSessionHandler(client))

--- a/packages/health_connector_hc_android/android/src/main/kotlin/com/phamtunglam/health_connector_hc_android/handlers/health_record_handlers/OvulationTestHandler.kt
+++ b/packages/health_connector_hc_android/android/src/main/kotlin/com/phamtunglam/health_connector_hc_android/handlers/health_record_handlers/OvulationTestHandler.kt
@@ -1,0 +1,18 @@
+package com.phamtunglam.health_connector_hc_android.handlers.health_record_handlers
+
+import androidx.health.connect.client.HealthConnectClient
+import com.phamtunglam.health_connector_hc_android.handlers.DeletableHealthRecordHandler
+import com.phamtunglam.health_connector_hc_android.handlers.ReadableHealthRecordHandler
+import com.phamtunglam.health_connector_hc_android.handlers.WritableHealthRecordHandler
+import com.phamtunglam.health_connector_hc_android.pigeon.HealthDataTypeDto
+
+/**
+ * Handler for Ovulation Test records.
+ */
+internal class OvulationTestHandler(override val client: HealthConnectClient) :
+    ReadableHealthRecordHandler,
+    WritableHealthRecordHandler,
+    DeletableHealthRecordHandler {
+
+    override val dataType = HealthDataTypeDto.OVULATION_TEST
+}

--- a/packages/health_connector_hc_android/android/src/main/kotlin/com/phamtunglam/health_connector_hc_android/mappers/HealthDataTypeMappers.kt
+++ b/packages/health_connector_hc_android/android/src/main/kotlin/com/phamtunglam/health_connector_hc_android/mappers/HealthDataTypeMappers.kt
@@ -17,6 +17,7 @@ import androidx.health.connect.client.records.HydrationRecord
 import androidx.health.connect.client.records.LeanBodyMassRecord
 import androidx.health.connect.client.records.MindfulnessSessionRecord
 import androidx.health.connect.client.records.NutritionRecord
+import androidx.health.connect.client.records.OvulationTestRecord
 import androidx.health.connect.client.records.OxygenSaturationRecord
 import androidx.health.connect.client.records.PowerRecord
 import androidx.health.connect.client.records.Record
@@ -63,6 +64,7 @@ internal fun HealthDataTypeDto.toHealthConnectRecordClass(): KClass<out Record> 
     HealthDataTypeDto.RESPIRATORY_RATE -> RespiratoryRateRecord::class
     HealthDataTypeDto.VO2MAX -> Vo2MaxRecord::class
     HealthDataTypeDto.NUTRITION -> NutritionRecord::class
+    HealthDataTypeDto.OVULATION_TEST -> OvulationTestRecord::class
     HealthDataTypeDto.SPEED_SERIES -> SpeedRecord::class
     HealthDataTypeDto.POWER_SERIES -> PowerRecord::class
     HealthDataTypeDto.CYCLING_PEDALING_CADENCE_SERIES_RECORD -> CyclingPedalingCadenceRecord::class

--- a/packages/health_connector_hc_android/android/src/main/kotlin/com/phamtunglam/health_connector_hc_android/mappers/health_record_mappers/HealthRecordIdMappers.kt
+++ b/packages/health_connector_hc_android/android/src/main/kotlin/com/phamtunglam/health_connector_hc_android/mappers/health_record_mappers/HealthRecordIdMappers.kt
@@ -17,6 +17,7 @@ import com.phamtunglam.health_connector_hc_android.pigeon.HydrationRecordDto
 import com.phamtunglam.health_connector_hc_android.pigeon.LeanBodyMassRecordDto
 import com.phamtunglam.health_connector_hc_android.pigeon.MindfulnessSessionRecordDto
 import com.phamtunglam.health_connector_hc_android.pigeon.NutritionRecordDto
+import com.phamtunglam.health_connector_hc_android.pigeon.OvulationTestRecordDto
 import com.phamtunglam.health_connector_hc_android.pigeon.OxygenSaturationRecordDto
 import com.phamtunglam.health_connector_hc_android.pigeon.PowerSeriesRecordDto
 import com.phamtunglam.health_connector_hc_android.pigeon.RespiratoryRateRecordDto
@@ -57,6 +58,7 @@ internal val HealthRecordDto.id: String?
         is HeartRateSeriesRecordDto -> id
         is RestingHeartRateRecordDto -> id
         is SexualActivityRecordDto -> id
+        is OvulationTestRecordDto -> id
         is OxygenSaturationRecordDto -> id
         is SleepSessionRecordDto -> id
         is SpeedSeriesRecordDto -> id

--- a/packages/health_connector_hc_android/android/src/main/kotlin/com/phamtunglam/health_connector_hc_android/mappers/health_record_mappers/HealthRecordMappers.kt
+++ b/packages/health_connector_hc_android/android/src/main/kotlin/com/phamtunglam/health_connector_hc_android/mappers/health_record_mappers/HealthRecordMappers.kt
@@ -17,6 +17,7 @@ import androidx.health.connect.client.records.HydrationRecord
 import androidx.health.connect.client.records.LeanBodyMassRecord
 import androidx.health.connect.client.records.MindfulnessSessionRecord
 import androidx.health.connect.client.records.NutritionRecord
+import androidx.health.connect.client.records.OvulationTestRecord
 import androidx.health.connect.client.records.OxygenSaturationRecord
 import androidx.health.connect.client.records.PowerRecord
 import androidx.health.connect.client.records.Record
@@ -47,6 +48,7 @@ import com.phamtunglam.health_connector_hc_android.pigeon.HydrationRecordDto
 import com.phamtunglam.health_connector_hc_android.pigeon.LeanBodyMassRecordDto
 import com.phamtunglam.health_connector_hc_android.pigeon.MindfulnessSessionRecordDto
 import com.phamtunglam.health_connector_hc_android.pigeon.NutritionRecordDto
+import com.phamtunglam.health_connector_hc_android.pigeon.OvulationTestRecordDto
 import com.phamtunglam.health_connector_hc_android.pigeon.OxygenSaturationRecordDto
 import com.phamtunglam.health_connector_hc_android.pigeon.PowerSeriesRecordDto
 import com.phamtunglam.health_connector_hc_android.pigeon.RespiratoryRateRecordDto
@@ -87,9 +89,11 @@ internal val HealthRecordDto.dataType: HealthDataTypeDto
         is MindfulnessSessionRecordDto -> HealthDataTypeDto.MINDFULNESS_SESSION
         is SpeedSeriesRecordDto -> HealthDataTypeDto.SPEED_SERIES
         is NutritionRecordDto -> HealthDataTypeDto.NUTRITION
+        is OvulationTestRecordDto -> HealthDataTypeDto.OVULATION_TEST
         is OxygenSaturationRecordDto -> HealthDataTypeDto.OXYGEN_SATURATION
         is PowerSeriesRecordDto -> HealthDataTypeDto.POWER_SERIES
-        is CyclingPedalingCadenceSeriesRecordDto -> HealthDataTypeDto.CYCLING_PEDALING_CADENCE_SERIES_RECORD
+        is CyclingPedalingCadenceSeriesRecordDto ->
+            HealthDataTypeDto.CYCLING_PEDALING_CADENCE_SERIES_RECORD
         is RespiratoryRateRecordDto -> HealthDataTypeDto.RESPIRATORY_RATE
         is Vo2MaxRecordDto -> HealthDataTypeDto.VO2MAX
         is BloodPressureRecordDto -> HealthDataTypeDto.BLOOD_PRESSURE
@@ -124,6 +128,7 @@ internal fun HealthRecordDto.toHealthConnect(): Record = when (this) {
     is MindfulnessSessionRecordDto -> toHealthConnect()
     is SpeedSeriesRecordDto -> toHealthConnect()
     is NutritionRecordDto -> toHealthConnect()
+    is OvulationTestRecordDto -> toHealthConnect()
     is OxygenSaturationRecordDto -> toHealthConnect()
     is PowerSeriesRecordDto -> toHealthConnect()
     is CyclingPedalingCadenceSeriesRecordDto -> toHealthConnect()
@@ -175,5 +180,6 @@ internal fun Record.toDto(): HealthRecordDto = when (this) {
     is BloodPressureRecord -> toDto()
     is BloodGlucoseRecord -> toDto()
     is ExerciseSessionRecord -> toDto()
+    is OvulationTestRecord -> toDto()
     else -> throw IllegalArgumentException("Unsupported record type: ${this::class.simpleName}")
 }

--- a/packages/health_connector_hc_android/android/src/main/kotlin/com/phamtunglam/health_connector_hc_android/mappers/health_record_mappers/OvulationTestRecordMappers.kt
+++ b/packages/health_connector_hc_android/android/src/main/kotlin/com/phamtunglam/health_connector_hc_android/mappers/health_record_mappers/OvulationTestRecordMappers.kt
@@ -1,0 +1,29 @@
+package com.phamtunglam.health_connector_hc_android.mappers.health_record_mappers
+
+import androidx.health.connect.client.records.OvulationTestRecord
+import com.phamtunglam.health_connector_hc_android.mappers.metadata_mappers.toDto
+import com.phamtunglam.health_connector_hc_android.mappers.metadata_mappers.toHealthConnect
+import com.phamtunglam.health_connector_hc_android.pigeon.OvulationTestRecordDto
+import java.time.Instant
+import java.time.ZoneOffset
+
+/**
+ * Converts a Health Connect [OvulationTestRecord] object to a [OvulationTestRecordDto].
+ */
+internal fun OvulationTestRecord.toDto(): OvulationTestRecordDto = OvulationTestRecordDto(
+    id = metadata.id,
+    time = time.toEpochMilli(),
+    zoneOffsetSeconds = zoneOffset?.totalSeconds?.toLong(),
+    metadata = metadata.toDto(),
+    result = result.toOvulationTestResultTypeDto(),
+)
+
+/**
+ * Converts a [OvulationTestRecordDto] to a Health Connect [OvulationTestRecord] object.
+ */
+internal fun OvulationTestRecordDto.toHealthConnect(): OvulationTestRecord = OvulationTestRecord(
+    time = Instant.ofEpochMilli(time),
+    zoneOffset = zoneOffsetSeconds?.let { ZoneOffset.ofTotalSeconds(it.toInt()) },
+    result = result.toHealthConnect(),
+    metadata = metadata.toHealthConnect(id),
+)

--- a/packages/health_connector_hc_android/android/src/main/kotlin/com/phamtunglam/health_connector_hc_android/mappers/health_record_mappers/OvulationTestResultTypeMappers.kt
+++ b/packages/health_connector_hc_android/android/src/main/kotlin/com/phamtunglam/health_connector_hc_android/mappers/health_record_mappers/OvulationTestResultTypeMappers.kt
@@ -1,0 +1,33 @@
+package com.phamtunglam.health_connector_hc_android.mappers.health_record_mappers
+
+import androidx.health.connect.client.records.OvulationTestRecord
+import com.phamtunglam.health_connector_hc_android.pigeon.OvulationTestResultTypeDto
+
+/**
+ * Converts a Health Connect ovulation test result value to [OvulationTestResultTypeDto].
+ */
+internal fun Int.toOvulationTestResultTypeDto(): OvulationTestResultTypeDto = when (this) {
+    OvulationTestRecord.RESULT_NEGATIVE ->
+        OvulationTestResultTypeDto.NEGATIVE
+    OvulationTestRecord.RESULT_INCONCLUSIVE ->
+        OvulationTestResultTypeDto.INCONCLUSIVE
+    OvulationTestRecord.RESULT_HIGH ->
+        OvulationTestResultTypeDto.HIGH
+    OvulationTestRecord.RESULT_POSITIVE ->
+        OvulationTestResultTypeDto.POSITIVE
+    else -> throw IllegalArgumentException("Unknown ovulation test result value: $this")
+}
+
+/**
+ * Converts a [OvulationTestResultTypeDto] to a Health Connect ovulation test result value.
+ */
+internal fun OvulationTestResultTypeDto.toHealthConnect(): Int = when (this) {
+    OvulationTestResultTypeDto.NEGATIVE ->
+        OvulationTestRecord.RESULT_NEGATIVE
+    OvulationTestResultTypeDto.INCONCLUSIVE ->
+        OvulationTestRecord.RESULT_INCONCLUSIVE
+    OvulationTestResultTypeDto.HIGH ->
+        OvulationTestRecord.RESULT_HIGH
+    OvulationTestResultTypeDto.POSITIVE ->
+        OvulationTestRecord.RESULT_POSITIVE
+}

--- a/packages/health_connector_hc_android/android/src/main/kotlin/com/phamtunglam/health_connector_hc_android/mappers/permission_mappers/HealthDataPermissionMapper.kt
+++ b/packages/health_connector_hc_android/android/src/main/kotlin/com/phamtunglam/health_connector_hc_android/mappers/permission_mappers/HealthDataPermissionMapper.kt
@@ -18,6 +18,7 @@ import androidx.health.connect.client.records.HydrationRecord
 import androidx.health.connect.client.records.LeanBodyMassRecord
 import androidx.health.connect.client.records.MindfulnessSessionRecord
 import androidx.health.connect.client.records.NutritionRecord
+import androidx.health.connect.client.records.OvulationTestRecord
 import androidx.health.connect.client.records.OxygenSaturationRecord
 import androidx.health.connect.client.records.PowerRecord
 import androidx.health.connect.client.records.RespiratoryRateRecord
@@ -205,6 +206,18 @@ internal fun getHealthConnectPermission(
 
             PermissionAccessTypeDto.WRITE -> HealthPermission.getWritePermission(
                 SexualActivityRecord::class,
+            )
+        }
+    }
+
+    HealthDataTypeDto.OVULATION_TEST -> {
+        when (accessType) {
+            PermissionAccessTypeDto.READ -> HealthPermission.getReadPermission(
+                OvulationTestRecord::class,
+            )
+
+            PermissionAccessTypeDto.WRITE -> HealthPermission.getWritePermission(
+                OvulationTestRecord::class,
             )
         }
     }
@@ -431,6 +444,7 @@ internal fun String.toHealthDataPermissionDto(): HealthDataPermissionRequestDto 
         "SLEEP_SESSION" -> HealthDataTypeDto.SLEEP_SESSION
         "BLOOD_PRESSURE" -> HealthDataTypeDto.BLOOD_PRESSURE
         "BLOOD_GLUCOSE" -> HealthDataTypeDto.BLOOD_GLUCOSE
+        "OVULATION_TEST" -> HealthDataTypeDto.OVULATION_TEST
         "OXYGEN_SATURATION" -> HealthDataTypeDto.OXYGEN_SATURATION
         "RESPIRATORY_RATE" -> HealthDataTypeDto.RESPIRATORY_RATE
         "VO2MAX" -> HealthDataTypeDto.VO2MAX

--- a/packages/health_connector_hc_android/android/src/main/kotlin/com/phamtunglam/health_connector_hc_android/pigeon/HealthConnectorHCAndroidApi.g.kt
+++ b/packages/health_connector_hc_android/android/src/main/kotlin/com/phamtunglam/health_connector_hc_android/pigeon/HealthConnectorHCAndroidApi.g.kt
@@ -684,6 +684,29 @@ enum class SexualActivityProtectionUsedTypeDto(val raw: Int) {
   }
 }
 
+/**
+ * Ovulation test result classification.
+ *
+ * Maps to Android Health Connect OvulationTestRecord result constants
+ * and iOS HealthKit HKCategoryValueOvulationTestResult enum.
+ */
+enum class OvulationTestResultTypeDto(val raw: Int) {
+  /** Test result is negative (no hormonal surge). */
+  NEGATIVE(0),
+  /** Test result is inconclusive. */
+  INCONCLUSIVE(1),
+  /** Test result shows high estrogen levels. */
+  HIGH(2),
+  /** Test result is positive (LH surge detected). */
+  POSITIVE(3);
+
+  companion object {
+    fun ofRaw(raw: Int): OvulationTestResultTypeDto? {
+      return values().firstOrNull { it.raw == raw }
+    }
+  }
+}
+
 /** Represents a health data type. */
 enum class HealthDataTypeDto(val raw: Int) {
   /** Active calories burned data. */
@@ -726,20 +749,22 @@ enum class HealthDataTypeDto(val raw: Int) {
   RESTING_HEART_RATE(18),
   /** Composite blood pressure data (systolic + diastolic). */
   BLOOD_PRESSURE(19),
+  /** Ovulation test data. */
+  OVULATION_TEST(20),
   /** Oxygen saturation data. */
-  OXYGEN_SATURATION(20),
+  OXYGEN_SATURATION(21),
   /** Power data. */
-  POWER_SERIES(21),
+  POWER_SERIES(22),
   /** Respiratory rate data. */
-  RESPIRATORY_RATE(22),
+  RESPIRATORY_RATE(23),
   /** VO2 max (maximal oxygen uptake) data. */
-  VO2MAX(23),
+  VO2MAX(24),
   /** Blood glucose data. */
-  BLOOD_GLUCOSE(24),
+  BLOOD_GLUCOSE(25),
   /** Speed data. */
-  SPEED_SERIES(25),
+  SPEED_SERIES(26),
   /** Mindfulness session data. */
-  MINDFULNESS_SESSION(26);
+  MINDFULNESS_SESSION(27);
 
   companion object {
     fun ofRaw(raw: Int): HealthDataTypeDto? {
@@ -1500,6 +1525,55 @@ data class OxygenSaturationRecordDto (
   }
   override fun equals(other: Any?): Boolean {
     if (other !is OxygenSaturationRecordDto) {
+      return false
+    }
+    if (this === other) {
+      return true
+    }
+    return HealthConnectorHCAndroidApiPigeonUtils.deepEquals(toList(), other.toList())  }
+
+  override fun hashCode(): Int = toList().hashCode()
+}
+
+/**
+ * Represents an ovulation test record for platform transfer.
+ *
+ * Generated class from Pigeon that represents data sent in messages.
+ */
+data class OvulationTestRecordDto (
+  /** Platform-assigned unique identifier. */
+  val id: String? = null,
+  /** Metadata about this record. */
+  val metadata: MetadataDto,
+  /** Measurement time in milliseconds since epoch (UTC). */
+  val time: Long,
+  /** Timezone offset in seconds for measurement time (optional). */
+  val zoneOffsetSeconds: Long? = null,
+  /** The ovulation test result. */
+  val result: OvulationTestResultTypeDto
+) : HealthRecordDto()
+ {
+  companion object {
+    fun fromList(pigeonVar_list: List<Any?>): OvulationTestRecordDto {
+      val id = pigeonVar_list[0] as String?
+      val metadata = pigeonVar_list[1] as MetadataDto
+      val time = pigeonVar_list[2] as Long
+      val zoneOffsetSeconds = pigeonVar_list[3] as Long?
+      val result = pigeonVar_list[4] as OvulationTestResultTypeDto
+      return OvulationTestRecordDto(id, metadata, time, zoneOffsetSeconds, result)
+    }
+  }
+  fun toList(): List<Any?> {
+    return listOf(
+      id,
+      metadata,
+      time,
+      zoneOffsetSeconds,
+      result,
+    )
+  }
+  override fun equals(other: Any?): Boolean {
+    if (other !is OvulationTestRecordDto) {
       return false
     }
     if (this === other) {
@@ -3899,325 +3973,335 @@ private open class HealthConnectorHCAndroidApiPigeonCodec : StandardMessageCodec
       }
       157.toByte() -> {
         return (readValue(buffer) as Long?)?.let {
-          HealthDataTypeDto.ofRaw(it.toInt())
+          OvulationTestResultTypeDto.ofRaw(it.toInt())
         }
       }
       158.toByte() -> {
         return (readValue(buffer) as Long?)?.let {
-          SleepStageTypeDto.ofRaw(it.toInt())
+          HealthDataTypeDto.ofRaw(it.toInt())
         }
       }
       159.toByte() -> {
         return (readValue(buffer) as Long?)?.let {
-          HealthPlatformFeatureDto.ofRaw(it.toInt())
+          SleepStageTypeDto.ofRaw(it.toInt())
         }
       }
       160.toByte() -> {
         return (readValue(buffer) as Long?)?.let {
-          HealthPlatformFeatureStatusDto.ofRaw(it.toInt())
+          HealthPlatformFeatureDto.ofRaw(it.toInt())
         }
       }
       161.toByte() -> {
         return (readValue(buffer) as Long?)?.let {
-          AggregationMetricDto.ofRaw(it.toInt())
+          HealthPlatformFeatureStatusDto.ofRaw(it.toInt())
         }
       }
       162.toByte() -> {
         return (readValue(buffer) as Long?)?.let {
-          BloodPressureHealthDataTypeDto.ofRaw(it.toInt())
+          AggregationMetricDto.ofRaw(it.toInt())
         }
       }
       163.toByte() -> {
-        return (readValue(buffer) as? List<Any?>)?.let {
-          BloodGlucoseDto.fromList(it)
+        return (readValue(buffer) as Long?)?.let {
+          BloodPressureHealthDataTypeDto.ofRaw(it.toInt())
         }
       }
       164.toByte() -> {
         return (readValue(buffer) as? List<Any?>)?.let {
-          EnergyDto.fromList(it)
+          BloodGlucoseDto.fromList(it)
         }
       }
       165.toByte() -> {
         return (readValue(buffer) as? List<Any?>)?.let {
-          TimeDurationDto.fromList(it)
+          EnergyDto.fromList(it)
         }
       }
       166.toByte() -> {
         return (readValue(buffer) as? List<Any?>)?.let {
-          LengthDto.fromList(it)
+          TimeDurationDto.fromList(it)
         }
       }
       167.toByte() -> {
         return (readValue(buffer) as? List<Any?>)?.let {
-          MassDto.fromList(it)
+          LengthDto.fromList(it)
         }
       }
       168.toByte() -> {
         return (readValue(buffer) as? List<Any?>)?.let {
-          NumberDto.fromList(it)
+          MassDto.fromList(it)
         }
       }
       169.toByte() -> {
         return (readValue(buffer) as? List<Any?>)?.let {
-          PercentageDto.fromList(it)
+          NumberDto.fromList(it)
         }
       }
       170.toByte() -> {
         return (readValue(buffer) as? List<Any?>)?.let {
-          PowerDto.fromList(it)
+          PercentageDto.fromList(it)
         }
       }
       171.toByte() -> {
         return (readValue(buffer) as? List<Any?>)?.let {
-          PressureDto.fromList(it)
+          PowerDto.fromList(it)
         }
       }
       172.toByte() -> {
         return (readValue(buffer) as? List<Any?>)?.let {
-          TemperatureDto.fromList(it)
+          PressureDto.fromList(it)
         }
       }
       173.toByte() -> {
         return (readValue(buffer) as? List<Any?>)?.let {
-          VelocityDto.fromList(it)
+          TemperatureDto.fromList(it)
         }
       }
       174.toByte() -> {
         return (readValue(buffer) as? List<Any?>)?.let {
-          VolumeDto.fromList(it)
+          VelocityDto.fromList(it)
         }
       }
       175.toByte() -> {
         return (readValue(buffer) as? List<Any?>)?.let {
-          MetadataDto.fromList(it)
+          VolumeDto.fromList(it)
         }
       }
       176.toByte() -> {
         return (readValue(buffer) as? List<Any?>)?.let {
-          BloodGlucoseRecordDto.fromList(it)
+          MetadataDto.fromList(it)
         }
       }
       177.toByte() -> {
         return (readValue(buffer) as? List<Any?>)?.let {
-          RestingHeartRateRecordDto.fromList(it)
+          BloodGlucoseRecordDto.fromList(it)
         }
       }
       178.toByte() -> {
         return (readValue(buffer) as? List<Any?>)?.let {
-          OxygenSaturationRecordDto.fromList(it)
+          RestingHeartRateRecordDto.fromList(it)
         }
       }
       179.toByte() -> {
         return (readValue(buffer) as? List<Any?>)?.let {
-          RespiratoryRateRecordDto.fromList(it)
+          OxygenSaturationRecordDto.fromList(it)
         }
       }
       180.toByte() -> {
         return (readValue(buffer) as? List<Any?>)?.let {
-          Vo2MaxRecordDto.fromList(it)
+          OvulationTestRecordDto.fromList(it)
         }
       }
       181.toByte() -> {
         return (readValue(buffer) as? List<Any?>)?.let {
-          ActiveCaloriesBurnedRecordDto.fromList(it)
+          RespiratoryRateRecordDto.fromList(it)
         }
       }
       182.toByte() -> {
         return (readValue(buffer) as? List<Any?>)?.let {
-          DistanceRecordDto.fromList(it)
+          Vo2MaxRecordDto.fromList(it)
         }
       }
       183.toByte() -> {
         return (readValue(buffer) as? List<Any?>)?.let {
-          FloorsClimbedRecordDto.fromList(it)
+          ActiveCaloriesBurnedRecordDto.fromList(it)
         }
       }
       184.toByte() -> {
         return (readValue(buffer) as? List<Any?>)?.let {
-          WheelchairPushesRecordDto.fromList(it)
+          DistanceRecordDto.fromList(it)
         }
       }
       185.toByte() -> {
         return (readValue(buffer) as? List<Any?>)?.let {
-          StepsRecordDto.fromList(it)
+          FloorsClimbedRecordDto.fromList(it)
         }
       }
       186.toByte() -> {
         return (readValue(buffer) as? List<Any?>)?.let {
-          WeightRecordDto.fromList(it)
+          WheelchairPushesRecordDto.fromList(it)
         }
       }
       187.toByte() -> {
         return (readValue(buffer) as? List<Any?>)?.let {
-          BloodPressureRecordDto.fromList(it)
+          StepsRecordDto.fromList(it)
         }
       }
       188.toByte() -> {
         return (readValue(buffer) as? List<Any?>)?.let {
-          LeanBodyMassRecordDto.fromList(it)
+          WeightRecordDto.fromList(it)
         }
       }
       189.toByte() -> {
         return (readValue(buffer) as? List<Any?>)?.let {
-          HeightRecordDto.fromList(it)
+          BloodPressureRecordDto.fromList(it)
         }
       }
       190.toByte() -> {
         return (readValue(buffer) as? List<Any?>)?.let {
-          BodyFatPercentageRecordDto.fromList(it)
+          LeanBodyMassRecordDto.fromList(it)
         }
       }
       191.toByte() -> {
         return (readValue(buffer) as? List<Any?>)?.let {
-          BodyTemperatureRecordDto.fromList(it)
+          HeightRecordDto.fromList(it)
         }
       }
       192.toByte() -> {
         return (readValue(buffer) as? List<Any?>)?.let {
-          CervicalMucusRecordDto.fromList(it)
+          BodyFatPercentageRecordDto.fromList(it)
         }
       }
       193.toByte() -> {
         return (readValue(buffer) as? List<Any?>)?.let {
-          HydrationRecordDto.fromList(it)
+          BodyTemperatureRecordDto.fromList(it)
         }
       }
       194.toByte() -> {
         return (readValue(buffer) as? List<Any?>)?.let {
-          HeartRateMeasurementDto.fromList(it)
+          CervicalMucusRecordDto.fromList(it)
         }
       }
       195.toByte() -> {
         return (readValue(buffer) as? List<Any?>)?.let {
-          HeartRateSeriesRecordDto.fromList(it)
+          HydrationRecordDto.fromList(it)
         }
       }
       196.toByte() -> {
         return (readValue(buffer) as? List<Any?>)?.let {
-          CyclingPedalingCadenceMeasurementDto.fromList(it)
+          HeartRateMeasurementDto.fromList(it)
         }
       }
       197.toByte() -> {
         return (readValue(buffer) as? List<Any?>)?.let {
-          CyclingPedalingCadenceSeriesRecordDto.fromList(it)
+          HeartRateSeriesRecordDto.fromList(it)
         }
       }
       198.toByte() -> {
         return (readValue(buffer) as? List<Any?>)?.let {
-          SpeedMeasurementDto.fromList(it)
+          CyclingPedalingCadenceMeasurementDto.fromList(it)
         }
       }
       199.toByte() -> {
         return (readValue(buffer) as? List<Any?>)?.let {
-          SpeedSeriesRecordDto.fromList(it)
+          CyclingPedalingCadenceSeriesRecordDto.fromList(it)
         }
       }
       200.toByte() -> {
         return (readValue(buffer) as? List<Any?>)?.let {
-          PowerMeasurementDto.fromList(it)
+          SpeedMeasurementDto.fromList(it)
         }
       }
       201.toByte() -> {
         return (readValue(buffer) as? List<Any?>)?.let {
-          PowerSeriesRecordDto.fromList(it)
+          SpeedSeriesRecordDto.fromList(it)
         }
       }
       202.toByte() -> {
         return (readValue(buffer) as? List<Any?>)?.let {
-          SleepStageDto.fromList(it)
+          PowerMeasurementDto.fromList(it)
         }
       }
       203.toByte() -> {
         return (readValue(buffer) as? List<Any?>)?.let {
-          SleepSessionRecordDto.fromList(it)
+          PowerSeriesRecordDto.fromList(it)
         }
       }
       204.toByte() -> {
         return (readValue(buffer) as? List<Any?>)?.let {
-          SexualActivityRecordDto.fromList(it)
+          SleepStageDto.fromList(it)
         }
       }
       205.toByte() -> {
         return (readValue(buffer) as? List<Any?>)?.let {
-          ExerciseSessionRecordDto.fromList(it)
+          SleepSessionRecordDto.fromList(it)
         }
       }
       206.toByte() -> {
         return (readValue(buffer) as? List<Any?>)?.let {
-          MindfulnessSessionRecordDto.fromList(it)
+          SexualActivityRecordDto.fromList(it)
         }
       }
       207.toByte() -> {
         return (readValue(buffer) as? List<Any?>)?.let {
-          NutritionRecordDto.fromList(it)
+          ExerciseSessionRecordDto.fromList(it)
         }
       }
       208.toByte() -> {
         return (readValue(buffer) as? List<Any?>)?.let {
-          HealthPlatformFeaturePermissionRequestResultDto.fromList(it)
+          MindfulnessSessionRecordDto.fromList(it)
         }
       }
       209.toByte() -> {
         return (readValue(buffer) as? List<Any?>)?.let {
-          HealthDataPermissionRequestDto.fromList(it)
+          NutritionRecordDto.fromList(it)
         }
       }
       210.toByte() -> {
         return (readValue(buffer) as? List<Any?>)?.let {
-          HealthDataPermissionRequestResultDto.fromList(it)
+          HealthPlatformFeaturePermissionRequestResultDto.fromList(it)
         }
       }
       211.toByte() -> {
         return (readValue(buffer) as? List<Any?>)?.let {
-          HealthPlatformFeaturePermissionRequest.fromList(it)
+          HealthDataPermissionRequestDto.fromList(it)
         }
       }
       212.toByte() -> {
         return (readValue(buffer) as? List<Any?>)?.let {
-          PermissionRequestsDto.fromList(it)
+          HealthDataPermissionRequestResultDto.fromList(it)
         }
       }
       213.toByte() -> {
         return (readValue(buffer) as? List<Any?>)?.let {
-          PermissionRequestsResponseDto.fromList(it)
+          HealthPlatformFeaturePermissionRequest.fromList(it)
         }
       }
       214.toByte() -> {
         return (readValue(buffer) as? List<Any?>)?.let {
-          CommonAggregateRequestDto.fromList(it)
+          PermissionRequestsDto.fromList(it)
         }
       }
       215.toByte() -> {
         return (readValue(buffer) as? List<Any?>)?.let {
-          BloodPressureAggregateRequestDto.fromList(it)
+          PermissionRequestsResponseDto.fromList(it)
         }
       }
       216.toByte() -> {
         return (readValue(buffer) as? List<Any?>)?.let {
-          DeleteRecordsByIdsRequestDto.fromList(it)
+          CommonAggregateRequestDto.fromList(it)
         }
       }
       217.toByte() -> {
         return (readValue(buffer) as? List<Any?>)?.let {
-          DeleteRecordsByTimeRangeRequestDto.fromList(it)
+          BloodPressureAggregateRequestDto.fromList(it)
         }
       }
       218.toByte() -> {
         return (readValue(buffer) as? List<Any?>)?.let {
-          ReadRecordRequestDto.fromList(it)
+          DeleteRecordsByIdsRequestDto.fromList(it)
         }
       }
       219.toByte() -> {
         return (readValue(buffer) as? List<Any?>)?.let {
-          ReadRecordsRequestDto.fromList(it)
+          DeleteRecordsByTimeRangeRequestDto.fromList(it)
         }
       }
       220.toByte() -> {
         return (readValue(buffer) as? List<Any?>)?.let {
-          ReadRecordsResponseDto.fromList(it)
+          ReadRecordRequestDto.fromList(it)
         }
       }
       221.toByte() -> {
+        return (readValue(buffer) as? List<Any?>)?.let {
+          ReadRecordsRequestDto.fromList(it)
+        }
+      }
+      222.toByte() -> {
+        return (readValue(buffer) as? List<Any?>)?.let {
+          ReadRecordsResponseDto.fromList(it)
+        }
+      }
+      223.toByte() -> {
         return (readValue(buffer) as? List<Any?>)?.let {
           HealthConnectorConfigDto.fromList(it)
         }
@@ -4339,264 +4423,272 @@ private open class HealthConnectorHCAndroidApiPigeonCodec : StandardMessageCodec
         stream.write(156)
         writeValue(stream, value.raw.toLong())
       }
-      is HealthDataTypeDto -> {
+      is OvulationTestResultTypeDto -> {
         stream.write(157)
         writeValue(stream, value.raw.toLong())
       }
-      is SleepStageTypeDto -> {
+      is HealthDataTypeDto -> {
         stream.write(158)
         writeValue(stream, value.raw.toLong())
       }
-      is HealthPlatformFeatureDto -> {
+      is SleepStageTypeDto -> {
         stream.write(159)
         writeValue(stream, value.raw.toLong())
       }
-      is HealthPlatformFeatureStatusDto -> {
+      is HealthPlatformFeatureDto -> {
         stream.write(160)
         writeValue(stream, value.raw.toLong())
       }
-      is AggregationMetricDto -> {
+      is HealthPlatformFeatureStatusDto -> {
         stream.write(161)
         writeValue(stream, value.raw.toLong())
       }
-      is BloodPressureHealthDataTypeDto -> {
+      is AggregationMetricDto -> {
         stream.write(162)
         writeValue(stream, value.raw.toLong())
       }
-      is BloodGlucoseDto -> {
+      is BloodPressureHealthDataTypeDto -> {
         stream.write(163)
-        writeValue(stream, value.toList())
+        writeValue(stream, value.raw.toLong())
       }
-      is EnergyDto -> {
+      is BloodGlucoseDto -> {
         stream.write(164)
         writeValue(stream, value.toList())
       }
-      is TimeDurationDto -> {
+      is EnergyDto -> {
         stream.write(165)
         writeValue(stream, value.toList())
       }
-      is LengthDto -> {
+      is TimeDurationDto -> {
         stream.write(166)
         writeValue(stream, value.toList())
       }
-      is MassDto -> {
+      is LengthDto -> {
         stream.write(167)
         writeValue(stream, value.toList())
       }
-      is NumberDto -> {
+      is MassDto -> {
         stream.write(168)
         writeValue(stream, value.toList())
       }
-      is PercentageDto -> {
+      is NumberDto -> {
         stream.write(169)
         writeValue(stream, value.toList())
       }
-      is PowerDto -> {
+      is PercentageDto -> {
         stream.write(170)
         writeValue(stream, value.toList())
       }
-      is PressureDto -> {
+      is PowerDto -> {
         stream.write(171)
         writeValue(stream, value.toList())
       }
-      is TemperatureDto -> {
+      is PressureDto -> {
         stream.write(172)
         writeValue(stream, value.toList())
       }
-      is VelocityDto -> {
+      is TemperatureDto -> {
         stream.write(173)
         writeValue(stream, value.toList())
       }
-      is VolumeDto -> {
+      is VelocityDto -> {
         stream.write(174)
         writeValue(stream, value.toList())
       }
-      is MetadataDto -> {
+      is VolumeDto -> {
         stream.write(175)
         writeValue(stream, value.toList())
       }
-      is BloodGlucoseRecordDto -> {
+      is MetadataDto -> {
         stream.write(176)
         writeValue(stream, value.toList())
       }
-      is RestingHeartRateRecordDto -> {
+      is BloodGlucoseRecordDto -> {
         stream.write(177)
         writeValue(stream, value.toList())
       }
-      is OxygenSaturationRecordDto -> {
+      is RestingHeartRateRecordDto -> {
         stream.write(178)
         writeValue(stream, value.toList())
       }
-      is RespiratoryRateRecordDto -> {
+      is OxygenSaturationRecordDto -> {
         stream.write(179)
         writeValue(stream, value.toList())
       }
-      is Vo2MaxRecordDto -> {
+      is OvulationTestRecordDto -> {
         stream.write(180)
         writeValue(stream, value.toList())
       }
-      is ActiveCaloriesBurnedRecordDto -> {
+      is RespiratoryRateRecordDto -> {
         stream.write(181)
         writeValue(stream, value.toList())
       }
-      is DistanceRecordDto -> {
+      is Vo2MaxRecordDto -> {
         stream.write(182)
         writeValue(stream, value.toList())
       }
-      is FloorsClimbedRecordDto -> {
+      is ActiveCaloriesBurnedRecordDto -> {
         stream.write(183)
         writeValue(stream, value.toList())
       }
-      is WheelchairPushesRecordDto -> {
+      is DistanceRecordDto -> {
         stream.write(184)
         writeValue(stream, value.toList())
       }
-      is StepsRecordDto -> {
+      is FloorsClimbedRecordDto -> {
         stream.write(185)
         writeValue(stream, value.toList())
       }
-      is WeightRecordDto -> {
+      is WheelchairPushesRecordDto -> {
         stream.write(186)
         writeValue(stream, value.toList())
       }
-      is BloodPressureRecordDto -> {
+      is StepsRecordDto -> {
         stream.write(187)
         writeValue(stream, value.toList())
       }
-      is LeanBodyMassRecordDto -> {
+      is WeightRecordDto -> {
         stream.write(188)
         writeValue(stream, value.toList())
       }
-      is HeightRecordDto -> {
+      is BloodPressureRecordDto -> {
         stream.write(189)
         writeValue(stream, value.toList())
       }
-      is BodyFatPercentageRecordDto -> {
+      is LeanBodyMassRecordDto -> {
         stream.write(190)
         writeValue(stream, value.toList())
       }
-      is BodyTemperatureRecordDto -> {
+      is HeightRecordDto -> {
         stream.write(191)
         writeValue(stream, value.toList())
       }
-      is CervicalMucusRecordDto -> {
+      is BodyFatPercentageRecordDto -> {
         stream.write(192)
         writeValue(stream, value.toList())
       }
-      is HydrationRecordDto -> {
+      is BodyTemperatureRecordDto -> {
         stream.write(193)
         writeValue(stream, value.toList())
       }
-      is HeartRateMeasurementDto -> {
+      is CervicalMucusRecordDto -> {
         stream.write(194)
         writeValue(stream, value.toList())
       }
-      is HeartRateSeriesRecordDto -> {
+      is HydrationRecordDto -> {
         stream.write(195)
         writeValue(stream, value.toList())
       }
-      is CyclingPedalingCadenceMeasurementDto -> {
+      is HeartRateMeasurementDto -> {
         stream.write(196)
         writeValue(stream, value.toList())
       }
-      is CyclingPedalingCadenceSeriesRecordDto -> {
+      is HeartRateSeriesRecordDto -> {
         stream.write(197)
         writeValue(stream, value.toList())
       }
-      is SpeedMeasurementDto -> {
+      is CyclingPedalingCadenceMeasurementDto -> {
         stream.write(198)
         writeValue(stream, value.toList())
       }
-      is SpeedSeriesRecordDto -> {
+      is CyclingPedalingCadenceSeriesRecordDto -> {
         stream.write(199)
         writeValue(stream, value.toList())
       }
-      is PowerMeasurementDto -> {
+      is SpeedMeasurementDto -> {
         stream.write(200)
         writeValue(stream, value.toList())
       }
-      is PowerSeriesRecordDto -> {
+      is SpeedSeriesRecordDto -> {
         stream.write(201)
         writeValue(stream, value.toList())
       }
-      is SleepStageDto -> {
+      is PowerMeasurementDto -> {
         stream.write(202)
         writeValue(stream, value.toList())
       }
-      is SleepSessionRecordDto -> {
+      is PowerSeriesRecordDto -> {
         stream.write(203)
         writeValue(stream, value.toList())
       }
-      is SexualActivityRecordDto -> {
+      is SleepStageDto -> {
         stream.write(204)
         writeValue(stream, value.toList())
       }
-      is ExerciseSessionRecordDto -> {
+      is SleepSessionRecordDto -> {
         stream.write(205)
         writeValue(stream, value.toList())
       }
-      is MindfulnessSessionRecordDto -> {
+      is SexualActivityRecordDto -> {
         stream.write(206)
         writeValue(stream, value.toList())
       }
-      is NutritionRecordDto -> {
+      is ExerciseSessionRecordDto -> {
         stream.write(207)
         writeValue(stream, value.toList())
       }
-      is HealthPlatformFeaturePermissionRequestResultDto -> {
+      is MindfulnessSessionRecordDto -> {
         stream.write(208)
         writeValue(stream, value.toList())
       }
-      is HealthDataPermissionRequestDto -> {
+      is NutritionRecordDto -> {
         stream.write(209)
         writeValue(stream, value.toList())
       }
-      is HealthDataPermissionRequestResultDto -> {
+      is HealthPlatformFeaturePermissionRequestResultDto -> {
         stream.write(210)
         writeValue(stream, value.toList())
       }
-      is HealthPlatformFeaturePermissionRequest -> {
+      is HealthDataPermissionRequestDto -> {
         stream.write(211)
         writeValue(stream, value.toList())
       }
-      is PermissionRequestsDto -> {
+      is HealthDataPermissionRequestResultDto -> {
         stream.write(212)
         writeValue(stream, value.toList())
       }
-      is PermissionRequestsResponseDto -> {
+      is HealthPlatformFeaturePermissionRequest -> {
         stream.write(213)
         writeValue(stream, value.toList())
       }
-      is CommonAggregateRequestDto -> {
+      is PermissionRequestsDto -> {
         stream.write(214)
         writeValue(stream, value.toList())
       }
-      is BloodPressureAggregateRequestDto -> {
+      is PermissionRequestsResponseDto -> {
         stream.write(215)
         writeValue(stream, value.toList())
       }
-      is DeleteRecordsByIdsRequestDto -> {
+      is CommonAggregateRequestDto -> {
         stream.write(216)
         writeValue(stream, value.toList())
       }
-      is DeleteRecordsByTimeRangeRequestDto -> {
+      is BloodPressureAggregateRequestDto -> {
         stream.write(217)
         writeValue(stream, value.toList())
       }
-      is ReadRecordRequestDto -> {
+      is DeleteRecordsByIdsRequestDto -> {
         stream.write(218)
         writeValue(stream, value.toList())
       }
-      is ReadRecordsRequestDto -> {
+      is DeleteRecordsByTimeRangeRequestDto -> {
         stream.write(219)
         writeValue(stream, value.toList())
       }
-      is ReadRecordsResponseDto -> {
+      is ReadRecordRequestDto -> {
         stream.write(220)
         writeValue(stream, value.toList())
       }
-      is HealthConnectorConfigDto -> {
+      is ReadRecordsRequestDto -> {
         stream.write(221)
+        writeValue(stream, value.toList())
+      }
+      is ReadRecordsResponseDto -> {
+        stream.write(222)
+        writeValue(stream, value.toList())
+      }
+      is HealthConnectorConfigDto -> {
+        stream.write(223)
         writeValue(stream, value.toList())
       }
       else -> super.writeValue(stream, value)

--- a/packages/health_connector_hc_android/lib/src/mappers/health_data_type_mappers.dart
+++ b/packages/health_connector_hc_android/lib/src/mappers/health_data_type_mappers.dart
@@ -35,6 +35,7 @@ import 'package:health_connector_core/health_connector_core_internal.dart'
         MonounsaturatedFatNutrientDataType,
         NiacinNutrientDataType,
         NutritionHealthDataType,
+        OvulationTestDataType,
         OxygenSaturationHealthDataType,
         PaddleSportsDistanceDataType,
         PantothenicAcidNutrientDataType,
@@ -135,6 +136,8 @@ extension HealthDataTypeDtoToDomain on HealthDataTypeDto {
         return HealthDataType.restingHeartRate;
       case HealthDataTypeDto.bloodPressure:
         return HealthDataType.bloodPressure;
+      case HealthDataTypeDto.ovulationTest:
+        return HealthDataType.ovulationTest;
       case HealthDataTypeDto.oxygenSaturation:
         return HealthDataType.oxygenSaturation;
       case HealthDataTypeDto.respiratoryRate:
@@ -233,6 +236,8 @@ extension HealthDataTypeToDto on HealthDataType<HealthRecord, MeasurementUnit> {
         );
       case BloodPressureHealthDataType _:
         return HealthDataTypeDto.bloodPressure;
+      case OvulationTestDataType _:
+        return HealthDataTypeDto.ovulationTest;
       case OxygenSaturationHealthDataType _:
         return HealthDataTypeDto.oxygenSaturation;
       case RespiratoryRateHealthDataType _:

--- a/packages/health_connector_hc_android/lib/src/mappers/health_record_mappers/health_record_mapper.dart
+++ b/packages/health_connector_hc_android/lib/src/mappers/health_record_mappers/health_record_mapper.dart
@@ -28,6 +28,7 @@ import 'package:health_connector_core/health_connector_core_internal.dart'
         WeightRecord,
         WheelchairPushesRecord,
         PhosphorusNutrientRecord,
+        OvulationTestRecord,
         OxygenSaturationRecord,
         PowerSeriesRecord,
         EnergyNutrientRecord,
@@ -86,6 +87,7 @@ import 'package:health_connector_hc_android/src/mappers/health_record_mappers/hy
 import 'package:health_connector_hc_android/src/mappers/health_record_mappers/lean_body_mass_record_mappers.dart';
 import 'package:health_connector_hc_android/src/mappers/health_record_mappers/mindfulness_session_record_mappers.dart';
 import 'package:health_connector_hc_android/src/mappers/health_record_mappers/nutrition_record_mappers.dart';
+import 'package:health_connector_hc_android/src/mappers/health_record_mappers/ovulation_test_record_mappers.dart';
 import 'package:health_connector_hc_android/src/mappers/health_record_mappers/oxygen_saturation_record_mappers.dart';
 import 'package:health_connector_hc_android/src/mappers/health_record_mappers/power_record_mappers.dart';
 import 'package:health_connector_hc_android/src/mappers/health_record_mappers/respiratory_rate_record_mappers.dart';
@@ -113,6 +115,7 @@ import 'package:health_connector_hc_android/src/pigeon/health_connector_hc_andro
         HydrationRecordDto,
         LeanBodyMassRecordDto,
         NutritionRecordDto,
+        OvulationTestRecordDto,
         OxygenSaturationRecordDto,
         PowerSeriesRecordDto,
         RestingHeartRateRecordDto,
@@ -220,6 +223,8 @@ extension HealthRecordToDto on HealthRecord {
         return NutritionRecordToDto(record).toDto();
       case final RestingHeartRateRecord record:
         return RestingHeartRateRecordToDto(record).toDto();
+      case final OvulationTestRecord record:
+        return OvulationTestRecordToDto(record).toDto();
       case final OxygenSaturationRecord record:
         return OxygenSaturationRecordToDto(record).toDto();
       case final BloodPressureRecord record:
@@ -490,6 +495,8 @@ extension HealthRecordDtoToDomain on HealthRecordDto {
         return NutritionRecordDtoToDomain(dto).toDomain();
       case final RestingHeartRateRecordDto dto:
         return RestingHeartRateRecordDtoToDomain(dto).toDomain();
+      case final OvulationTestRecordDto dto:
+        return OvulationTestRecordDtoToDomain(dto).toDomain();
       case final OxygenSaturationRecordDto dto:
         return OxygenSaturationRecordDtoToDomain(dto).toDomain();
       case final BloodPressureRecordDto dto:

--- a/packages/health_connector_hc_android/lib/src/mappers/health_record_mappers/ovulation_test_record_mappers.dart
+++ b/packages/health_connector_hc_android/lib/src/mappers/health_record_mappers/ovulation_test_record_mappers.dart
@@ -1,0 +1,38 @@
+import 'package:health_connector_core/health_connector_core_internal.dart';
+import 'package:health_connector_hc_android/src/mappers/health_record_mappers/health_record_id_mappers.dart';
+import 'package:health_connector_hc_android/src/mappers/health_record_mappers/ovulation_test_result_type_mappers.dart';
+import 'package:health_connector_hc_android/src/mappers/metadata_mappers/metadata_mapper.dart';
+import 'package:health_connector_hc_android/src/pigeon/health_connector_hc_android_api.g.dart';
+import 'package:meta/meta.dart' show internal;
+
+/// Extension to convert [OvulationTestRecord] to [OvulationTestRecordDto].
+@sinceV2_2_0
+@internal
+extension OvulationTestRecordToDto on OvulationTestRecord {
+  /// Converts [OvulationTestRecord] to [OvulationTestRecordDto].
+  OvulationTestRecordDto toDto() {
+    return OvulationTestRecordDto(
+      id: id.value,
+      metadata: metadata.toDto(),
+      time: time.millisecondsSinceEpoch,
+      zoneOffsetSeconds: zoneOffsetSeconds,
+      result: result.toDto(),
+    );
+  }
+}
+
+/// Extension to convert [OvulationTestRecordDto] to [OvulationTestRecord].
+@sinceV2_2_0
+@internal
+extension OvulationTestRecordDtoToDomain on OvulationTestRecordDto {
+  /// Converts [OvulationTestRecordDto] to [OvulationTestRecord].
+  OvulationTestRecord toDomain() {
+    return OvulationTestRecord(
+      id: id?.toDomain() ?? HealthRecordId.none,
+      metadata: metadata.toDomain(),
+      time: DateTime.fromMillisecondsSinceEpoch(time, isUtc: true).toLocal(),
+      zoneOffsetSeconds: zoneOffsetSeconds,
+      result: result.toDomain(),
+    );
+  }
+}

--- a/packages/health_connector_hc_android/lib/src/mappers/health_record_mappers/ovulation_test_result_type_mappers.dart
+++ b/packages/health_connector_hc_android/lib/src/mappers/health_record_mappers/ovulation_test_result_type_mappers.dart
@@ -1,0 +1,40 @@
+import 'package:health_connector_core/health_connector_core_internal.dart';
+import 'package:health_connector_hc_android/src/pigeon/health_connector_hc_android_api.g.dart'
+    show OvulationTestResultTypeDto;
+import 'package:meta/meta.dart' show internal;
+
+/// Converts [OvulationTestResultType] to [OvulationTestResultTypeDto].
+@sinceV2_2_0
+@internal
+extension OvulationTestResultTypeToDto on OvulationTestResultType {
+  OvulationTestResultTypeDto toDto() {
+    switch (this) {
+      case OvulationTestResultType.negative:
+        return OvulationTestResultTypeDto.negative;
+      case OvulationTestResultType.inconclusive:
+        return OvulationTestResultTypeDto.inconclusive;
+      case OvulationTestResultType.high:
+        return OvulationTestResultTypeDto.high;
+      case OvulationTestResultType.positive:
+        return OvulationTestResultTypeDto.positive;
+    }
+  }
+}
+
+/// Converts [OvulationTestResultTypeDto] to [OvulationTestResultType].
+@sinceV2_2_0
+@internal
+extension OvulationTestResultTypeDtoToDomain on OvulationTestResultTypeDto {
+  OvulationTestResultType toDomain() {
+    switch (this) {
+      case OvulationTestResultTypeDto.negative:
+        return OvulationTestResultType.negative;
+      case OvulationTestResultTypeDto.inconclusive:
+        return OvulationTestResultType.inconclusive;
+      case OvulationTestResultTypeDto.high:
+        return OvulationTestResultType.high;
+      case OvulationTestResultTypeDto.positive:
+        return OvulationTestResultType.positive;
+    }
+  }
+}

--- a/packages/health_connector_hc_android/lib/src/mappers/request_and_response_mappers/aggregate_request_mapper.dart
+++ b/packages/health_connector_hc_android/lib/src/mappers/request_and_response_mappers/aggregate_request_mapper.dart
@@ -27,6 +27,7 @@ import 'package:health_connector_core/health_connector_core_internal.dart'
         HydrationHealthDataType,
         LeanBodyMassHealthDataType,
         NutritionHealthDataType,
+        OvulationTestDataType,
         OxygenSaturationHealthDataType,
         SleepSessionHealthDataType,
         SleepStageHealthDataType,
@@ -158,6 +159,7 @@ extension AggregateRequestDtoMapper<
           case HydrationHealthDataType _:
           case LeanBodyMassHealthDataType _:
           case NutritionHealthDataType _:
+          case OvulationTestDataType _:
           case SexualActivityDataType _:
           case SleepSessionHealthDataType _:
           case SleepStageHealthDataType _:

--- a/packages/health_connector_hc_android/lib/src/pigeon/health_connector_hc_android_api.g.dart
+++ b/packages/health_connector_hc_android/lib/src/pigeon/health_connector_hc_android_api.g.dart
@@ -534,6 +534,24 @@ enum SexualActivityProtectionUsedTypeDto {
   unknown,
 }
 
+/// Ovulation test result classification.
+///
+/// Maps to Android Health Connect OvulationTestRecord result constants
+/// and iOS HealthKit HKCategoryValueOvulationTestResult enum.
+enum OvulationTestResultTypeDto {
+  /// Test result is negative (no hormonal surge).
+  negative,
+
+  /// Test result is inconclusive.
+  inconclusive,
+
+  /// Test result shows high estrogen levels.
+  high,
+
+  /// Test result is positive (LH surge detected).
+  positive,
+}
+
 /// Represents a health data type.
 enum HealthDataTypeDto {
   /// Active calories burned data.
@@ -595,6 +613,9 @@ enum HealthDataTypeDto {
 
   /// Composite blood pressure data (systolic + diastolic).
   bloodPressure,
+
+  /// Ovulation test data.
+  ovulationTest,
 
   /// Oxygen saturation data.
   oxygenSaturation,
@@ -1556,6 +1577,73 @@ class OxygenSaturationRecordDto extends HealthRecordDto {
   bool operator ==(Object other) {
     if (other is! OxygenSaturationRecordDto ||
         other.runtimeType != runtimeType) {
+      return false;
+    }
+    if (identical(this, other)) {
+      return true;
+    }
+    return _deepEquals(encode(), other.encode());
+  }
+
+  @override
+  // ignore: avoid_equals_and_hash_code_on_mutable_classes
+  int get hashCode => Object.hashAll(_toList());
+}
+
+/// Represents an ovulation test record for platform transfer.
+class OvulationTestRecordDto extends HealthRecordDto {
+  OvulationTestRecordDto({
+    this.id,
+    required this.metadata,
+    required this.time,
+    this.zoneOffsetSeconds,
+    required this.result,
+  });
+
+  /// Platform-assigned unique identifier.
+  String? id;
+
+  /// Metadata about this record.
+  MetadataDto metadata;
+
+  /// Measurement time in milliseconds since epoch (UTC).
+  int time;
+
+  /// Timezone offset in seconds for measurement time (optional).
+  int? zoneOffsetSeconds;
+
+  /// The ovulation test result.
+  OvulationTestResultTypeDto result;
+
+  List<Object?> _toList() {
+    return <Object?>[
+      id,
+      metadata,
+      time,
+      zoneOffsetSeconds,
+      result,
+    ];
+  }
+
+  Object encode() {
+    return _toList();
+  }
+
+  static OvulationTestRecordDto decode(Object result) {
+    result as List<Object?>;
+    return OvulationTestRecordDto(
+      id: result[0] as String?,
+      metadata: result[1]! as MetadataDto,
+      time: result[2]! as int,
+      zoneOffsetSeconds: result[3] as int?,
+      result: result[4]! as OvulationTestResultTypeDto,
+    );
+  }
+
+  @override
+  // ignore: avoid_equals_and_hash_code_on_mutable_classes
+  bool operator ==(Object other) {
+    if (other is! OvulationTestRecordDto || other.runtimeType != runtimeType) {
       return false;
     }
     if (identical(this, other)) {
@@ -4733,200 +4821,206 @@ class _PigeonCodec extends StandardMessageCodec {
     } else if (value is SexualActivityProtectionUsedTypeDto) {
       buffer.putUint8(156);
       writeValue(buffer, value.index);
-    } else if (value is HealthDataTypeDto) {
+    } else if (value is OvulationTestResultTypeDto) {
       buffer.putUint8(157);
       writeValue(buffer, value.index);
-    } else if (value is SleepStageTypeDto) {
+    } else if (value is HealthDataTypeDto) {
       buffer.putUint8(158);
       writeValue(buffer, value.index);
-    } else if (value is HealthPlatformFeatureDto) {
+    } else if (value is SleepStageTypeDto) {
       buffer.putUint8(159);
       writeValue(buffer, value.index);
-    } else if (value is HealthPlatformFeatureStatusDto) {
+    } else if (value is HealthPlatformFeatureDto) {
       buffer.putUint8(160);
       writeValue(buffer, value.index);
-    } else if (value is AggregationMetricDto) {
+    } else if (value is HealthPlatformFeatureStatusDto) {
       buffer.putUint8(161);
       writeValue(buffer, value.index);
-    } else if (value is BloodPressureHealthDataTypeDto) {
+    } else if (value is AggregationMetricDto) {
       buffer.putUint8(162);
       writeValue(buffer, value.index);
-    } else if (value is BloodGlucoseDto) {
+    } else if (value is BloodPressureHealthDataTypeDto) {
       buffer.putUint8(163);
-      writeValue(buffer, value.encode());
-    } else if (value is EnergyDto) {
+      writeValue(buffer, value.index);
+    } else if (value is BloodGlucoseDto) {
       buffer.putUint8(164);
       writeValue(buffer, value.encode());
-    } else if (value is TimeDurationDto) {
+    } else if (value is EnergyDto) {
       buffer.putUint8(165);
       writeValue(buffer, value.encode());
-    } else if (value is LengthDto) {
+    } else if (value is TimeDurationDto) {
       buffer.putUint8(166);
       writeValue(buffer, value.encode());
-    } else if (value is MassDto) {
+    } else if (value is LengthDto) {
       buffer.putUint8(167);
       writeValue(buffer, value.encode());
-    } else if (value is NumberDto) {
+    } else if (value is MassDto) {
       buffer.putUint8(168);
       writeValue(buffer, value.encode());
-    } else if (value is PercentageDto) {
+    } else if (value is NumberDto) {
       buffer.putUint8(169);
       writeValue(buffer, value.encode());
-    } else if (value is PowerDto) {
+    } else if (value is PercentageDto) {
       buffer.putUint8(170);
       writeValue(buffer, value.encode());
-    } else if (value is PressureDto) {
+    } else if (value is PowerDto) {
       buffer.putUint8(171);
       writeValue(buffer, value.encode());
-    } else if (value is TemperatureDto) {
+    } else if (value is PressureDto) {
       buffer.putUint8(172);
       writeValue(buffer, value.encode());
-    } else if (value is VelocityDto) {
+    } else if (value is TemperatureDto) {
       buffer.putUint8(173);
       writeValue(buffer, value.encode());
-    } else if (value is VolumeDto) {
+    } else if (value is VelocityDto) {
       buffer.putUint8(174);
       writeValue(buffer, value.encode());
-    } else if (value is MetadataDto) {
+    } else if (value is VolumeDto) {
       buffer.putUint8(175);
       writeValue(buffer, value.encode());
-    } else if (value is BloodGlucoseRecordDto) {
+    } else if (value is MetadataDto) {
       buffer.putUint8(176);
       writeValue(buffer, value.encode());
-    } else if (value is RestingHeartRateRecordDto) {
+    } else if (value is BloodGlucoseRecordDto) {
       buffer.putUint8(177);
       writeValue(buffer, value.encode());
-    } else if (value is OxygenSaturationRecordDto) {
+    } else if (value is RestingHeartRateRecordDto) {
       buffer.putUint8(178);
       writeValue(buffer, value.encode());
-    } else if (value is RespiratoryRateRecordDto) {
+    } else if (value is OxygenSaturationRecordDto) {
       buffer.putUint8(179);
       writeValue(buffer, value.encode());
-    } else if (value is Vo2MaxRecordDto) {
+    } else if (value is OvulationTestRecordDto) {
       buffer.putUint8(180);
       writeValue(buffer, value.encode());
-    } else if (value is ActiveCaloriesBurnedRecordDto) {
+    } else if (value is RespiratoryRateRecordDto) {
       buffer.putUint8(181);
       writeValue(buffer, value.encode());
-    } else if (value is DistanceRecordDto) {
+    } else if (value is Vo2MaxRecordDto) {
       buffer.putUint8(182);
       writeValue(buffer, value.encode());
-    } else if (value is FloorsClimbedRecordDto) {
+    } else if (value is ActiveCaloriesBurnedRecordDto) {
       buffer.putUint8(183);
       writeValue(buffer, value.encode());
-    } else if (value is WheelchairPushesRecordDto) {
+    } else if (value is DistanceRecordDto) {
       buffer.putUint8(184);
       writeValue(buffer, value.encode());
-    } else if (value is StepsRecordDto) {
+    } else if (value is FloorsClimbedRecordDto) {
       buffer.putUint8(185);
       writeValue(buffer, value.encode());
-    } else if (value is WeightRecordDto) {
+    } else if (value is WheelchairPushesRecordDto) {
       buffer.putUint8(186);
       writeValue(buffer, value.encode());
-    } else if (value is BloodPressureRecordDto) {
+    } else if (value is StepsRecordDto) {
       buffer.putUint8(187);
       writeValue(buffer, value.encode());
-    } else if (value is LeanBodyMassRecordDto) {
+    } else if (value is WeightRecordDto) {
       buffer.putUint8(188);
       writeValue(buffer, value.encode());
-    } else if (value is HeightRecordDto) {
+    } else if (value is BloodPressureRecordDto) {
       buffer.putUint8(189);
       writeValue(buffer, value.encode());
-    } else if (value is BodyFatPercentageRecordDto) {
+    } else if (value is LeanBodyMassRecordDto) {
       buffer.putUint8(190);
       writeValue(buffer, value.encode());
-    } else if (value is BodyTemperatureRecordDto) {
+    } else if (value is HeightRecordDto) {
       buffer.putUint8(191);
       writeValue(buffer, value.encode());
-    } else if (value is CervicalMucusRecordDto) {
+    } else if (value is BodyFatPercentageRecordDto) {
       buffer.putUint8(192);
       writeValue(buffer, value.encode());
-    } else if (value is HydrationRecordDto) {
+    } else if (value is BodyTemperatureRecordDto) {
       buffer.putUint8(193);
       writeValue(buffer, value.encode());
-    } else if (value is HeartRateMeasurementDto) {
+    } else if (value is CervicalMucusRecordDto) {
       buffer.putUint8(194);
       writeValue(buffer, value.encode());
-    } else if (value is HeartRateSeriesRecordDto) {
+    } else if (value is HydrationRecordDto) {
       buffer.putUint8(195);
       writeValue(buffer, value.encode());
-    } else if (value is CyclingPedalingCadenceMeasurementDto) {
+    } else if (value is HeartRateMeasurementDto) {
       buffer.putUint8(196);
       writeValue(buffer, value.encode());
-    } else if (value is CyclingPedalingCadenceSeriesRecordDto) {
+    } else if (value is HeartRateSeriesRecordDto) {
       buffer.putUint8(197);
       writeValue(buffer, value.encode());
-    } else if (value is SpeedMeasurementDto) {
+    } else if (value is CyclingPedalingCadenceMeasurementDto) {
       buffer.putUint8(198);
       writeValue(buffer, value.encode());
-    } else if (value is SpeedSeriesRecordDto) {
+    } else if (value is CyclingPedalingCadenceSeriesRecordDto) {
       buffer.putUint8(199);
       writeValue(buffer, value.encode());
-    } else if (value is PowerMeasurementDto) {
+    } else if (value is SpeedMeasurementDto) {
       buffer.putUint8(200);
       writeValue(buffer, value.encode());
-    } else if (value is PowerSeriesRecordDto) {
+    } else if (value is SpeedSeriesRecordDto) {
       buffer.putUint8(201);
       writeValue(buffer, value.encode());
-    } else if (value is SleepStageDto) {
+    } else if (value is PowerMeasurementDto) {
       buffer.putUint8(202);
       writeValue(buffer, value.encode());
-    } else if (value is SleepSessionRecordDto) {
+    } else if (value is PowerSeriesRecordDto) {
       buffer.putUint8(203);
       writeValue(buffer, value.encode());
-    } else if (value is SexualActivityRecordDto) {
+    } else if (value is SleepStageDto) {
       buffer.putUint8(204);
       writeValue(buffer, value.encode());
-    } else if (value is ExerciseSessionRecordDto) {
+    } else if (value is SleepSessionRecordDto) {
       buffer.putUint8(205);
       writeValue(buffer, value.encode());
-    } else if (value is MindfulnessSessionRecordDto) {
+    } else if (value is SexualActivityRecordDto) {
       buffer.putUint8(206);
       writeValue(buffer, value.encode());
-    } else if (value is NutritionRecordDto) {
+    } else if (value is ExerciseSessionRecordDto) {
       buffer.putUint8(207);
       writeValue(buffer, value.encode());
-    } else if (value is HealthPlatformFeaturePermissionRequestResultDto) {
+    } else if (value is MindfulnessSessionRecordDto) {
       buffer.putUint8(208);
       writeValue(buffer, value.encode());
-    } else if (value is HealthDataPermissionRequestDto) {
+    } else if (value is NutritionRecordDto) {
       buffer.putUint8(209);
       writeValue(buffer, value.encode());
-    } else if (value is HealthDataPermissionRequestResultDto) {
+    } else if (value is HealthPlatformFeaturePermissionRequestResultDto) {
       buffer.putUint8(210);
       writeValue(buffer, value.encode());
-    } else if (value is HealthPlatformFeaturePermissionRequest) {
+    } else if (value is HealthDataPermissionRequestDto) {
       buffer.putUint8(211);
       writeValue(buffer, value.encode());
-    } else if (value is PermissionRequestsDto) {
+    } else if (value is HealthDataPermissionRequestResultDto) {
       buffer.putUint8(212);
       writeValue(buffer, value.encode());
-    } else if (value is PermissionRequestsResponseDto) {
+    } else if (value is HealthPlatformFeaturePermissionRequest) {
       buffer.putUint8(213);
       writeValue(buffer, value.encode());
-    } else if (value is CommonAggregateRequestDto) {
+    } else if (value is PermissionRequestsDto) {
       buffer.putUint8(214);
       writeValue(buffer, value.encode());
-    } else if (value is BloodPressureAggregateRequestDto) {
+    } else if (value is PermissionRequestsResponseDto) {
       buffer.putUint8(215);
       writeValue(buffer, value.encode());
-    } else if (value is DeleteRecordsByIdsRequestDto) {
+    } else if (value is CommonAggregateRequestDto) {
       buffer.putUint8(216);
       writeValue(buffer, value.encode());
-    } else if (value is DeleteRecordsByTimeRangeRequestDto) {
+    } else if (value is BloodPressureAggregateRequestDto) {
       buffer.putUint8(217);
       writeValue(buffer, value.encode());
-    } else if (value is ReadRecordRequestDto) {
+    } else if (value is DeleteRecordsByIdsRequestDto) {
       buffer.putUint8(218);
       writeValue(buffer, value.encode());
-    } else if (value is ReadRecordsRequestDto) {
+    } else if (value is DeleteRecordsByTimeRangeRequestDto) {
       buffer.putUint8(219);
       writeValue(buffer, value.encode());
-    } else if (value is ReadRecordsResponseDto) {
+    } else if (value is ReadRecordRequestDto) {
       buffer.putUint8(220);
       writeValue(buffer, value.encode());
-    } else if (value is HealthConnectorConfigDto) {
+    } else if (value is ReadRecordsRequestDto) {
       buffer.putUint8(221);
+      writeValue(buffer, value.encode());
+    } else if (value is ReadRecordsResponseDto) {
+      buffer.putUint8(222);
+      writeValue(buffer, value.encode());
+    } else if (value is HealthConnectorConfigDto) {
+      buffer.putUint8(223);
       writeValue(buffer, value.encode());
     } else {
       super.writeValue(buffer, value);
@@ -5032,147 +5126,152 @@ class _PigeonCodec extends StandardMessageCodec {
             : SexualActivityProtectionUsedTypeDto.values[value];
       case 157:
         final int? value = readValue(buffer) as int?;
-        return value == null ? null : HealthDataTypeDto.values[value];
+        return value == null ? null : OvulationTestResultTypeDto.values[value];
       case 158:
         final int? value = readValue(buffer) as int?;
-        return value == null ? null : SleepStageTypeDto.values[value];
+        return value == null ? null : HealthDataTypeDto.values[value];
       case 159:
         final int? value = readValue(buffer) as int?;
-        return value == null ? null : HealthPlatformFeatureDto.values[value];
+        return value == null ? null : SleepStageTypeDto.values[value];
       case 160:
+        final int? value = readValue(buffer) as int?;
+        return value == null ? null : HealthPlatformFeatureDto.values[value];
+      case 161:
         final int? value = readValue(buffer) as int?;
         return value == null
             ? null
             : HealthPlatformFeatureStatusDto.values[value];
-      case 161:
+      case 162:
         final int? value = readValue(buffer) as int?;
         return value == null ? null : AggregationMetricDto.values[value];
-      case 162:
+      case 163:
         final int? value = readValue(buffer) as int?;
         return value == null
             ? null
             : BloodPressureHealthDataTypeDto.values[value];
-      case 163:
-        return BloodGlucoseDto.decode(readValue(buffer)!);
       case 164:
-        return EnergyDto.decode(readValue(buffer)!);
+        return BloodGlucoseDto.decode(readValue(buffer)!);
       case 165:
-        return TimeDurationDto.decode(readValue(buffer)!);
+        return EnergyDto.decode(readValue(buffer)!);
       case 166:
-        return LengthDto.decode(readValue(buffer)!);
+        return TimeDurationDto.decode(readValue(buffer)!);
       case 167:
-        return MassDto.decode(readValue(buffer)!);
+        return LengthDto.decode(readValue(buffer)!);
       case 168:
-        return NumberDto.decode(readValue(buffer)!);
+        return MassDto.decode(readValue(buffer)!);
       case 169:
-        return PercentageDto.decode(readValue(buffer)!);
+        return NumberDto.decode(readValue(buffer)!);
       case 170:
-        return PowerDto.decode(readValue(buffer)!);
+        return PercentageDto.decode(readValue(buffer)!);
       case 171:
-        return PressureDto.decode(readValue(buffer)!);
+        return PowerDto.decode(readValue(buffer)!);
       case 172:
-        return TemperatureDto.decode(readValue(buffer)!);
+        return PressureDto.decode(readValue(buffer)!);
       case 173:
-        return VelocityDto.decode(readValue(buffer)!);
+        return TemperatureDto.decode(readValue(buffer)!);
       case 174:
-        return VolumeDto.decode(readValue(buffer)!);
+        return VelocityDto.decode(readValue(buffer)!);
       case 175:
-        return MetadataDto.decode(readValue(buffer)!);
+        return VolumeDto.decode(readValue(buffer)!);
       case 176:
-        return BloodGlucoseRecordDto.decode(readValue(buffer)!);
+        return MetadataDto.decode(readValue(buffer)!);
       case 177:
-        return RestingHeartRateRecordDto.decode(readValue(buffer)!);
+        return BloodGlucoseRecordDto.decode(readValue(buffer)!);
       case 178:
-        return OxygenSaturationRecordDto.decode(readValue(buffer)!);
+        return RestingHeartRateRecordDto.decode(readValue(buffer)!);
       case 179:
-        return RespiratoryRateRecordDto.decode(readValue(buffer)!);
+        return OxygenSaturationRecordDto.decode(readValue(buffer)!);
       case 180:
-        return Vo2MaxRecordDto.decode(readValue(buffer)!);
+        return OvulationTestRecordDto.decode(readValue(buffer)!);
       case 181:
-        return ActiveCaloriesBurnedRecordDto.decode(readValue(buffer)!);
+        return RespiratoryRateRecordDto.decode(readValue(buffer)!);
       case 182:
-        return DistanceRecordDto.decode(readValue(buffer)!);
+        return Vo2MaxRecordDto.decode(readValue(buffer)!);
       case 183:
-        return FloorsClimbedRecordDto.decode(readValue(buffer)!);
+        return ActiveCaloriesBurnedRecordDto.decode(readValue(buffer)!);
       case 184:
-        return WheelchairPushesRecordDto.decode(readValue(buffer)!);
+        return DistanceRecordDto.decode(readValue(buffer)!);
       case 185:
-        return StepsRecordDto.decode(readValue(buffer)!);
+        return FloorsClimbedRecordDto.decode(readValue(buffer)!);
       case 186:
-        return WeightRecordDto.decode(readValue(buffer)!);
+        return WheelchairPushesRecordDto.decode(readValue(buffer)!);
       case 187:
-        return BloodPressureRecordDto.decode(readValue(buffer)!);
+        return StepsRecordDto.decode(readValue(buffer)!);
       case 188:
-        return LeanBodyMassRecordDto.decode(readValue(buffer)!);
+        return WeightRecordDto.decode(readValue(buffer)!);
       case 189:
-        return HeightRecordDto.decode(readValue(buffer)!);
+        return BloodPressureRecordDto.decode(readValue(buffer)!);
       case 190:
-        return BodyFatPercentageRecordDto.decode(readValue(buffer)!);
+        return LeanBodyMassRecordDto.decode(readValue(buffer)!);
       case 191:
-        return BodyTemperatureRecordDto.decode(readValue(buffer)!);
+        return HeightRecordDto.decode(readValue(buffer)!);
       case 192:
-        return CervicalMucusRecordDto.decode(readValue(buffer)!);
+        return BodyFatPercentageRecordDto.decode(readValue(buffer)!);
       case 193:
-        return HydrationRecordDto.decode(readValue(buffer)!);
+        return BodyTemperatureRecordDto.decode(readValue(buffer)!);
       case 194:
-        return HeartRateMeasurementDto.decode(readValue(buffer)!);
+        return CervicalMucusRecordDto.decode(readValue(buffer)!);
       case 195:
-        return HeartRateSeriesRecordDto.decode(readValue(buffer)!);
+        return HydrationRecordDto.decode(readValue(buffer)!);
       case 196:
-        return CyclingPedalingCadenceMeasurementDto.decode(readValue(buffer)!);
+        return HeartRateMeasurementDto.decode(readValue(buffer)!);
       case 197:
-        return CyclingPedalingCadenceSeriesRecordDto.decode(readValue(buffer)!);
+        return HeartRateSeriesRecordDto.decode(readValue(buffer)!);
       case 198:
-        return SpeedMeasurementDto.decode(readValue(buffer)!);
+        return CyclingPedalingCadenceMeasurementDto.decode(readValue(buffer)!);
       case 199:
-        return SpeedSeriesRecordDto.decode(readValue(buffer)!);
+        return CyclingPedalingCadenceSeriesRecordDto.decode(readValue(buffer)!);
       case 200:
-        return PowerMeasurementDto.decode(readValue(buffer)!);
+        return SpeedMeasurementDto.decode(readValue(buffer)!);
       case 201:
-        return PowerSeriesRecordDto.decode(readValue(buffer)!);
+        return SpeedSeriesRecordDto.decode(readValue(buffer)!);
       case 202:
-        return SleepStageDto.decode(readValue(buffer)!);
+        return PowerMeasurementDto.decode(readValue(buffer)!);
       case 203:
-        return SleepSessionRecordDto.decode(readValue(buffer)!);
+        return PowerSeriesRecordDto.decode(readValue(buffer)!);
       case 204:
-        return SexualActivityRecordDto.decode(readValue(buffer)!);
+        return SleepStageDto.decode(readValue(buffer)!);
       case 205:
-        return ExerciseSessionRecordDto.decode(readValue(buffer)!);
+        return SleepSessionRecordDto.decode(readValue(buffer)!);
       case 206:
-        return MindfulnessSessionRecordDto.decode(readValue(buffer)!);
+        return SexualActivityRecordDto.decode(readValue(buffer)!);
       case 207:
-        return NutritionRecordDto.decode(readValue(buffer)!);
+        return ExerciseSessionRecordDto.decode(readValue(buffer)!);
       case 208:
+        return MindfulnessSessionRecordDto.decode(readValue(buffer)!);
+      case 209:
+        return NutritionRecordDto.decode(readValue(buffer)!);
+      case 210:
         return HealthPlatformFeaturePermissionRequestResultDto.decode(
           readValue(buffer)!,
         );
-      case 209:
-        return HealthDataPermissionRequestDto.decode(readValue(buffer)!);
-      case 210:
-        return HealthDataPermissionRequestResultDto.decode(readValue(buffer)!);
       case 211:
+        return HealthDataPermissionRequestDto.decode(readValue(buffer)!);
+      case 212:
+        return HealthDataPermissionRequestResultDto.decode(readValue(buffer)!);
+      case 213:
         return HealthPlatformFeaturePermissionRequest.decode(
           readValue(buffer)!,
         );
-      case 212:
-        return PermissionRequestsDto.decode(readValue(buffer)!);
-      case 213:
-        return PermissionRequestsResponseDto.decode(readValue(buffer)!);
       case 214:
-        return CommonAggregateRequestDto.decode(readValue(buffer)!);
+        return PermissionRequestsDto.decode(readValue(buffer)!);
       case 215:
-        return BloodPressureAggregateRequestDto.decode(readValue(buffer)!);
+        return PermissionRequestsResponseDto.decode(readValue(buffer)!);
       case 216:
-        return DeleteRecordsByIdsRequestDto.decode(readValue(buffer)!);
+        return CommonAggregateRequestDto.decode(readValue(buffer)!);
       case 217:
-        return DeleteRecordsByTimeRangeRequestDto.decode(readValue(buffer)!);
+        return BloodPressureAggregateRequestDto.decode(readValue(buffer)!);
       case 218:
-        return ReadRecordRequestDto.decode(readValue(buffer)!);
+        return DeleteRecordsByIdsRequestDto.decode(readValue(buffer)!);
       case 219:
-        return ReadRecordsRequestDto.decode(readValue(buffer)!);
+        return DeleteRecordsByTimeRangeRequestDto.decode(readValue(buffer)!);
       case 220:
-        return ReadRecordsResponseDto.decode(readValue(buffer)!);
+        return ReadRecordRequestDto.decode(readValue(buffer)!);
       case 221:
+        return ReadRecordsRequestDto.decode(readValue(buffer)!);
+      case 222:
+        return ReadRecordsResponseDto.decode(readValue(buffer)!);
+      case 223:
         return HealthConnectorConfigDto.decode(readValue(buffer)!);
       default:
         return super.readValueOfType(type, buffer);

--- a/packages/health_connector_hc_android/pigeons/health_connector_hc_android_api.dart
+++ b/packages/health_connector_hc_android/pigeons/health_connector_hc_android_api.dart
@@ -645,6 +645,24 @@ enum SexualActivityProtectionUsedTypeDto {
   unknown,
 }
 
+/// Ovulation test result classification.
+///
+/// Maps to Android Health Connect OvulationTestRecord result constants
+/// and iOS HealthKit HKCategoryValueOvulationTestResult enum.
+enum OvulationTestResultTypeDto {
+  /// Test result is negative (no hormonal surge).
+  negative,
+
+  /// Test result is inconclusive.
+  inconclusive,
+
+  /// Test result shows high estrogen levels.
+  high,
+
+  /// Test result is positive (LH surge detected).
+  positive,
+}
+
 // endregion
 
 // region Health Records
@@ -717,6 +735,9 @@ enum HealthDataTypeDto {
 
   /// Composite blood pressure data (systolic + diastolic).
   bloodPressure,
+
+  /// Ovulation test data.
+  ovulationTest,
 
   /// Oxygen saturation data.
   oxygenSaturation,
@@ -828,6 +849,32 @@ class OxygenSaturationRecordDto extends HealthRecordDto {
 
   /// Timezone offset in seconds for measurement time (optional).
   final int? zoneOffsetSeconds;
+}
+
+/// Represents an ovulation test record for platform transfer.
+class OvulationTestRecordDto extends HealthRecordDto {
+  OvulationTestRecordDto({
+    required this.id,
+    required this.metadata,
+    required this.time,
+    required this.result,
+    this.zoneOffsetSeconds,
+  });
+
+  /// Platform-assigned unique identifier.
+  final String? id;
+
+  /// Metadata about this record.
+  final MetadataDto metadata;
+
+  /// Measurement time in milliseconds since epoch (UTC).
+  final int time;
+
+  /// Timezone offset in seconds for measurement time (optional).
+  final int? zoneOffsetSeconds;
+
+  /// The ovulation test result.
+  final OvulationTestResultTypeDto result;
 }
 
 /// Represents a respiratory rate record for platform transfer.

--- a/packages/health_connector_hk_ios/ios/health_connector_hk_ios/Sources/health_connector_hk_ios/handlers/HealthRecordHandlerRegistry.swift
+++ b/packages/health_connector_hk_ios/ios/health_connector_hk_ios/Sources/health_connector_hk_ios/handlers/HealthRecordHandlerRegistry.swift
@@ -134,6 +134,7 @@ final class HealthRecordHandlerRegistry: @unchecked Sendable {
         register(Vo2MaxHandler(healthStore: healthStore))
         register(BloodGlucoseHandler(healthStore: healthStore))
         register(NutritionHandler(healthStore: healthStore))
+        register(OvulationTestHandler(healthStore: healthStore))
         register(BloodPressureHandler(healthStore: healthStore))
         register(SystolicBloodPressureHandler(healthStore: healthStore))
         register(DiastolicBloodPressureHandler(healthStore: healthStore))

--- a/packages/health_connector_hk_ios/ios/health_connector_hk_ios/Sources/health_connector_hk_ios/handlers/health_record_handlers/OvulationTestHandler.swift
+++ b/packages/health_connector_hk_ios/ios/health_connector_hk_ios/Sources/health_connector_hk_ios/handlers/health_record_handlers/OvulationTestHandler.swift
@@ -1,0 +1,20 @@
+import Foundation
+import HealthKit
+
+/// Handler for ovulation test data (category sample type)
+final class OvulationTestHandler: @unchecked Sendable,
+    ReadableHealthRecordHandler,
+    WritableHealthRecordHandler,
+    DeletableHealthRecordHandler
+{
+    typealias RecordDto = OvulationTestRecordDto
+    typealias SampleType = HKCategorySample
+
+    let healthStore: HKHealthStore
+
+    init(healthStore: HKHealthStore) {
+        self.healthStore = healthStore
+    }
+
+    static let dataType: HealthDataTypeDto = .ovulationTest
+}

--- a/packages/health_connector_hk_ios/ios/health_connector_hk_ios/Sources/health_connector_hk_ios/mappers/HealthDataTypeMapper.swift
+++ b/packages/health_connector_hk_ios/ios/health_connector_hk_ios/Sources/health_connector_hk_ios/mappers/HealthDataTypeMapper.swift
@@ -230,6 +230,8 @@ extension HealthDataTypeDto {
             try HKCategoryType.make(from: .sexualActivity)
         case .cervicalMucus:
             try HKCategoryType.make(from: .cervicalMucusQuality)
+        case .ovulationTest:
+            try HKCategoryType.make(from: .ovulationTestResult)
         case .exerciseSession:
             HKObjectType.workoutType()
         case .mindfulnessSession:

--- a/packages/health_connector_hk_ios/ios/health_connector_hk_ios/Sources/health_connector_hk_ios/mappers/PermissionMapper.swift
+++ b/packages/health_connector_hk_ios/ios/health_connector_hk_ios/Sources/health_connector_hk_ios/mappers/PermissionMapper.swift
@@ -88,7 +88,8 @@ extension HealthDataPermissionDto {
              .stairDescentSpeed:
             try [healthDataType.toHealthKit()]
         case .sexualActivity,
-             .cervicalMucus:
+             .cervicalMucus,
+             .ovulationTest:
             try [healthDataType.toHealthKit()]
         // Exercise sessions use HKWorkoutType, not HKQuantityType
         case .exerciseSession:

--- a/packages/health_connector_hk_ios/ios/health_connector_hk_ios/Sources/health_connector_hk_ios/mappers/health_record_mappers/HealthRecordMapper.swift
+++ b/packages/health_connector_hk_ios/ios/health_connector_hk_ios/Sources/health_connector_hk_ios/mappers/health_record_mappers/HealthRecordMapper.swift
@@ -67,6 +67,8 @@ extension HealthRecordDto {
             return try dto.toHealthKit()
         case let dto as MindfulnessSessionRecordDto:
             return try dto.toHealthKit()
+        case let dto as OvulationTestRecordDto:
+            return try dto.toHealthKit()
         default:
             throw HealthConnectorError.unsupportedOperation(
                 message:
@@ -120,6 +122,8 @@ extension HKCategorySample {
             try toSleepStageRecordDto()
         case .mindfulnessSession:
             try toMindfulnessSessionDto()
+        case .ovulationTest:
+            try toOvulationTestRecordDto()
         default:
             throw HealthConnectorError.invalidArgument(
                 message: "Unsupported health data type for HKCategorySample",

--- a/packages/health_connector_hk_ios/ios/health_connector_hk_ios/Sources/health_connector_hk_ios/mappers/health_record_mappers/OvulationTestRecordMapper.swift
+++ b/packages/health_connector_hk_ios/ios/health_connector_hk_ios/Sources/health_connector_hk_ios/mappers/health_record_mappers/OvulationTestRecordMapper.swift
@@ -1,0 +1,105 @@
+import Foundation
+import HealthKit
+
+// MARK: - HKCategorySample to DTO
+
+extension HKCategorySample {
+    /// Converts a HealthKit ovulation test category sample to `OvulationTestRecordDto`.
+    func toOvulationTestRecordDto() throws -> OvulationTestRecordDto {
+        // Create builder from HK metadata with source and device
+        var builder = MetadataBuilder(
+            fromHKMetadata: metadata ?? [:],
+            source: sourceRevision.source,
+            device: device
+        )
+
+        // Extract timezone offset from metadata
+        let zoneOffset = StartTimeZoneOffsetKey.read(from: builder.metadataDict)
+
+        // Convert HealthKit category value to DTO
+        guard let hkResult = HKCategoryValueOvulationTestResult(rawValue: value) else {
+            throw HealthConnectorError.invalidArgument(
+                message: "Invalid ovulation test result value: \(value)"
+            )
+        }
+
+        return try OvulationTestRecordDto(
+            id: uuid.uuidString,
+            metadata: builder.toMetadataDto(),
+            time: Int64(startDate.timeIntervalSince1970 * 1000),
+            zoneOffsetSeconds: zoneOffset,
+            result: hkResult.toOvulationTestResultTypeDto()
+        )
+    }
+}
+
+// MARK: - DTO to HealthKit
+
+extension OvulationTestRecordDto {
+    /// Converts a `OvulationTestRecordDto` to a HealthKit category sample.
+    func toHealthKit() throws -> HKCategorySample {
+        guard
+            let categoryType = HKObjectType.categoryType(
+                forIdentifier: .ovulationTestResult
+            )
+        else {
+            throw HealthConnectorError.invalidArgument(
+                message: "Failed to create category type for ovulation test"
+            )
+        }
+
+        let startDate = Date(timeIntervalSince1970: TimeInterval(time) / 1000)
+        let endDate = startDate // Ovulation test is an instant observation
+
+        // Build metadata using centralized builder
+        let builder = try MetadataBuilder(from: metadata)
+
+        return HKCategorySample(
+            type: categoryType,
+            value: result.toHealthKit().rawValue,
+            start: startDate,
+            end: endDate,
+            device: builder.healthDevice,
+            metadata: builder.build()
+        )
+    }
+}
+
+// MARK: - Enum Mapping Helpers
+
+extension HKCategoryValueOvulationTestResult {
+    /// Converts `HKCategoryValueOvulationTestResult` to `OvulationTestResultTypeDto`.
+    ///
+    /// The `@unknown default` case handles future HealthKit versions that might add new
+    /// result types, throwing an error for unrecognized values.
+    func toOvulationTestResultTypeDto() -> OvulationTestResultTypeDto {
+        switch self {
+        case .negative:
+            return .negative
+        case .indeterminate:
+            return .inconclusive
+        case .estrogenSurge:
+            return .high
+        case .luteinizingHormoneSurge:
+            return .positive
+        @unknown default:
+            return .negative // Default to negative for unknown future values
+        }
+    }
+}
+
+extension OvulationTestResultTypeDto {
+    /// Converts `OvulationTestResultTypeDto` to `HKCategoryValueOvulationTestResult`.
+    func toHealthKit() -> HKCategoryValueOvulationTestResult {
+        switch self {
+        case .negative:
+            .negative
+        case .inconclusive:
+            .indeterminate
+        case .high:
+            .estrogenSurge
+        case .positive:
+            .luteinizingHormoneSurge
+        }
+    }
+}

--- a/packages/health_connector_hk_ios/ios/health_connector_hk_ios/Sources/health_connector_hk_ios/pigeon/HealthConnectorHKIOSApi.g.swift
+++ b/packages/health_connector_hk_ios/ios/health_connector_hk_ios/Sources/health_connector_hk_ios/pigeon/HealthConnectorHKIOSApi.g.swift
@@ -484,6 +484,21 @@ public enum SexualActivityProtectionUsedTypeDto: Int {
   case unknown = 2
 }
 
+/// Ovulation test result classification.
+///
+/// Maps to Android Health Connect OvulationTestRecord result constants
+/// and iOS HealthKit HKCategoryValueOvulationTestResult enum.
+public enum OvulationTestResultTypeDto: Int {
+  /// Test result is negative (no hormonal surge).
+  case negative = 0
+  /// Test result is inconclusive.
+  case inconclusive = 1
+  /// Test result shows high estrogen levels.
+  case high = 2
+  /// Test result is positive (LH surge detected).
+  case positive = 3
+}
+
 /// Represents the type of speed-based activity.
 ///
 /// Maps to different iOS HKQuantityTypeIdentifier values.
@@ -762,18 +777,20 @@ public enum HealthDataTypeDto: Int {
   case systolicBloodPressure = 67
   /// Diastolic blood pressure (HKQuantityType.bloodPressureDiastolic).
   case diastolicBloodPressure = 68
+  /// Ovulation test data.
+  case ovulationTest = 69
   /// Oxygen saturation data.
-  case oxygenSaturation = 69
+  case oxygenSaturation = 70
   /// Respiratory rate data.
-  case respiratoryRate = 70
+  case respiratoryRate = 71
   /// VO2 max (maximal oxygen uptake) data.
-  case vo2Max = 71
+  case vo2Max = 72
   /// Blood glucose data.
-  case bloodGlucose = 72
+  case bloodGlucose = 73
   /// Exercise session data.
-  case exerciseSession = 73
+  case exerciseSession = 74
   /// Mindfulness session data.
-  case mindfulnessSession = 74
+  case mindfulnessSession = 75
 }
 
 /// Aggregation metric types for health data queries.
@@ -2538,6 +2555,54 @@ public struct OxygenSaturationRecordDto: HealthRecordDto {
     ]
   }
   public static func == (lhs: OxygenSaturationRecordDto, rhs: OxygenSaturationRecordDto) -> Bool {
+    return deepEqualsHealthConnectorHKIOSApi(lhs.toList(), rhs.toList())  }
+  public func hash(into hasher: inout Hasher) {
+    deepHashHealthConnectorHKIOSApi(value: toList(), hasher: &hasher)
+  }
+}
+
+/// Represents an ovulation test record for platform transfer.
+///
+/// Generated class from Pigeon that represents data sent in messages.
+public struct OvulationTestRecordDto: HealthRecordDto {
+  /// Platform-assigned unique identifier.
+  var id: String? = nil
+  /// Metadata about this record.
+  var metadata: MetadataDto
+  /// Measurement time in milliseconds since epoch (UTC).
+  var time: Int64
+  /// Timezone offset in seconds for measurement time (optional).
+  var zoneOffsetSeconds: Int64? = nil
+  /// The ovulation test result.
+  var result: OvulationTestResultTypeDto
+
+
+  // swift-format-ignore: AlwaysUseLowerCamelCase
+  static func fromList(_ pigeonVar_list: [Any?]) -> OvulationTestRecordDto? {
+    let id: String? = nilOrValue(pigeonVar_list[0])
+    let metadata = pigeonVar_list[1] as! MetadataDto
+    let time = pigeonVar_list[2] as! Int64
+    let zoneOffsetSeconds: Int64? = nilOrValue(pigeonVar_list[3])
+    let result = pigeonVar_list[4] as! OvulationTestResultTypeDto
+
+    return OvulationTestRecordDto(
+      id: id,
+      metadata: metadata,
+      time: time,
+      zoneOffsetSeconds: zoneOffsetSeconds,
+      result: result
+    )
+  }
+  func toList() -> [Any?] {
+    return [
+      id,
+      metadata,
+      time,
+      zoneOffsetSeconds,
+      result,
+    ]
+  }
+  public static func == (lhs: OvulationTestRecordDto, rhs: OvulationTestRecordDto) -> Bool {
     return deepEqualsHealthConnectorHKIOSApi(lhs.toList(), rhs.toList())  }
   public func hash(into hasher: inout Hasher) {
     deepHashHealthConnectorHKIOSApi(value: toList(), hasher: &hasher)
@@ -5385,208 +5450,216 @@ private class HealthConnectorHKIOSApiPigeonCodecReader: FlutterStandardReader {
     case 156:
       let enumResultAsInt: Int? = nilOrValue(self.readValue() as! Int?)
       if let enumResultAsInt = enumResultAsInt {
-        return SpeedActivityTypeDto(rawValue: enumResultAsInt)
+        return OvulationTestResultTypeDto(rawValue: enumResultAsInt)
       }
       return nil
     case 157:
       let enumResultAsInt: Int? = nilOrValue(self.readValue() as! Int?)
       if let enumResultAsInt = enumResultAsInt {
-        return ExerciseTypeDto(rawValue: enumResultAsInt)
+        return SpeedActivityTypeDto(rawValue: enumResultAsInt)
       }
       return nil
     case 158:
       let enumResultAsInt: Int? = nilOrValue(self.readValue() as! Int?)
       if let enumResultAsInt = enumResultAsInt {
-        return MindfulnessSessionTypeDto(rawValue: enumResultAsInt)
+        return ExerciseTypeDto(rawValue: enumResultAsInt)
       }
       return nil
     case 159:
       let enumResultAsInt: Int? = nilOrValue(self.readValue() as! Int?)
       if let enumResultAsInt = enumResultAsInt {
-        return HealthDataTypeDto(rawValue: enumResultAsInt)
+        return MindfulnessSessionTypeDto(rawValue: enumResultAsInt)
       }
       return nil
     case 160:
       let enumResultAsInt: Int? = nilOrValue(self.readValue() as! Int?)
       if let enumResultAsInt = enumResultAsInt {
-        return AggregationMetricDto(rawValue: enumResultAsInt)
+        return HealthDataTypeDto(rawValue: enumResultAsInt)
       }
       return nil
     case 161:
-      return BloodGlucoseDto.fromList(self.readValue() as! [Any?])
+      let enumResultAsInt: Int? = nilOrValue(self.readValue() as! Int?)
+      if let enumResultAsInt = enumResultAsInt {
+        return AggregationMetricDto(rawValue: enumResultAsInt)
+      }
+      return nil
     case 162:
-      return EnergyDto.fromList(self.readValue() as! [Any?])
+      return BloodGlucoseDto.fromList(self.readValue() as! [Any?])
     case 163:
-      return TimeDurationDto.fromList(self.readValue() as! [Any?])
+      return EnergyDto.fromList(self.readValue() as! [Any?])
     case 164:
-      return LengthDto.fromList(self.readValue() as! [Any?])
+      return TimeDurationDto.fromList(self.readValue() as! [Any?])
     case 165:
-      return MassDto.fromList(self.readValue() as! [Any?])
+      return LengthDto.fromList(self.readValue() as! [Any?])
     case 166:
-      return NumberDto.fromList(self.readValue() as! [Any?])
+      return MassDto.fromList(self.readValue() as! [Any?])
     case 167:
-      return PercentageDto.fromList(self.readValue() as! [Any?])
+      return NumberDto.fromList(self.readValue() as! [Any?])
     case 168:
-      return PowerDto.fromList(self.readValue() as! [Any?])
+      return PercentageDto.fromList(self.readValue() as! [Any?])
     case 169:
-      return PressureDto.fromList(self.readValue() as! [Any?])
+      return PowerDto.fromList(self.readValue() as! [Any?])
     case 170:
-      return TemperatureDto.fromList(self.readValue() as! [Any?])
+      return PressureDto.fromList(self.readValue() as! [Any?])
     case 171:
-      return VelocityDto.fromList(self.readValue() as! [Any?])
+      return TemperatureDto.fromList(self.readValue() as! [Any?])
     case 172:
-      return VolumeDto.fromList(self.readValue() as! [Any?])
+      return VelocityDto.fromList(self.readValue() as! [Any?])
     case 173:
-      return MetadataDto.fromList(self.readValue() as! [Any?])
+      return VolumeDto.fromList(self.readValue() as! [Any?])
     case 174:
-      return HealthDataPermissionDto.fromList(self.readValue() as! [Any?])
+      return MetadataDto.fromList(self.readValue() as! [Any?])
     case 175:
-      return RestingHeartRateRecordDto.fromList(self.readValue() as! [Any?])
+      return HealthDataPermissionDto.fromList(self.readValue() as! [Any?])
     case 176:
-      return Vo2MaxRecordDto.fromList(self.readValue() as! [Any?])
+      return RestingHeartRateRecordDto.fromList(self.readValue() as! [Any?])
     case 177:
-      return BloodGlucoseRecordDto.fromList(self.readValue() as! [Any?])
+      return Vo2MaxRecordDto.fromList(self.readValue() as! [Any?])
     case 178:
-      return ExerciseSessionRecordDto.fromList(self.readValue() as! [Any?])
+      return BloodGlucoseRecordDto.fromList(self.readValue() as! [Any?])
     case 179:
-      return MindfulnessSessionRecordDto.fromList(self.readValue() as! [Any?])
+      return ExerciseSessionRecordDto.fromList(self.readValue() as! [Any?])
     case 180:
-      return ActiveCaloriesBurnedRecordDto.fromList(self.readValue() as! [Any?])
+      return MindfulnessSessionRecordDto.fromList(self.readValue() as! [Any?])
     case 181:
-      return DistanceActivityRecordDto.fromList(self.readValue() as! [Any?])
+      return ActiveCaloriesBurnedRecordDto.fromList(self.readValue() as! [Any?])
     case 182:
-      return SpeedActivityRecordDto.fromList(self.readValue() as! [Any?])
+      return DistanceActivityRecordDto.fromList(self.readValue() as! [Any?])
     case 183:
-      return FloorsClimbedRecordDto.fromList(self.readValue() as! [Any?])
+      return SpeedActivityRecordDto.fromList(self.readValue() as! [Any?])
     case 184:
-      return WheelchairPushesRecordDto.fromList(self.readValue() as! [Any?])
+      return FloorsClimbedRecordDto.fromList(self.readValue() as! [Any?])
     case 185:
-      return StepsRecordDto.fromList(self.readValue() as! [Any?])
+      return WheelchairPushesRecordDto.fromList(self.readValue() as! [Any?])
     case 186:
-      return WeightRecordDto.fromList(self.readValue() as! [Any?])
+      return StepsRecordDto.fromList(self.readValue() as! [Any?])
     case 187:
-      return BloodPressureRecordDto.fromList(self.readValue() as! [Any?])
+      return WeightRecordDto.fromList(self.readValue() as! [Any?])
     case 188:
-      return SystolicBloodPressureRecordDto.fromList(self.readValue() as! [Any?])
+      return BloodPressureRecordDto.fromList(self.readValue() as! [Any?])
     case 189:
-      return DiastolicBloodPressureRecordDto.fromList(self.readValue() as! [Any?])
+      return SystolicBloodPressureRecordDto.fromList(self.readValue() as! [Any?])
     case 190:
-      return LeanBodyMassRecordDto.fromList(self.readValue() as! [Any?])
+      return DiastolicBloodPressureRecordDto.fromList(self.readValue() as! [Any?])
     case 191:
-      return HeightRecordDto.fromList(self.readValue() as! [Any?])
+      return LeanBodyMassRecordDto.fromList(self.readValue() as! [Any?])
     case 192:
-      return BodyFatPercentageRecordDto.fromList(self.readValue() as! [Any?])
+      return HeightRecordDto.fromList(self.readValue() as! [Any?])
     case 193:
-      return BodyTemperatureRecordDto.fromList(self.readValue() as! [Any?])
+      return BodyFatPercentageRecordDto.fromList(self.readValue() as! [Any?])
     case 194:
-      return CervicalMucusRecordDto.fromList(self.readValue() as! [Any?])
+      return BodyTemperatureRecordDto.fromList(self.readValue() as! [Any?])
     case 195:
-      return CyclingPowerRecordDto.fromList(self.readValue() as! [Any?])
+      return CervicalMucusRecordDto.fromList(self.readValue() as! [Any?])
     case 196:
-      return OxygenSaturationRecordDto.fromList(self.readValue() as! [Any?])
+      return CyclingPowerRecordDto.fromList(self.readValue() as! [Any?])
     case 197:
-      return RespiratoryRateRecordDto.fromList(self.readValue() as! [Any?])
+      return OxygenSaturationRecordDto.fromList(self.readValue() as! [Any?])
     case 198:
-      return HydrationRecordDto.fromList(self.readValue() as! [Any?])
+      return OvulationTestRecordDto.fromList(self.readValue() as! [Any?])
     case 199:
-      return HeartRateMeasurementDto.fromList(self.readValue() as! [Any?])
+      return RespiratoryRateRecordDto.fromList(self.readValue() as! [Any?])
     case 200:
-      return HeartRateMeasurementRecordDto.fromList(self.readValue() as! [Any?])
+      return HydrationRecordDto.fromList(self.readValue() as! [Any?])
     case 201:
-      return CyclingPedalingCadenceMeasurementDto.fromList(self.readValue() as! [Any?])
+      return HeartRateMeasurementDto.fromList(self.readValue() as! [Any?])
     case 202:
-      return CyclingPedalingCadenceMeasurementRecordDto.fromList(self.readValue() as! [Any?])
+      return HeartRateMeasurementRecordDto.fromList(self.readValue() as! [Any?])
     case 203:
-      return SleepStageRecordDto.fromList(self.readValue() as! [Any?])
+      return CyclingPedalingCadenceMeasurementDto.fromList(self.readValue() as! [Any?])
     case 204:
-      return SexualActivityRecordDto.fromList(self.readValue() as! [Any?])
+      return CyclingPedalingCadenceMeasurementRecordDto.fromList(self.readValue() as! [Any?])
     case 205:
-      return EnergyNutrientRecordDto.fromList(self.readValue() as! [Any?])
+      return SleepStageRecordDto.fromList(self.readValue() as! [Any?])
     case 206:
-      return CaffeineNutrientRecordDto.fromList(self.readValue() as! [Any?])
+      return SexualActivityRecordDto.fromList(self.readValue() as! [Any?])
     case 207:
-      return ProteinNutrientRecordDto.fromList(self.readValue() as! [Any?])
+      return EnergyNutrientRecordDto.fromList(self.readValue() as! [Any?])
     case 208:
-      return TotalCarbohydrateNutrientRecordDto.fromList(self.readValue() as! [Any?])
+      return CaffeineNutrientRecordDto.fromList(self.readValue() as! [Any?])
     case 209:
-      return TotalFatNutrientRecordDto.fromList(self.readValue() as! [Any?])
+      return ProteinNutrientRecordDto.fromList(self.readValue() as! [Any?])
     case 210:
-      return SaturatedFatNutrientRecordDto.fromList(self.readValue() as! [Any?])
+      return TotalCarbohydrateNutrientRecordDto.fromList(self.readValue() as! [Any?])
     case 211:
-      return MonounsaturatedFatNutrientRecordDto.fromList(self.readValue() as! [Any?])
+      return TotalFatNutrientRecordDto.fromList(self.readValue() as! [Any?])
     case 212:
-      return PolyunsaturatedFatNutrientRecordDto.fromList(self.readValue() as! [Any?])
+      return SaturatedFatNutrientRecordDto.fromList(self.readValue() as! [Any?])
     case 213:
-      return CholesterolNutrientRecordDto.fromList(self.readValue() as! [Any?])
+      return MonounsaturatedFatNutrientRecordDto.fromList(self.readValue() as! [Any?])
     case 214:
-      return DietaryFiberNutrientRecordDto.fromList(self.readValue() as! [Any?])
+      return PolyunsaturatedFatNutrientRecordDto.fromList(self.readValue() as! [Any?])
     case 215:
-      return SugarNutrientRecordDto.fromList(self.readValue() as! [Any?])
+      return CholesterolNutrientRecordDto.fromList(self.readValue() as! [Any?])
     case 216:
-      return VitaminANutrientRecordDto.fromList(self.readValue() as! [Any?])
+      return DietaryFiberNutrientRecordDto.fromList(self.readValue() as! [Any?])
     case 217:
-      return VitaminB6NutrientRecordDto.fromList(self.readValue() as! [Any?])
+      return SugarNutrientRecordDto.fromList(self.readValue() as! [Any?])
     case 218:
-      return VitaminB12NutrientRecordDto.fromList(self.readValue() as! [Any?])
+      return VitaminANutrientRecordDto.fromList(self.readValue() as! [Any?])
     case 219:
-      return VitaminCNutrientRecordDto.fromList(self.readValue() as! [Any?])
+      return VitaminB6NutrientRecordDto.fromList(self.readValue() as! [Any?])
     case 220:
-      return VitaminDNutrientRecordDto.fromList(self.readValue() as! [Any?])
+      return VitaminB12NutrientRecordDto.fromList(self.readValue() as! [Any?])
     case 221:
-      return VitaminENutrientRecordDto.fromList(self.readValue() as! [Any?])
+      return VitaminCNutrientRecordDto.fromList(self.readValue() as! [Any?])
     case 222:
-      return VitaminKNutrientRecordDto.fromList(self.readValue() as! [Any?])
+      return VitaminDNutrientRecordDto.fromList(self.readValue() as! [Any?])
     case 223:
-      return ThiaminNutrientRecordDto.fromList(self.readValue() as! [Any?])
+      return VitaminENutrientRecordDto.fromList(self.readValue() as! [Any?])
     case 224:
-      return RiboflavinNutrientRecordDto.fromList(self.readValue() as! [Any?])
+      return VitaminKNutrientRecordDto.fromList(self.readValue() as! [Any?])
     case 225:
-      return NiacinNutrientRecordDto.fromList(self.readValue() as! [Any?])
+      return ThiaminNutrientRecordDto.fromList(self.readValue() as! [Any?])
     case 226:
-      return FolateNutrientRecordDto.fromList(self.readValue() as! [Any?])
+      return RiboflavinNutrientRecordDto.fromList(self.readValue() as! [Any?])
     case 227:
-      return BiotinNutrientRecordDto.fromList(self.readValue() as! [Any?])
+      return NiacinNutrientRecordDto.fromList(self.readValue() as! [Any?])
     case 228:
-      return PantothenicAcidNutrientRecordDto.fromList(self.readValue() as! [Any?])
+      return FolateNutrientRecordDto.fromList(self.readValue() as! [Any?])
     case 229:
-      return CalciumNutrientRecordDto.fromList(self.readValue() as! [Any?])
+      return BiotinNutrientRecordDto.fromList(self.readValue() as! [Any?])
     case 230:
-      return IronNutrientRecordDto.fromList(self.readValue() as! [Any?])
+      return PantothenicAcidNutrientRecordDto.fromList(self.readValue() as! [Any?])
     case 231:
-      return MagnesiumNutrientRecordDto.fromList(self.readValue() as! [Any?])
+      return CalciumNutrientRecordDto.fromList(self.readValue() as! [Any?])
     case 232:
-      return ManganeseNutrientRecordDto.fromList(self.readValue() as! [Any?])
+      return IronNutrientRecordDto.fromList(self.readValue() as! [Any?])
     case 233:
-      return PhosphorusNutrientRecordDto.fromList(self.readValue() as! [Any?])
+      return MagnesiumNutrientRecordDto.fromList(self.readValue() as! [Any?])
     case 234:
-      return PotassiumNutrientRecordDto.fromList(self.readValue() as! [Any?])
+      return ManganeseNutrientRecordDto.fromList(self.readValue() as! [Any?])
     case 235:
-      return SeleniumNutrientRecordDto.fromList(self.readValue() as! [Any?])
+      return PhosphorusNutrientRecordDto.fromList(self.readValue() as! [Any?])
     case 236:
-      return SodiumNutrientRecordDto.fromList(self.readValue() as! [Any?])
+      return PotassiumNutrientRecordDto.fromList(self.readValue() as! [Any?])
     case 237:
-      return ZincNutrientRecordDto.fromList(self.readValue() as! [Any?])
+      return SeleniumNutrientRecordDto.fromList(self.readValue() as! [Any?])
     case 238:
-      return NutritionRecordDto.fromList(self.readValue() as! [Any?])
+      return SodiumNutrientRecordDto.fromList(self.readValue() as! [Any?])
     case 239:
-      return HealthDataPermissionRequestResultDto.fromList(self.readValue() as! [Any?])
+      return ZincNutrientRecordDto.fromList(self.readValue() as! [Any?])
     case 240:
-      return PermissionsRequestDto.fromList(self.readValue() as! [Any?])
+      return NutritionRecordDto.fromList(self.readValue() as! [Any?])
     case 241:
-      return PermissionsRequestResponseDto.fromList(self.readValue() as! [Any?])
+      return HealthDataPermissionRequestResultDto.fromList(self.readValue() as! [Any?])
     case 242:
-      return AggregateRequestDto.fromList(self.readValue() as! [Any?])
+      return PermissionsRequestDto.fromList(self.readValue() as! [Any?])
     case 243:
-      return DeleteRecordsByIdsRequestDto.fromList(self.readValue() as! [Any?])
+      return PermissionsRequestResponseDto.fromList(self.readValue() as! [Any?])
     case 244:
-      return DeleteRecordsByTimeRangeRequestDto.fromList(self.readValue() as! [Any?])
+      return AggregateRequestDto.fromList(self.readValue() as! [Any?])
     case 245:
-      return ReadRecordRequestDto.fromList(self.readValue() as! [Any?])
+      return DeleteRecordsByIdsRequestDto.fromList(self.readValue() as! [Any?])
     case 246:
-      return ReadRecordsRequestDto.fromList(self.readValue() as! [Any?])
+      return DeleteRecordsByTimeRangeRequestDto.fromList(self.readValue() as! [Any?])
     case 247:
-      return ReadRecordsResponseDto.fromList(self.readValue() as! [Any?])
+      return ReadRecordRequestDto.fromList(self.readValue() as! [Any?])
     case 248:
+      return ReadRecordsRequestDto.fromList(self.readValue() as! [Any?])
+    case 249:
+      return ReadRecordsResponseDto.fromList(self.readValue() as! [Any?])
+    case 250:
       return HealthConnectorConfigDto.fromList(self.readValue() as! [Any?])
     default:
       return super.readValue(ofType: type)
@@ -5677,284 +5750,290 @@ private class HealthConnectorHKIOSApiPigeonCodecWriter: FlutterStandardWriter {
     } else if let value = value as? SexualActivityProtectionUsedTypeDto {
       super.writeByte(155)
       super.writeValue(value.rawValue)
-    } else if let value = value as? SpeedActivityTypeDto {
+    } else if let value = value as? OvulationTestResultTypeDto {
       super.writeByte(156)
       super.writeValue(value.rawValue)
-    } else if let value = value as? ExerciseTypeDto {
+    } else if let value = value as? SpeedActivityTypeDto {
       super.writeByte(157)
       super.writeValue(value.rawValue)
-    } else if let value = value as? MindfulnessSessionTypeDto {
+    } else if let value = value as? ExerciseTypeDto {
       super.writeByte(158)
       super.writeValue(value.rawValue)
-    } else if let value = value as? HealthDataTypeDto {
+    } else if let value = value as? MindfulnessSessionTypeDto {
       super.writeByte(159)
       super.writeValue(value.rawValue)
-    } else if let value = value as? AggregationMetricDto {
+    } else if let value = value as? HealthDataTypeDto {
       super.writeByte(160)
       super.writeValue(value.rawValue)
-    } else if let value = value as? BloodGlucoseDto {
+    } else if let value = value as? AggregationMetricDto {
       super.writeByte(161)
-      super.writeValue(value.toList())
-    } else if let value = value as? EnergyDto {
+      super.writeValue(value.rawValue)
+    } else if let value = value as? BloodGlucoseDto {
       super.writeByte(162)
       super.writeValue(value.toList())
-    } else if let value = value as? TimeDurationDto {
+    } else if let value = value as? EnergyDto {
       super.writeByte(163)
       super.writeValue(value.toList())
-    } else if let value = value as? LengthDto {
+    } else if let value = value as? TimeDurationDto {
       super.writeByte(164)
       super.writeValue(value.toList())
-    } else if let value = value as? MassDto {
+    } else if let value = value as? LengthDto {
       super.writeByte(165)
       super.writeValue(value.toList())
-    } else if let value = value as? NumberDto {
+    } else if let value = value as? MassDto {
       super.writeByte(166)
       super.writeValue(value.toList())
-    } else if let value = value as? PercentageDto {
+    } else if let value = value as? NumberDto {
       super.writeByte(167)
       super.writeValue(value.toList())
-    } else if let value = value as? PowerDto {
+    } else if let value = value as? PercentageDto {
       super.writeByte(168)
       super.writeValue(value.toList())
-    } else if let value = value as? PressureDto {
+    } else if let value = value as? PowerDto {
       super.writeByte(169)
       super.writeValue(value.toList())
-    } else if let value = value as? TemperatureDto {
+    } else if let value = value as? PressureDto {
       super.writeByte(170)
       super.writeValue(value.toList())
-    } else if let value = value as? VelocityDto {
+    } else if let value = value as? TemperatureDto {
       super.writeByte(171)
       super.writeValue(value.toList())
-    } else if let value = value as? VolumeDto {
+    } else if let value = value as? VelocityDto {
       super.writeByte(172)
       super.writeValue(value.toList())
-    } else if let value = value as? MetadataDto {
+    } else if let value = value as? VolumeDto {
       super.writeByte(173)
       super.writeValue(value.toList())
-    } else if let value = value as? HealthDataPermissionDto {
+    } else if let value = value as? MetadataDto {
       super.writeByte(174)
       super.writeValue(value.toList())
-    } else if let value = value as? RestingHeartRateRecordDto {
+    } else if let value = value as? HealthDataPermissionDto {
       super.writeByte(175)
       super.writeValue(value.toList())
-    } else if let value = value as? Vo2MaxRecordDto {
+    } else if let value = value as? RestingHeartRateRecordDto {
       super.writeByte(176)
       super.writeValue(value.toList())
-    } else if let value = value as? BloodGlucoseRecordDto {
+    } else if let value = value as? Vo2MaxRecordDto {
       super.writeByte(177)
       super.writeValue(value.toList())
-    } else if let value = value as? ExerciseSessionRecordDto {
+    } else if let value = value as? BloodGlucoseRecordDto {
       super.writeByte(178)
       super.writeValue(value.toList())
-    } else if let value = value as? MindfulnessSessionRecordDto {
+    } else if let value = value as? ExerciseSessionRecordDto {
       super.writeByte(179)
       super.writeValue(value.toList())
-    } else if let value = value as? ActiveCaloriesBurnedRecordDto {
+    } else if let value = value as? MindfulnessSessionRecordDto {
       super.writeByte(180)
       super.writeValue(value.toList())
-    } else if let value = value as? DistanceActivityRecordDto {
+    } else if let value = value as? ActiveCaloriesBurnedRecordDto {
       super.writeByte(181)
       super.writeValue(value.toList())
-    } else if let value = value as? SpeedActivityRecordDto {
+    } else if let value = value as? DistanceActivityRecordDto {
       super.writeByte(182)
       super.writeValue(value.toList())
-    } else if let value = value as? FloorsClimbedRecordDto {
+    } else if let value = value as? SpeedActivityRecordDto {
       super.writeByte(183)
       super.writeValue(value.toList())
-    } else if let value = value as? WheelchairPushesRecordDto {
+    } else if let value = value as? FloorsClimbedRecordDto {
       super.writeByte(184)
       super.writeValue(value.toList())
-    } else if let value = value as? StepsRecordDto {
+    } else if let value = value as? WheelchairPushesRecordDto {
       super.writeByte(185)
       super.writeValue(value.toList())
-    } else if let value = value as? WeightRecordDto {
+    } else if let value = value as? StepsRecordDto {
       super.writeByte(186)
       super.writeValue(value.toList())
-    } else if let value = value as? BloodPressureRecordDto {
+    } else if let value = value as? WeightRecordDto {
       super.writeByte(187)
       super.writeValue(value.toList())
-    } else if let value = value as? SystolicBloodPressureRecordDto {
+    } else if let value = value as? BloodPressureRecordDto {
       super.writeByte(188)
       super.writeValue(value.toList())
-    } else if let value = value as? DiastolicBloodPressureRecordDto {
+    } else if let value = value as? SystolicBloodPressureRecordDto {
       super.writeByte(189)
       super.writeValue(value.toList())
-    } else if let value = value as? LeanBodyMassRecordDto {
+    } else if let value = value as? DiastolicBloodPressureRecordDto {
       super.writeByte(190)
       super.writeValue(value.toList())
-    } else if let value = value as? HeightRecordDto {
+    } else if let value = value as? LeanBodyMassRecordDto {
       super.writeByte(191)
       super.writeValue(value.toList())
-    } else if let value = value as? BodyFatPercentageRecordDto {
+    } else if let value = value as? HeightRecordDto {
       super.writeByte(192)
       super.writeValue(value.toList())
-    } else if let value = value as? BodyTemperatureRecordDto {
+    } else if let value = value as? BodyFatPercentageRecordDto {
       super.writeByte(193)
       super.writeValue(value.toList())
-    } else if let value = value as? CervicalMucusRecordDto {
+    } else if let value = value as? BodyTemperatureRecordDto {
       super.writeByte(194)
       super.writeValue(value.toList())
-    } else if let value = value as? CyclingPowerRecordDto {
+    } else if let value = value as? CervicalMucusRecordDto {
       super.writeByte(195)
       super.writeValue(value.toList())
-    } else if let value = value as? OxygenSaturationRecordDto {
+    } else if let value = value as? CyclingPowerRecordDto {
       super.writeByte(196)
       super.writeValue(value.toList())
-    } else if let value = value as? RespiratoryRateRecordDto {
+    } else if let value = value as? OxygenSaturationRecordDto {
       super.writeByte(197)
       super.writeValue(value.toList())
-    } else if let value = value as? HydrationRecordDto {
+    } else if let value = value as? OvulationTestRecordDto {
       super.writeByte(198)
       super.writeValue(value.toList())
-    } else if let value = value as? HeartRateMeasurementDto {
+    } else if let value = value as? RespiratoryRateRecordDto {
       super.writeByte(199)
       super.writeValue(value.toList())
-    } else if let value = value as? HeartRateMeasurementRecordDto {
+    } else if let value = value as? HydrationRecordDto {
       super.writeByte(200)
       super.writeValue(value.toList())
-    } else if let value = value as? CyclingPedalingCadenceMeasurementDto {
+    } else if let value = value as? HeartRateMeasurementDto {
       super.writeByte(201)
       super.writeValue(value.toList())
-    } else if let value = value as? CyclingPedalingCadenceMeasurementRecordDto {
+    } else if let value = value as? HeartRateMeasurementRecordDto {
       super.writeByte(202)
       super.writeValue(value.toList())
-    } else if let value = value as? SleepStageRecordDto {
+    } else if let value = value as? CyclingPedalingCadenceMeasurementDto {
       super.writeByte(203)
       super.writeValue(value.toList())
-    } else if let value = value as? SexualActivityRecordDto {
+    } else if let value = value as? CyclingPedalingCadenceMeasurementRecordDto {
       super.writeByte(204)
       super.writeValue(value.toList())
-    } else if let value = value as? EnergyNutrientRecordDto {
+    } else if let value = value as? SleepStageRecordDto {
       super.writeByte(205)
       super.writeValue(value.toList())
-    } else if let value = value as? CaffeineNutrientRecordDto {
+    } else if let value = value as? SexualActivityRecordDto {
       super.writeByte(206)
       super.writeValue(value.toList())
-    } else if let value = value as? ProteinNutrientRecordDto {
+    } else if let value = value as? EnergyNutrientRecordDto {
       super.writeByte(207)
       super.writeValue(value.toList())
-    } else if let value = value as? TotalCarbohydrateNutrientRecordDto {
+    } else if let value = value as? CaffeineNutrientRecordDto {
       super.writeByte(208)
       super.writeValue(value.toList())
-    } else if let value = value as? TotalFatNutrientRecordDto {
+    } else if let value = value as? ProteinNutrientRecordDto {
       super.writeByte(209)
       super.writeValue(value.toList())
-    } else if let value = value as? SaturatedFatNutrientRecordDto {
+    } else if let value = value as? TotalCarbohydrateNutrientRecordDto {
       super.writeByte(210)
       super.writeValue(value.toList())
-    } else if let value = value as? MonounsaturatedFatNutrientRecordDto {
+    } else if let value = value as? TotalFatNutrientRecordDto {
       super.writeByte(211)
       super.writeValue(value.toList())
-    } else if let value = value as? PolyunsaturatedFatNutrientRecordDto {
+    } else if let value = value as? SaturatedFatNutrientRecordDto {
       super.writeByte(212)
       super.writeValue(value.toList())
-    } else if let value = value as? CholesterolNutrientRecordDto {
+    } else if let value = value as? MonounsaturatedFatNutrientRecordDto {
       super.writeByte(213)
       super.writeValue(value.toList())
-    } else if let value = value as? DietaryFiberNutrientRecordDto {
+    } else if let value = value as? PolyunsaturatedFatNutrientRecordDto {
       super.writeByte(214)
       super.writeValue(value.toList())
-    } else if let value = value as? SugarNutrientRecordDto {
+    } else if let value = value as? CholesterolNutrientRecordDto {
       super.writeByte(215)
       super.writeValue(value.toList())
-    } else if let value = value as? VitaminANutrientRecordDto {
+    } else if let value = value as? DietaryFiberNutrientRecordDto {
       super.writeByte(216)
       super.writeValue(value.toList())
-    } else if let value = value as? VitaminB6NutrientRecordDto {
+    } else if let value = value as? SugarNutrientRecordDto {
       super.writeByte(217)
       super.writeValue(value.toList())
-    } else if let value = value as? VitaminB12NutrientRecordDto {
+    } else if let value = value as? VitaminANutrientRecordDto {
       super.writeByte(218)
       super.writeValue(value.toList())
-    } else if let value = value as? VitaminCNutrientRecordDto {
+    } else if let value = value as? VitaminB6NutrientRecordDto {
       super.writeByte(219)
       super.writeValue(value.toList())
-    } else if let value = value as? VitaminDNutrientRecordDto {
+    } else if let value = value as? VitaminB12NutrientRecordDto {
       super.writeByte(220)
       super.writeValue(value.toList())
-    } else if let value = value as? VitaminENutrientRecordDto {
+    } else if let value = value as? VitaminCNutrientRecordDto {
       super.writeByte(221)
       super.writeValue(value.toList())
-    } else if let value = value as? VitaminKNutrientRecordDto {
+    } else if let value = value as? VitaminDNutrientRecordDto {
       super.writeByte(222)
       super.writeValue(value.toList())
-    } else if let value = value as? ThiaminNutrientRecordDto {
+    } else if let value = value as? VitaminENutrientRecordDto {
       super.writeByte(223)
       super.writeValue(value.toList())
-    } else if let value = value as? RiboflavinNutrientRecordDto {
+    } else if let value = value as? VitaminKNutrientRecordDto {
       super.writeByte(224)
       super.writeValue(value.toList())
-    } else if let value = value as? NiacinNutrientRecordDto {
+    } else if let value = value as? ThiaminNutrientRecordDto {
       super.writeByte(225)
       super.writeValue(value.toList())
-    } else if let value = value as? FolateNutrientRecordDto {
+    } else if let value = value as? RiboflavinNutrientRecordDto {
       super.writeByte(226)
       super.writeValue(value.toList())
-    } else if let value = value as? BiotinNutrientRecordDto {
+    } else if let value = value as? NiacinNutrientRecordDto {
       super.writeByte(227)
       super.writeValue(value.toList())
-    } else if let value = value as? PantothenicAcidNutrientRecordDto {
+    } else if let value = value as? FolateNutrientRecordDto {
       super.writeByte(228)
       super.writeValue(value.toList())
-    } else if let value = value as? CalciumNutrientRecordDto {
+    } else if let value = value as? BiotinNutrientRecordDto {
       super.writeByte(229)
       super.writeValue(value.toList())
-    } else if let value = value as? IronNutrientRecordDto {
+    } else if let value = value as? PantothenicAcidNutrientRecordDto {
       super.writeByte(230)
       super.writeValue(value.toList())
-    } else if let value = value as? MagnesiumNutrientRecordDto {
+    } else if let value = value as? CalciumNutrientRecordDto {
       super.writeByte(231)
       super.writeValue(value.toList())
-    } else if let value = value as? ManganeseNutrientRecordDto {
+    } else if let value = value as? IronNutrientRecordDto {
       super.writeByte(232)
       super.writeValue(value.toList())
-    } else if let value = value as? PhosphorusNutrientRecordDto {
+    } else if let value = value as? MagnesiumNutrientRecordDto {
       super.writeByte(233)
       super.writeValue(value.toList())
-    } else if let value = value as? PotassiumNutrientRecordDto {
+    } else if let value = value as? ManganeseNutrientRecordDto {
       super.writeByte(234)
       super.writeValue(value.toList())
-    } else if let value = value as? SeleniumNutrientRecordDto {
+    } else if let value = value as? PhosphorusNutrientRecordDto {
       super.writeByte(235)
       super.writeValue(value.toList())
-    } else if let value = value as? SodiumNutrientRecordDto {
+    } else if let value = value as? PotassiumNutrientRecordDto {
       super.writeByte(236)
       super.writeValue(value.toList())
-    } else if let value = value as? ZincNutrientRecordDto {
+    } else if let value = value as? SeleniumNutrientRecordDto {
       super.writeByte(237)
       super.writeValue(value.toList())
-    } else if let value = value as? NutritionRecordDto {
+    } else if let value = value as? SodiumNutrientRecordDto {
       super.writeByte(238)
       super.writeValue(value.toList())
-    } else if let value = value as? HealthDataPermissionRequestResultDto {
+    } else if let value = value as? ZincNutrientRecordDto {
       super.writeByte(239)
       super.writeValue(value.toList())
-    } else if let value = value as? PermissionsRequestDto {
+    } else if let value = value as? NutritionRecordDto {
       super.writeByte(240)
       super.writeValue(value.toList())
-    } else if let value = value as? PermissionsRequestResponseDto {
+    } else if let value = value as? HealthDataPermissionRequestResultDto {
       super.writeByte(241)
       super.writeValue(value.toList())
-    } else if let value = value as? AggregateRequestDto {
+    } else if let value = value as? PermissionsRequestDto {
       super.writeByte(242)
       super.writeValue(value.toList())
-    } else if let value = value as? DeleteRecordsByIdsRequestDto {
+    } else if let value = value as? PermissionsRequestResponseDto {
       super.writeByte(243)
       super.writeValue(value.toList())
-    } else if let value = value as? DeleteRecordsByTimeRangeRequestDto {
+    } else if let value = value as? AggregateRequestDto {
       super.writeByte(244)
       super.writeValue(value.toList())
-    } else if let value = value as? ReadRecordRequestDto {
+    } else if let value = value as? DeleteRecordsByIdsRequestDto {
       super.writeByte(245)
       super.writeValue(value.toList())
-    } else if let value = value as? ReadRecordsRequestDto {
+    } else if let value = value as? DeleteRecordsByTimeRangeRequestDto {
       super.writeByte(246)
       super.writeValue(value.toList())
-    } else if let value = value as? ReadRecordsResponseDto {
+    } else if let value = value as? ReadRecordRequestDto {
       super.writeByte(247)
       super.writeValue(value.toList())
-    } else if let value = value as? HealthConnectorConfigDto {
+    } else if let value = value as? ReadRecordsRequestDto {
       super.writeByte(248)
+      super.writeValue(value.toList())
+    } else if let value = value as? ReadRecordsResponseDto {
+      super.writeByte(249)
+      super.writeValue(value.toList())
+    } else if let value = value as? HealthConnectorConfigDto {
+      super.writeByte(250)
       super.writeValue(value.toList())
     } else {
       super.writeValue(value)

--- a/packages/health_connector_hk_ios/ios/health_connector_hk_ios/Sources/health_connector_hk_ios/utils/HealthConnectorDtoExtensions.swift
+++ b/packages/health_connector_hk_ios/ios/health_connector_hk_ios/Sources/health_connector_hk_ios/utils/HealthConnectorDtoExtensions.swift
@@ -48,6 +48,8 @@ extension HealthRecordDto {
             record.id
         case let record as CyclingPedalingCadenceMeasurementRecordDto:
             record.id
+        case let record as OvulationTestRecordDto:
+            record.id
         default:
             nil
         }
@@ -197,6 +199,8 @@ extension HealthRecordDto {
                 return .mindfulnessSession
             case is CyclingPedalingCadenceMeasurementRecordDto:
                 return .cyclingPedalingCadenceMeasurementRecord
+            case is OvulationTestRecordDto:
+                return .ovulationTest
             default:
                 throw HealthConnectorError.invalidArgument(
                     message: "Unimplemented HealthRecordDto type: \(type(of: self))")
@@ -340,6 +344,8 @@ extension HealthRecordDto {
         case let dto as SexualActivityRecordDto:
             return dto.time
         case let dto as CervicalMucusRecordDto:
+            return dto.time
+        case let dto as OvulationTestRecordDto:
             return dto.time
         default:
             throw HealthConnectorError.invalidArgument(

--- a/packages/health_connector_hk_ios/ios/health_connector_hk_ios/Sources/health_connector_hk_ios/utils/HealthKitExtensions.swift
+++ b/packages/health_connector_hk_ios/ios/health_connector_hk_ios/Sources/health_connector_hk_ios/utils/HealthKitExtensions.swift
@@ -154,6 +154,8 @@ extension HKSample {
                 return .sexualActivity
             case HKCategoryTypeIdentifier.cervicalMucusQuality.rawValue:
                 return .cervicalMucus
+            case HKCategoryTypeIdentifier.ovulationTestResult.rawValue:
+                return .ovulationTest
             case HKCategoryTypeIdentifier.mindfulSession.rawValue:
                 return .mindfulnessSession
             // Correlation types

--- a/packages/health_connector_hk_ios/lib/src/mappers/health_data_type_mappers.dart
+++ b/packages/health_connector_hk_ios/lib/src/mappers/health_data_type_mappers.dart
@@ -45,6 +45,7 @@ import 'package:health_connector_core/health_connector_core_internal.dart'
         MonounsaturatedFatNutrientDataType,
         CholesterolNutrientDataType,
         RespiratoryRateHealthDataType,
+        OvulationTestDataType,
         OxygenSaturationHealthDataType,
         RestingHeartRateHealthDataType,
         DietaryFiberNutrientDataType,
@@ -202,6 +203,8 @@ extension HealthDataTypeDtoToDomain on HealthDataTypeDto {
         return HealthDataType.diastolicBloodPressure;
       case HealthDataTypeDto.restingHeartRate:
         return HealthDataType.restingHeartRate;
+      case HealthDataTypeDto.ovulationTest:
+        return HealthDataType.ovulationTest;
       case HealthDataTypeDto.oxygenSaturation:
         return HealthDataType.oxygenSaturation;
       case HealthDataTypeDto.respiratoryRate:
@@ -365,6 +368,8 @@ extension HealthDataTypeToDto on HealthDataType<HealthRecord, MeasurementUnit> {
         return HealthDataTypeDto.diastolicBloodPressure;
       case RestingHeartRateHealthDataType _:
         return HealthDataTypeDto.restingHeartRate;
+      case OvulationTestDataType _:
+        return HealthDataTypeDto.ovulationTest;
       case OxygenSaturationHealthDataType _:
         return HealthDataTypeDto.oxygenSaturation;
       case RespiratoryRateHealthDataType _:

--- a/packages/health_connector_hk_ios/lib/src/mappers/health_record_mappers/health_record_mapper.dart
+++ b/packages/health_connector_hk_ios/lib/src/mappers/health_record_mappers/health_record_mapper.dart
@@ -62,6 +62,7 @@ import 'package:health_connector_core/health_connector_core_internal.dart'
         WeightRecord,
         WheelchairPushesRecord,
         ZincNutrientRecord,
+        OvulationTestRecord,
         OxygenSaturationRecord,
         RespiratoryRateRecord,
         BloodGlucoseRecord,
@@ -88,6 +89,7 @@ import 'package:health_connector_hk_ios/src/mappers/health_record_mappers/hydrat
 import 'package:health_connector_hk_ios/src/mappers/health_record_mappers/lean_body_mass_record_mappers.dart';
 import 'package:health_connector_hk_ios/src/mappers/health_record_mappers/mindfulness_session_record_mappers.dart';
 import 'package:health_connector_hk_ios/src/mappers/health_record_mappers/nutrition_record_mappers.dart';
+import 'package:health_connector_hk_ios/src/mappers/health_record_mappers/ovulation_test_record_mappers.dart';
 import 'package:health_connector_hk_ios/src/mappers/health_record_mappers/oxygen_saturation_record_mappers.dart';
 import 'package:health_connector_hk_ios/src/mappers/health_record_mappers/respiratory_rate_record_mappers.dart';
 import 'package:health_connector_hk_ios/src/mappers/health_record_mappers/resting_heart_rate_record_mappers.dart';
@@ -158,6 +160,7 @@ import 'package:health_connector_hk_ios/src/pigeon/health_connector_hk_ios_api.g
         WeightRecordDto,
         WheelchairPushesRecordDto,
         ZincNutrientRecordDto,
+        OvulationTestRecordDto,
         OxygenSaturationRecordDto,
         RespiratoryRateRecordDto,
         BloodGlucoseRecordDto,
@@ -315,6 +318,8 @@ extension HealthRecordToDto on HealthRecord {
         return SodiumNutrientRecordToDto(record).toDto();
       case final ZincNutrientRecord record:
         return ZincNutrientRecordToDto(record).toDto();
+      case final OvulationTestRecord record:
+        return OvulationTestRecordToDto(record).toDto();
       case final OxygenSaturationRecord record:
         return OxygenSaturationRecordToDto(record).toDto();
       case final RespiratoryRateRecord record:
@@ -493,6 +498,8 @@ extension HealthRecordDtoToDomain on HealthRecordDto {
         return SodiumNutrientRecordDtoToDomain(dto).toDomain();
       case final ZincNutrientRecordDto dto:
         return ZincNutrientRecordDtoToDomain(dto).toDomain();
+      case final OvulationTestRecordDto dto:
+        return OvulationTestRecordDtoToDomain(dto).toDomain();
       case final NutritionRecordDto dto:
         return NutritionRecordDtoToDomain(dto).toDomain();
       case final Vo2MaxRecordDto dto:

--- a/packages/health_connector_hk_ios/lib/src/mappers/health_record_mappers/ovulation_test_record_mappers.dart
+++ b/packages/health_connector_hk_ios/lib/src/mappers/health_record_mappers/ovulation_test_record_mappers.dart
@@ -1,0 +1,38 @@
+import 'package:health_connector_core/health_connector_core_internal.dart';
+import 'package:health_connector_hk_ios/src/mappers/health_record_mappers/health_record_id_mappers.dart';
+import 'package:health_connector_hk_ios/src/mappers/health_record_mappers/ovulation_test_result_type_mappers.dart';
+import 'package:health_connector_hk_ios/src/mappers/metadata_mappers/metadata_mapper.dart';
+import 'package:health_connector_hk_ios/src/pigeon/health_connector_hk_ios_api.g.dart';
+import 'package:meta/meta.dart' show internal;
+
+/// Extension to convert [OvulationTestRecord] to [OvulationTestRecordDto].
+@sinceV2_2_0
+@internal
+extension OvulationTestRecordToDto on OvulationTestRecord {
+  /// Converts [OvulationTestRecord] to [OvulationTestRecordDto].
+  OvulationTestRecordDto toDto() {
+    return OvulationTestRecordDto(
+      id: id.value,
+      metadata: metadata.toDto(),
+      time: time.millisecondsSinceEpoch,
+      zoneOffsetSeconds: zoneOffsetSeconds,
+      result: result.toDto(),
+    );
+  }
+}
+
+/// Extension to convert [OvulationTestRecordDto] to [OvulationTestRecord].
+@sinceV2_2_0
+@internal
+extension OvulationTestRecordDtoToDomain on OvulationTestRecordDto {
+  /// Converts [OvulationTestRecordDto] to [OvulationTestRecord].
+  OvulationTestRecord toDomain() {
+    return OvulationTestRecord(
+      id: id?.toDomain() ?? HealthRecordId.none,
+      metadata: metadata.toDomain(),
+      time: DateTime.fromMillisecondsSinceEpoch(time, isUtc: true).toLocal(),
+      zoneOffsetSeconds: zoneOffsetSeconds,
+      result: result.toDomain(),
+    );
+  }
+}

--- a/packages/health_connector_hk_ios/lib/src/mappers/health_record_mappers/ovulation_test_result_type_mappers.dart
+++ b/packages/health_connector_hk_ios/lib/src/mappers/health_record_mappers/ovulation_test_result_type_mappers.dart
@@ -1,0 +1,40 @@
+import 'package:health_connector_core/health_connector_core_internal.dart';
+import 'package:health_connector_hk_ios/src/pigeon/health_connector_hk_ios_api.g.dart'
+    show OvulationTestResultTypeDto;
+import 'package:meta/meta.dart' show internal;
+
+/// Converts [OvulationTestResultType] to [OvulationTestResultTypeDto].
+@sinceV2_2_0
+@internal
+extension OvulationTestResultTypeToDto on OvulationTestResultType {
+  OvulationTestResultTypeDto toDto() {
+    switch (this) {
+      case OvulationTestResultType.negative:
+        return OvulationTestResultTypeDto.negative;
+      case OvulationTestResultType.inconclusive:
+        return OvulationTestResultTypeDto.inconclusive;
+      case OvulationTestResultType.high:
+        return OvulationTestResultTypeDto.high;
+      case OvulationTestResultType.positive:
+        return OvulationTestResultTypeDto.positive;
+    }
+  }
+}
+
+/// Converts [OvulationTestResultTypeDto] to [OvulationTestResultType].
+@sinceV2_2_0
+@internal
+extension OvulationTestResultTypeDtoToDomain on OvulationTestResultTypeDto {
+  OvulationTestResultType toDomain() {
+    switch (this) {
+      case OvulationTestResultTypeDto.negative:
+        return OvulationTestResultType.negative;
+      case OvulationTestResultTypeDto.inconclusive:
+        return OvulationTestResultType.inconclusive;
+      case OvulationTestResultTypeDto.high:
+        return OvulationTestResultType.high;
+      case OvulationTestResultTypeDto.positive:
+        return OvulationTestResultType.positive;
+    }
+  }
+}

--- a/packages/health_connector_hk_ios/lib/src/pigeon/health_connector_hk_ios_api.g.dart
+++ b/packages/health_connector_hk_ios/lib/src/pigeon/health_connector_hk_ios_api.g.dart
@@ -457,6 +457,24 @@ enum SexualActivityProtectionUsedTypeDto {
   unknown,
 }
 
+/// Ovulation test result classification.
+///
+/// Maps to Android Health Connect OvulationTestRecord result constants
+/// and iOS HealthKit HKCategoryValueOvulationTestResult enum.
+enum OvulationTestResultTypeDto {
+  /// Test result is negative (no hormonal surge).
+  negative,
+
+  /// Test result is inconclusive.
+  inconclusive,
+
+  /// Test result shows high estrogen levels.
+  high,
+
+  /// Test result is positive (LH surge detected).
+  positive,
+}
+
 /// Represents the type of speed-based activity.
 ///
 /// Maps to different iOS HKQuantityTypeIdentifier values.
@@ -824,6 +842,9 @@ enum HealthDataTypeDto {
 
   /// Diastolic blood pressure (HKQuantityType.bloodPressureDiastolic).
   diastolicBloodPressure,
+
+  /// Ovulation test data.
+  ovulationTest,
 
   /// Oxygen saturation data.
   oxygenSaturation,
@@ -3283,6 +3304,73 @@ class OxygenSaturationRecordDto extends HealthRecordDto {
   bool operator ==(Object other) {
     if (other is! OxygenSaturationRecordDto ||
         other.runtimeType != runtimeType) {
+      return false;
+    }
+    if (identical(this, other)) {
+      return true;
+    }
+    return _deepEquals(encode(), other.encode());
+  }
+
+  @override
+  // ignore: avoid_equals_and_hash_code_on_mutable_classes
+  int get hashCode => Object.hashAll(_toList());
+}
+
+/// Represents an ovulation test record for platform transfer.
+class OvulationTestRecordDto extends HealthRecordDto {
+  OvulationTestRecordDto({
+    this.id,
+    required this.metadata,
+    required this.time,
+    this.zoneOffsetSeconds,
+    required this.result,
+  });
+
+  /// Platform-assigned unique identifier.
+  String? id;
+
+  /// Metadata about this record.
+  MetadataDto metadata;
+
+  /// Measurement time in milliseconds since epoch (UTC).
+  int time;
+
+  /// Timezone offset in seconds for measurement time (optional).
+  int? zoneOffsetSeconds;
+
+  /// The ovulation test result.
+  OvulationTestResultTypeDto result;
+
+  List<Object?> _toList() {
+    return <Object?>[
+      id,
+      metadata,
+      time,
+      zoneOffsetSeconds,
+      result,
+    ];
+  }
+
+  Object encode() {
+    return _toList();
+  }
+
+  static OvulationTestRecordDto decode(Object result) {
+    result as List<Object?>;
+    return OvulationTestRecordDto(
+      id: result[0] as String?,
+      metadata: result[1]! as MetadataDto,
+      time: result[2]! as int,
+      zoneOffsetSeconds: result[3] as int?,
+      result: result[4]! as OvulationTestResultTypeDto,
+    );
+  }
+
+  @override
+  // ignore: avoid_equals_and_hash_code_on_mutable_classes
+  bool operator ==(Object other) {
+    if (other is! OvulationTestRecordDto || other.runtimeType != runtimeType) {
       return false;
     }
     if (identical(this, other)) {
@@ -7149,284 +7237,290 @@ class _PigeonCodec extends StandardMessageCodec {
     } else if (value is SexualActivityProtectionUsedTypeDto) {
       buffer.putUint8(155);
       writeValue(buffer, value.index);
-    } else if (value is SpeedActivityTypeDto) {
+    } else if (value is OvulationTestResultTypeDto) {
       buffer.putUint8(156);
       writeValue(buffer, value.index);
-    } else if (value is ExerciseTypeDto) {
+    } else if (value is SpeedActivityTypeDto) {
       buffer.putUint8(157);
       writeValue(buffer, value.index);
-    } else if (value is MindfulnessSessionTypeDto) {
+    } else if (value is ExerciseTypeDto) {
       buffer.putUint8(158);
       writeValue(buffer, value.index);
-    } else if (value is HealthDataTypeDto) {
+    } else if (value is MindfulnessSessionTypeDto) {
       buffer.putUint8(159);
       writeValue(buffer, value.index);
-    } else if (value is AggregationMetricDto) {
+    } else if (value is HealthDataTypeDto) {
       buffer.putUint8(160);
       writeValue(buffer, value.index);
-    } else if (value is BloodGlucoseDto) {
+    } else if (value is AggregationMetricDto) {
       buffer.putUint8(161);
-      writeValue(buffer, value.encode());
-    } else if (value is EnergyDto) {
+      writeValue(buffer, value.index);
+    } else if (value is BloodGlucoseDto) {
       buffer.putUint8(162);
       writeValue(buffer, value.encode());
-    } else if (value is TimeDurationDto) {
+    } else if (value is EnergyDto) {
       buffer.putUint8(163);
       writeValue(buffer, value.encode());
-    } else if (value is LengthDto) {
+    } else if (value is TimeDurationDto) {
       buffer.putUint8(164);
       writeValue(buffer, value.encode());
-    } else if (value is MassDto) {
+    } else if (value is LengthDto) {
       buffer.putUint8(165);
       writeValue(buffer, value.encode());
-    } else if (value is NumberDto) {
+    } else if (value is MassDto) {
       buffer.putUint8(166);
       writeValue(buffer, value.encode());
-    } else if (value is PercentageDto) {
+    } else if (value is NumberDto) {
       buffer.putUint8(167);
       writeValue(buffer, value.encode());
-    } else if (value is PowerDto) {
+    } else if (value is PercentageDto) {
       buffer.putUint8(168);
       writeValue(buffer, value.encode());
-    } else if (value is PressureDto) {
+    } else if (value is PowerDto) {
       buffer.putUint8(169);
       writeValue(buffer, value.encode());
-    } else if (value is TemperatureDto) {
+    } else if (value is PressureDto) {
       buffer.putUint8(170);
       writeValue(buffer, value.encode());
-    } else if (value is VelocityDto) {
+    } else if (value is TemperatureDto) {
       buffer.putUint8(171);
       writeValue(buffer, value.encode());
-    } else if (value is VolumeDto) {
+    } else if (value is VelocityDto) {
       buffer.putUint8(172);
       writeValue(buffer, value.encode());
-    } else if (value is MetadataDto) {
+    } else if (value is VolumeDto) {
       buffer.putUint8(173);
       writeValue(buffer, value.encode());
-    } else if (value is HealthDataPermissionDto) {
+    } else if (value is MetadataDto) {
       buffer.putUint8(174);
       writeValue(buffer, value.encode());
-    } else if (value is RestingHeartRateRecordDto) {
+    } else if (value is HealthDataPermissionDto) {
       buffer.putUint8(175);
       writeValue(buffer, value.encode());
-    } else if (value is Vo2MaxRecordDto) {
+    } else if (value is RestingHeartRateRecordDto) {
       buffer.putUint8(176);
       writeValue(buffer, value.encode());
-    } else if (value is BloodGlucoseRecordDto) {
+    } else if (value is Vo2MaxRecordDto) {
       buffer.putUint8(177);
       writeValue(buffer, value.encode());
-    } else if (value is ExerciseSessionRecordDto) {
+    } else if (value is BloodGlucoseRecordDto) {
       buffer.putUint8(178);
       writeValue(buffer, value.encode());
-    } else if (value is MindfulnessSessionRecordDto) {
+    } else if (value is ExerciseSessionRecordDto) {
       buffer.putUint8(179);
       writeValue(buffer, value.encode());
-    } else if (value is ActiveCaloriesBurnedRecordDto) {
+    } else if (value is MindfulnessSessionRecordDto) {
       buffer.putUint8(180);
       writeValue(buffer, value.encode());
-    } else if (value is DistanceActivityRecordDto) {
+    } else if (value is ActiveCaloriesBurnedRecordDto) {
       buffer.putUint8(181);
       writeValue(buffer, value.encode());
-    } else if (value is SpeedActivityRecordDto) {
+    } else if (value is DistanceActivityRecordDto) {
       buffer.putUint8(182);
       writeValue(buffer, value.encode());
-    } else if (value is FloorsClimbedRecordDto) {
+    } else if (value is SpeedActivityRecordDto) {
       buffer.putUint8(183);
       writeValue(buffer, value.encode());
-    } else if (value is WheelchairPushesRecordDto) {
+    } else if (value is FloorsClimbedRecordDto) {
       buffer.putUint8(184);
       writeValue(buffer, value.encode());
-    } else if (value is StepsRecordDto) {
+    } else if (value is WheelchairPushesRecordDto) {
       buffer.putUint8(185);
       writeValue(buffer, value.encode());
-    } else if (value is WeightRecordDto) {
+    } else if (value is StepsRecordDto) {
       buffer.putUint8(186);
       writeValue(buffer, value.encode());
-    } else if (value is BloodPressureRecordDto) {
+    } else if (value is WeightRecordDto) {
       buffer.putUint8(187);
       writeValue(buffer, value.encode());
-    } else if (value is SystolicBloodPressureRecordDto) {
+    } else if (value is BloodPressureRecordDto) {
       buffer.putUint8(188);
       writeValue(buffer, value.encode());
-    } else if (value is DiastolicBloodPressureRecordDto) {
+    } else if (value is SystolicBloodPressureRecordDto) {
       buffer.putUint8(189);
       writeValue(buffer, value.encode());
-    } else if (value is LeanBodyMassRecordDto) {
+    } else if (value is DiastolicBloodPressureRecordDto) {
       buffer.putUint8(190);
       writeValue(buffer, value.encode());
-    } else if (value is HeightRecordDto) {
+    } else if (value is LeanBodyMassRecordDto) {
       buffer.putUint8(191);
       writeValue(buffer, value.encode());
-    } else if (value is BodyFatPercentageRecordDto) {
+    } else if (value is HeightRecordDto) {
       buffer.putUint8(192);
       writeValue(buffer, value.encode());
-    } else if (value is BodyTemperatureRecordDto) {
+    } else if (value is BodyFatPercentageRecordDto) {
       buffer.putUint8(193);
       writeValue(buffer, value.encode());
-    } else if (value is CervicalMucusRecordDto) {
+    } else if (value is BodyTemperatureRecordDto) {
       buffer.putUint8(194);
       writeValue(buffer, value.encode());
-    } else if (value is CyclingPowerRecordDto) {
+    } else if (value is CervicalMucusRecordDto) {
       buffer.putUint8(195);
       writeValue(buffer, value.encode());
-    } else if (value is OxygenSaturationRecordDto) {
+    } else if (value is CyclingPowerRecordDto) {
       buffer.putUint8(196);
       writeValue(buffer, value.encode());
-    } else if (value is RespiratoryRateRecordDto) {
+    } else if (value is OxygenSaturationRecordDto) {
       buffer.putUint8(197);
       writeValue(buffer, value.encode());
-    } else if (value is HydrationRecordDto) {
+    } else if (value is OvulationTestRecordDto) {
       buffer.putUint8(198);
       writeValue(buffer, value.encode());
-    } else if (value is HeartRateMeasurementDto) {
+    } else if (value is RespiratoryRateRecordDto) {
       buffer.putUint8(199);
       writeValue(buffer, value.encode());
-    } else if (value is HeartRateMeasurementRecordDto) {
+    } else if (value is HydrationRecordDto) {
       buffer.putUint8(200);
       writeValue(buffer, value.encode());
-    } else if (value is CyclingPedalingCadenceMeasurementDto) {
+    } else if (value is HeartRateMeasurementDto) {
       buffer.putUint8(201);
       writeValue(buffer, value.encode());
-    } else if (value is CyclingPedalingCadenceMeasurementRecordDto) {
+    } else if (value is HeartRateMeasurementRecordDto) {
       buffer.putUint8(202);
       writeValue(buffer, value.encode());
-    } else if (value is SleepStageRecordDto) {
+    } else if (value is CyclingPedalingCadenceMeasurementDto) {
       buffer.putUint8(203);
       writeValue(buffer, value.encode());
-    } else if (value is SexualActivityRecordDto) {
+    } else if (value is CyclingPedalingCadenceMeasurementRecordDto) {
       buffer.putUint8(204);
       writeValue(buffer, value.encode());
-    } else if (value is EnergyNutrientRecordDto) {
+    } else if (value is SleepStageRecordDto) {
       buffer.putUint8(205);
       writeValue(buffer, value.encode());
-    } else if (value is CaffeineNutrientRecordDto) {
+    } else if (value is SexualActivityRecordDto) {
       buffer.putUint8(206);
       writeValue(buffer, value.encode());
-    } else if (value is ProteinNutrientRecordDto) {
+    } else if (value is EnergyNutrientRecordDto) {
       buffer.putUint8(207);
       writeValue(buffer, value.encode());
-    } else if (value is TotalCarbohydrateNutrientRecordDto) {
+    } else if (value is CaffeineNutrientRecordDto) {
       buffer.putUint8(208);
       writeValue(buffer, value.encode());
-    } else if (value is TotalFatNutrientRecordDto) {
+    } else if (value is ProteinNutrientRecordDto) {
       buffer.putUint8(209);
       writeValue(buffer, value.encode());
-    } else if (value is SaturatedFatNutrientRecordDto) {
+    } else if (value is TotalCarbohydrateNutrientRecordDto) {
       buffer.putUint8(210);
       writeValue(buffer, value.encode());
-    } else if (value is MonounsaturatedFatNutrientRecordDto) {
+    } else if (value is TotalFatNutrientRecordDto) {
       buffer.putUint8(211);
       writeValue(buffer, value.encode());
-    } else if (value is PolyunsaturatedFatNutrientRecordDto) {
+    } else if (value is SaturatedFatNutrientRecordDto) {
       buffer.putUint8(212);
       writeValue(buffer, value.encode());
-    } else if (value is CholesterolNutrientRecordDto) {
+    } else if (value is MonounsaturatedFatNutrientRecordDto) {
       buffer.putUint8(213);
       writeValue(buffer, value.encode());
-    } else if (value is DietaryFiberNutrientRecordDto) {
+    } else if (value is PolyunsaturatedFatNutrientRecordDto) {
       buffer.putUint8(214);
       writeValue(buffer, value.encode());
-    } else if (value is SugarNutrientRecordDto) {
+    } else if (value is CholesterolNutrientRecordDto) {
       buffer.putUint8(215);
       writeValue(buffer, value.encode());
-    } else if (value is VitaminANutrientRecordDto) {
+    } else if (value is DietaryFiberNutrientRecordDto) {
       buffer.putUint8(216);
       writeValue(buffer, value.encode());
-    } else if (value is VitaminB6NutrientRecordDto) {
+    } else if (value is SugarNutrientRecordDto) {
       buffer.putUint8(217);
       writeValue(buffer, value.encode());
-    } else if (value is VitaminB12NutrientRecordDto) {
+    } else if (value is VitaminANutrientRecordDto) {
       buffer.putUint8(218);
       writeValue(buffer, value.encode());
-    } else if (value is VitaminCNutrientRecordDto) {
+    } else if (value is VitaminB6NutrientRecordDto) {
       buffer.putUint8(219);
       writeValue(buffer, value.encode());
-    } else if (value is VitaminDNutrientRecordDto) {
+    } else if (value is VitaminB12NutrientRecordDto) {
       buffer.putUint8(220);
       writeValue(buffer, value.encode());
-    } else if (value is VitaminENutrientRecordDto) {
+    } else if (value is VitaminCNutrientRecordDto) {
       buffer.putUint8(221);
       writeValue(buffer, value.encode());
-    } else if (value is VitaminKNutrientRecordDto) {
+    } else if (value is VitaminDNutrientRecordDto) {
       buffer.putUint8(222);
       writeValue(buffer, value.encode());
-    } else if (value is ThiaminNutrientRecordDto) {
+    } else if (value is VitaminENutrientRecordDto) {
       buffer.putUint8(223);
       writeValue(buffer, value.encode());
-    } else if (value is RiboflavinNutrientRecordDto) {
+    } else if (value is VitaminKNutrientRecordDto) {
       buffer.putUint8(224);
       writeValue(buffer, value.encode());
-    } else if (value is NiacinNutrientRecordDto) {
+    } else if (value is ThiaminNutrientRecordDto) {
       buffer.putUint8(225);
       writeValue(buffer, value.encode());
-    } else if (value is FolateNutrientRecordDto) {
+    } else if (value is RiboflavinNutrientRecordDto) {
       buffer.putUint8(226);
       writeValue(buffer, value.encode());
-    } else if (value is BiotinNutrientRecordDto) {
+    } else if (value is NiacinNutrientRecordDto) {
       buffer.putUint8(227);
       writeValue(buffer, value.encode());
-    } else if (value is PantothenicAcidNutrientRecordDto) {
+    } else if (value is FolateNutrientRecordDto) {
       buffer.putUint8(228);
       writeValue(buffer, value.encode());
-    } else if (value is CalciumNutrientRecordDto) {
+    } else if (value is BiotinNutrientRecordDto) {
       buffer.putUint8(229);
       writeValue(buffer, value.encode());
-    } else if (value is IronNutrientRecordDto) {
+    } else if (value is PantothenicAcidNutrientRecordDto) {
       buffer.putUint8(230);
       writeValue(buffer, value.encode());
-    } else if (value is MagnesiumNutrientRecordDto) {
+    } else if (value is CalciumNutrientRecordDto) {
       buffer.putUint8(231);
       writeValue(buffer, value.encode());
-    } else if (value is ManganeseNutrientRecordDto) {
+    } else if (value is IronNutrientRecordDto) {
       buffer.putUint8(232);
       writeValue(buffer, value.encode());
-    } else if (value is PhosphorusNutrientRecordDto) {
+    } else if (value is MagnesiumNutrientRecordDto) {
       buffer.putUint8(233);
       writeValue(buffer, value.encode());
-    } else if (value is PotassiumNutrientRecordDto) {
+    } else if (value is ManganeseNutrientRecordDto) {
       buffer.putUint8(234);
       writeValue(buffer, value.encode());
-    } else if (value is SeleniumNutrientRecordDto) {
+    } else if (value is PhosphorusNutrientRecordDto) {
       buffer.putUint8(235);
       writeValue(buffer, value.encode());
-    } else if (value is SodiumNutrientRecordDto) {
+    } else if (value is PotassiumNutrientRecordDto) {
       buffer.putUint8(236);
       writeValue(buffer, value.encode());
-    } else if (value is ZincNutrientRecordDto) {
+    } else if (value is SeleniumNutrientRecordDto) {
       buffer.putUint8(237);
       writeValue(buffer, value.encode());
-    } else if (value is NutritionRecordDto) {
+    } else if (value is SodiumNutrientRecordDto) {
       buffer.putUint8(238);
       writeValue(buffer, value.encode());
-    } else if (value is HealthDataPermissionRequestResultDto) {
+    } else if (value is ZincNutrientRecordDto) {
       buffer.putUint8(239);
       writeValue(buffer, value.encode());
-    } else if (value is PermissionsRequestDto) {
+    } else if (value is NutritionRecordDto) {
       buffer.putUint8(240);
       writeValue(buffer, value.encode());
-    } else if (value is PermissionsRequestResponseDto) {
+    } else if (value is HealthDataPermissionRequestResultDto) {
       buffer.putUint8(241);
       writeValue(buffer, value.encode());
-    } else if (value is AggregateRequestDto) {
+    } else if (value is PermissionsRequestDto) {
       buffer.putUint8(242);
       writeValue(buffer, value.encode());
-    } else if (value is DeleteRecordsByIdsRequestDto) {
+    } else if (value is PermissionsRequestResponseDto) {
       buffer.putUint8(243);
       writeValue(buffer, value.encode());
-    } else if (value is DeleteRecordsByTimeRangeRequestDto) {
+    } else if (value is AggregateRequestDto) {
       buffer.putUint8(244);
       writeValue(buffer, value.encode());
-    } else if (value is ReadRecordRequestDto) {
+    } else if (value is DeleteRecordsByIdsRequestDto) {
       buffer.putUint8(245);
       writeValue(buffer, value.encode());
-    } else if (value is ReadRecordsRequestDto) {
+    } else if (value is DeleteRecordsByTimeRangeRequestDto) {
       buffer.putUint8(246);
       writeValue(buffer, value.encode());
-    } else if (value is ReadRecordsResponseDto) {
+    } else if (value is ReadRecordRequestDto) {
       buffer.putUint8(247);
       writeValue(buffer, value.encode());
-    } else if (value is HealthConnectorConfigDto) {
+    } else if (value is ReadRecordsRequestDto) {
       buffer.putUint8(248);
+      writeValue(buffer, value.encode());
+    } else if (value is ReadRecordsResponseDto) {
+      buffer.putUint8(249);
+      writeValue(buffer, value.encode());
+    } else if (value is HealthConnectorConfigDto) {
+      buffer.putUint8(250);
       writeValue(buffer, value.encode());
     } else {
       super.writeValue(buffer, value);
@@ -7529,196 +7623,201 @@ class _PigeonCodec extends StandardMessageCodec {
             : SexualActivityProtectionUsedTypeDto.values[value];
       case 156:
         final int? value = readValue(buffer) as int?;
-        return value == null ? null : SpeedActivityTypeDto.values[value];
+        return value == null ? null : OvulationTestResultTypeDto.values[value];
       case 157:
         final int? value = readValue(buffer) as int?;
-        return value == null ? null : ExerciseTypeDto.values[value];
+        return value == null ? null : SpeedActivityTypeDto.values[value];
       case 158:
         final int? value = readValue(buffer) as int?;
-        return value == null ? null : MindfulnessSessionTypeDto.values[value];
+        return value == null ? null : ExerciseTypeDto.values[value];
       case 159:
         final int? value = readValue(buffer) as int?;
-        return value == null ? null : HealthDataTypeDto.values[value];
+        return value == null ? null : MindfulnessSessionTypeDto.values[value];
       case 160:
         final int? value = readValue(buffer) as int?;
-        return value == null ? null : AggregationMetricDto.values[value];
+        return value == null ? null : HealthDataTypeDto.values[value];
       case 161:
-        return BloodGlucoseDto.decode(readValue(buffer)!);
+        final int? value = readValue(buffer) as int?;
+        return value == null ? null : AggregationMetricDto.values[value];
       case 162:
-        return EnergyDto.decode(readValue(buffer)!);
+        return BloodGlucoseDto.decode(readValue(buffer)!);
       case 163:
-        return TimeDurationDto.decode(readValue(buffer)!);
+        return EnergyDto.decode(readValue(buffer)!);
       case 164:
-        return LengthDto.decode(readValue(buffer)!);
+        return TimeDurationDto.decode(readValue(buffer)!);
       case 165:
-        return MassDto.decode(readValue(buffer)!);
+        return LengthDto.decode(readValue(buffer)!);
       case 166:
-        return NumberDto.decode(readValue(buffer)!);
+        return MassDto.decode(readValue(buffer)!);
       case 167:
-        return PercentageDto.decode(readValue(buffer)!);
+        return NumberDto.decode(readValue(buffer)!);
       case 168:
-        return PowerDto.decode(readValue(buffer)!);
+        return PercentageDto.decode(readValue(buffer)!);
       case 169:
-        return PressureDto.decode(readValue(buffer)!);
+        return PowerDto.decode(readValue(buffer)!);
       case 170:
-        return TemperatureDto.decode(readValue(buffer)!);
+        return PressureDto.decode(readValue(buffer)!);
       case 171:
-        return VelocityDto.decode(readValue(buffer)!);
+        return TemperatureDto.decode(readValue(buffer)!);
       case 172:
-        return VolumeDto.decode(readValue(buffer)!);
+        return VelocityDto.decode(readValue(buffer)!);
       case 173:
-        return MetadataDto.decode(readValue(buffer)!);
+        return VolumeDto.decode(readValue(buffer)!);
       case 174:
-        return HealthDataPermissionDto.decode(readValue(buffer)!);
+        return MetadataDto.decode(readValue(buffer)!);
       case 175:
-        return RestingHeartRateRecordDto.decode(readValue(buffer)!);
+        return HealthDataPermissionDto.decode(readValue(buffer)!);
       case 176:
-        return Vo2MaxRecordDto.decode(readValue(buffer)!);
+        return RestingHeartRateRecordDto.decode(readValue(buffer)!);
       case 177:
-        return BloodGlucoseRecordDto.decode(readValue(buffer)!);
+        return Vo2MaxRecordDto.decode(readValue(buffer)!);
       case 178:
-        return ExerciseSessionRecordDto.decode(readValue(buffer)!);
+        return BloodGlucoseRecordDto.decode(readValue(buffer)!);
       case 179:
-        return MindfulnessSessionRecordDto.decode(readValue(buffer)!);
+        return ExerciseSessionRecordDto.decode(readValue(buffer)!);
       case 180:
-        return ActiveCaloriesBurnedRecordDto.decode(readValue(buffer)!);
+        return MindfulnessSessionRecordDto.decode(readValue(buffer)!);
       case 181:
-        return DistanceActivityRecordDto.decode(readValue(buffer)!);
+        return ActiveCaloriesBurnedRecordDto.decode(readValue(buffer)!);
       case 182:
-        return SpeedActivityRecordDto.decode(readValue(buffer)!);
+        return DistanceActivityRecordDto.decode(readValue(buffer)!);
       case 183:
-        return FloorsClimbedRecordDto.decode(readValue(buffer)!);
+        return SpeedActivityRecordDto.decode(readValue(buffer)!);
       case 184:
-        return WheelchairPushesRecordDto.decode(readValue(buffer)!);
+        return FloorsClimbedRecordDto.decode(readValue(buffer)!);
       case 185:
-        return StepsRecordDto.decode(readValue(buffer)!);
+        return WheelchairPushesRecordDto.decode(readValue(buffer)!);
       case 186:
-        return WeightRecordDto.decode(readValue(buffer)!);
+        return StepsRecordDto.decode(readValue(buffer)!);
       case 187:
-        return BloodPressureRecordDto.decode(readValue(buffer)!);
+        return WeightRecordDto.decode(readValue(buffer)!);
       case 188:
-        return SystolicBloodPressureRecordDto.decode(readValue(buffer)!);
+        return BloodPressureRecordDto.decode(readValue(buffer)!);
       case 189:
-        return DiastolicBloodPressureRecordDto.decode(readValue(buffer)!);
+        return SystolicBloodPressureRecordDto.decode(readValue(buffer)!);
       case 190:
-        return LeanBodyMassRecordDto.decode(readValue(buffer)!);
+        return DiastolicBloodPressureRecordDto.decode(readValue(buffer)!);
       case 191:
-        return HeightRecordDto.decode(readValue(buffer)!);
+        return LeanBodyMassRecordDto.decode(readValue(buffer)!);
       case 192:
-        return BodyFatPercentageRecordDto.decode(readValue(buffer)!);
+        return HeightRecordDto.decode(readValue(buffer)!);
       case 193:
-        return BodyTemperatureRecordDto.decode(readValue(buffer)!);
+        return BodyFatPercentageRecordDto.decode(readValue(buffer)!);
       case 194:
-        return CervicalMucusRecordDto.decode(readValue(buffer)!);
+        return BodyTemperatureRecordDto.decode(readValue(buffer)!);
       case 195:
-        return CyclingPowerRecordDto.decode(readValue(buffer)!);
+        return CervicalMucusRecordDto.decode(readValue(buffer)!);
       case 196:
-        return OxygenSaturationRecordDto.decode(readValue(buffer)!);
+        return CyclingPowerRecordDto.decode(readValue(buffer)!);
       case 197:
-        return RespiratoryRateRecordDto.decode(readValue(buffer)!);
+        return OxygenSaturationRecordDto.decode(readValue(buffer)!);
       case 198:
-        return HydrationRecordDto.decode(readValue(buffer)!);
+        return OvulationTestRecordDto.decode(readValue(buffer)!);
       case 199:
-        return HeartRateMeasurementDto.decode(readValue(buffer)!);
+        return RespiratoryRateRecordDto.decode(readValue(buffer)!);
       case 200:
-        return HeartRateMeasurementRecordDto.decode(readValue(buffer)!);
+        return HydrationRecordDto.decode(readValue(buffer)!);
       case 201:
-        return CyclingPedalingCadenceMeasurementDto.decode(readValue(buffer)!);
+        return HeartRateMeasurementDto.decode(readValue(buffer)!);
       case 202:
+        return HeartRateMeasurementRecordDto.decode(readValue(buffer)!);
+      case 203:
+        return CyclingPedalingCadenceMeasurementDto.decode(readValue(buffer)!);
+      case 204:
         return CyclingPedalingCadenceMeasurementRecordDto.decode(
           readValue(buffer)!,
         );
-      case 203:
-        return SleepStageRecordDto.decode(readValue(buffer)!);
-      case 204:
-        return SexualActivityRecordDto.decode(readValue(buffer)!);
       case 205:
-        return EnergyNutrientRecordDto.decode(readValue(buffer)!);
+        return SleepStageRecordDto.decode(readValue(buffer)!);
       case 206:
-        return CaffeineNutrientRecordDto.decode(readValue(buffer)!);
+        return SexualActivityRecordDto.decode(readValue(buffer)!);
       case 207:
-        return ProteinNutrientRecordDto.decode(readValue(buffer)!);
+        return EnergyNutrientRecordDto.decode(readValue(buffer)!);
       case 208:
-        return TotalCarbohydrateNutrientRecordDto.decode(readValue(buffer)!);
+        return CaffeineNutrientRecordDto.decode(readValue(buffer)!);
       case 209:
-        return TotalFatNutrientRecordDto.decode(readValue(buffer)!);
+        return ProteinNutrientRecordDto.decode(readValue(buffer)!);
       case 210:
-        return SaturatedFatNutrientRecordDto.decode(readValue(buffer)!);
+        return TotalCarbohydrateNutrientRecordDto.decode(readValue(buffer)!);
       case 211:
-        return MonounsaturatedFatNutrientRecordDto.decode(readValue(buffer)!);
+        return TotalFatNutrientRecordDto.decode(readValue(buffer)!);
       case 212:
-        return PolyunsaturatedFatNutrientRecordDto.decode(readValue(buffer)!);
+        return SaturatedFatNutrientRecordDto.decode(readValue(buffer)!);
       case 213:
-        return CholesterolNutrientRecordDto.decode(readValue(buffer)!);
+        return MonounsaturatedFatNutrientRecordDto.decode(readValue(buffer)!);
       case 214:
-        return DietaryFiberNutrientRecordDto.decode(readValue(buffer)!);
+        return PolyunsaturatedFatNutrientRecordDto.decode(readValue(buffer)!);
       case 215:
-        return SugarNutrientRecordDto.decode(readValue(buffer)!);
+        return CholesterolNutrientRecordDto.decode(readValue(buffer)!);
       case 216:
-        return VitaminANutrientRecordDto.decode(readValue(buffer)!);
+        return DietaryFiberNutrientRecordDto.decode(readValue(buffer)!);
       case 217:
-        return VitaminB6NutrientRecordDto.decode(readValue(buffer)!);
+        return SugarNutrientRecordDto.decode(readValue(buffer)!);
       case 218:
-        return VitaminB12NutrientRecordDto.decode(readValue(buffer)!);
+        return VitaminANutrientRecordDto.decode(readValue(buffer)!);
       case 219:
-        return VitaminCNutrientRecordDto.decode(readValue(buffer)!);
+        return VitaminB6NutrientRecordDto.decode(readValue(buffer)!);
       case 220:
-        return VitaminDNutrientRecordDto.decode(readValue(buffer)!);
+        return VitaminB12NutrientRecordDto.decode(readValue(buffer)!);
       case 221:
-        return VitaminENutrientRecordDto.decode(readValue(buffer)!);
+        return VitaminCNutrientRecordDto.decode(readValue(buffer)!);
       case 222:
-        return VitaminKNutrientRecordDto.decode(readValue(buffer)!);
+        return VitaminDNutrientRecordDto.decode(readValue(buffer)!);
       case 223:
-        return ThiaminNutrientRecordDto.decode(readValue(buffer)!);
+        return VitaminENutrientRecordDto.decode(readValue(buffer)!);
       case 224:
-        return RiboflavinNutrientRecordDto.decode(readValue(buffer)!);
+        return VitaminKNutrientRecordDto.decode(readValue(buffer)!);
       case 225:
-        return NiacinNutrientRecordDto.decode(readValue(buffer)!);
+        return ThiaminNutrientRecordDto.decode(readValue(buffer)!);
       case 226:
-        return FolateNutrientRecordDto.decode(readValue(buffer)!);
+        return RiboflavinNutrientRecordDto.decode(readValue(buffer)!);
       case 227:
-        return BiotinNutrientRecordDto.decode(readValue(buffer)!);
+        return NiacinNutrientRecordDto.decode(readValue(buffer)!);
       case 228:
-        return PantothenicAcidNutrientRecordDto.decode(readValue(buffer)!);
+        return FolateNutrientRecordDto.decode(readValue(buffer)!);
       case 229:
-        return CalciumNutrientRecordDto.decode(readValue(buffer)!);
+        return BiotinNutrientRecordDto.decode(readValue(buffer)!);
       case 230:
-        return IronNutrientRecordDto.decode(readValue(buffer)!);
+        return PantothenicAcidNutrientRecordDto.decode(readValue(buffer)!);
       case 231:
-        return MagnesiumNutrientRecordDto.decode(readValue(buffer)!);
+        return CalciumNutrientRecordDto.decode(readValue(buffer)!);
       case 232:
-        return ManganeseNutrientRecordDto.decode(readValue(buffer)!);
+        return IronNutrientRecordDto.decode(readValue(buffer)!);
       case 233:
-        return PhosphorusNutrientRecordDto.decode(readValue(buffer)!);
+        return MagnesiumNutrientRecordDto.decode(readValue(buffer)!);
       case 234:
-        return PotassiumNutrientRecordDto.decode(readValue(buffer)!);
+        return ManganeseNutrientRecordDto.decode(readValue(buffer)!);
       case 235:
-        return SeleniumNutrientRecordDto.decode(readValue(buffer)!);
+        return PhosphorusNutrientRecordDto.decode(readValue(buffer)!);
       case 236:
-        return SodiumNutrientRecordDto.decode(readValue(buffer)!);
+        return PotassiumNutrientRecordDto.decode(readValue(buffer)!);
       case 237:
-        return ZincNutrientRecordDto.decode(readValue(buffer)!);
+        return SeleniumNutrientRecordDto.decode(readValue(buffer)!);
       case 238:
-        return NutritionRecordDto.decode(readValue(buffer)!);
+        return SodiumNutrientRecordDto.decode(readValue(buffer)!);
       case 239:
-        return HealthDataPermissionRequestResultDto.decode(readValue(buffer)!);
+        return ZincNutrientRecordDto.decode(readValue(buffer)!);
       case 240:
-        return PermissionsRequestDto.decode(readValue(buffer)!);
+        return NutritionRecordDto.decode(readValue(buffer)!);
       case 241:
-        return PermissionsRequestResponseDto.decode(readValue(buffer)!);
+        return HealthDataPermissionRequestResultDto.decode(readValue(buffer)!);
       case 242:
-        return AggregateRequestDto.decode(readValue(buffer)!);
+        return PermissionsRequestDto.decode(readValue(buffer)!);
       case 243:
-        return DeleteRecordsByIdsRequestDto.decode(readValue(buffer)!);
+        return PermissionsRequestResponseDto.decode(readValue(buffer)!);
       case 244:
-        return DeleteRecordsByTimeRangeRequestDto.decode(readValue(buffer)!);
+        return AggregateRequestDto.decode(readValue(buffer)!);
       case 245:
-        return ReadRecordRequestDto.decode(readValue(buffer)!);
+        return DeleteRecordsByIdsRequestDto.decode(readValue(buffer)!);
       case 246:
-        return ReadRecordsRequestDto.decode(readValue(buffer)!);
+        return DeleteRecordsByTimeRangeRequestDto.decode(readValue(buffer)!);
       case 247:
-        return ReadRecordsResponseDto.decode(readValue(buffer)!);
+        return ReadRecordRequestDto.decode(readValue(buffer)!);
       case 248:
+        return ReadRecordsRequestDto.decode(readValue(buffer)!);
+      case 249:
+        return ReadRecordsResponseDto.decode(readValue(buffer)!);
+      case 250:
         return HealthConnectorConfigDto.decode(readValue(buffer)!);
       default:
         return super.readValueOfType(type, buffer);

--- a/packages/health_connector_hk_ios/pigeons/health_connector_hk_ios_api.dart
+++ b/packages/health_connector_hk_ios/pigeons/health_connector_hk_ios_api.dart
@@ -602,6 +602,24 @@ enum SexualActivityProtectionUsedTypeDto {
   unknown,
 }
 
+/// Ovulation test result classification.
+///
+/// Maps to Android Health Connect OvulationTestRecord result constants
+/// and iOS HealthKit HKCategoryValueOvulationTestResult enum.
+enum OvulationTestResultTypeDto {
+  /// Test result is negative (no hormonal surge).
+  negative,
+
+  /// Test result is inconclusive.
+  inconclusive,
+
+  /// Test result shows high estrogen levels.
+  high,
+
+  /// Test result is positive (LH surge detected).
+  positive,
+}
+
 /// Represents the type of speed-based activity.
 ///
 /// Maps to different iOS HKQuantityTypeIdentifier values.
@@ -977,6 +995,9 @@ enum HealthDataTypeDto {
 
   /// Diastolic blood pressure (HKQuantityType.bloodPressureDiastolic).
   diastolicBloodPressure,
+
+  /// Ovulation test data.
+  ovulationTest,
 
   /// Oxygen saturation data.
   oxygenSaturation,
@@ -1708,6 +1729,32 @@ class OxygenSaturationRecordDto extends HealthRecordDto {
 
   /// Timezone offset in seconds for measurement time (optional).
   final int? zoneOffsetSeconds;
+}
+
+/// Represents an ovulation test record for platform transfer.
+class OvulationTestRecordDto extends HealthRecordDto {
+  OvulationTestRecordDto({
+    required this.id,
+    required this.metadata,
+    required this.time,
+    required this.result,
+    this.zoneOffsetSeconds,
+  });
+
+  /// Platform-assigned unique identifier.
+  final String? id;
+
+  /// Metadata about this record.
+  final MetadataDto metadata;
+
+  /// Measurement time in milliseconds since epoch (UTC).
+  final int time;
+
+  /// Timezone offset in seconds for measurement time (optional).
+  final int? zoneOffsetSeconds;
+
+  /// The ovulation test result.
+  final OvulationTestResultTypeDto result;
 }
 
 /// Represents a respiratory rate record for platform transfer.


### PR DESCRIPTION
### **PR Type**
Enhancement


___

### **Description**
- Add comprehensive support for ovulation test result data type across the health connector ecosystem

- Implement `OvulationTestRecord` domain model and `OvulationTestResultType` enum for fertility tracking with four result states (negative, inconclusive, high, positive)

- Create `OvulationTestDataType` supporting read by ID/time range, write, and delete operations (no aggregation)

- Add platform-specific implementations for iOS HealthKit and Android Health Connect with full bidirectional mapping

- Implement Swift handler (`OvulationTestHandler`) for iOS with `HKCategorySample` conversion

- Implement Kotlin handler (`OvulationTestHandler`) for Android with Health Connect record conversion

- Generate pigeon code for both platforms with proper DTO serialization/deserialization

- Add UI support in example toolbox with text constants, icons, and result type display extensions

- Update README with guidance for adding new health data types


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["OvulationTestRecord<br/>Domain Model"] --> B["OvulationTestDataType<br/>Health Data Type"]
  A --> C["OvulationTestResultType<br/>Enum"]
  B --> D["iOS HealthKit<br/>Integration"]
  B --> E["Android Health Connect<br/>Integration"]
  D --> F["OvulationTestHandler<br/>Swift"]
  D --> G["OvulationTestRecordMapper<br/>Swift"]
  E --> H["OvulationTestHandler<br/>Kotlin"]
  E --> I["OvulationTestRecordMappers<br/>Kotlin"]
  F --> J["HKCategorySample<br/>Conversion"]
  H --> K["Health Connect Record<br/>Conversion"]
  L["UI Components<br/>Toolbox"] --> M["Text Constants<br/>Icons<br/>Extensions"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><details><summary>40 files</summary><table>
<tr>
  <td>
    <details>
      <summary><strong>ovulation_test_record.dart</strong><dd><code>Add OvulationTestRecord domain model for fertility tracking</code></dd></summary>
<hr>

packages/health_connector_core/lib/src/models/health_records/ovulation_test/ovulation_test_record.dart

<ul><li>New file introducing <code>OvulationTestRecord</code> class extending <br><code>InstantHealthRecord</code><br> <li> Captures ovulation test results (negative, inconclusive, high, <br>positive) at specific timestamps<br> <li> Includes <code>copyWith</code> method and equality/hash implementations<br> <li> Provides comprehensive documentation with platform mapping and usage <br>examples</ul>


</details>


  </td>
  <td><a href="https://github.com/fam-tung-lam/health_connector/pull/57/files#diff-54a55fdf1575b433552168ab9580903a59b0910dbb94b272ccf00306e5c86ef4">+96/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>ovulation_test_result_type.dart</strong><dd><code>Add OvulationTestResultType enum for test outcomes</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/health_connector_core/lib/src/models/health_records/ovulation_test/ovulation_test_result_type.dart

<ul><li>New enum <code>OvulationTestResultType</code> with four values: negative, <br>inconclusive, high, positive<br> <li> Maps to Android Health Connect and iOS HealthKit ovulation test result <br>types<br> <li> Includes detailed documentation for each result type</ul>


</details>


  </td>
  <td><a href="https://github.com/fam-tung-lam/health_connector/pull/57/files#diff-df04a9b6c2fa9f74c39618bf52c3a88ee7e98eb18c62dff730a215f8e2f70e9d">+29/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>ovulation_test_data_type.dart</strong><dd><code>Add OvulationTestDataType for health data operations</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/health_connector_core/lib/src/models/health_data_types/ovulation_test_data_type.dart

<ul><li>New <code>OvulationTestDataType</code> class implementing readable, writeable, and <br>deletable interfaces<br> <li> Supports reading by ID and time range, writing, and deletion <br>operations<br> <li> No aggregation support for categorical data<br> <li> Includes comprehensive documentation and usage examples</ul>


</details>


  </td>
  <td><a href="https://github.com/fam-tung-lam/health_connector/pull/57/files#diff-b3c26b487bc41bbc7663ce9016b3c046200a183fe21310d324db9cbdc48c9e23">+134/-0</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>health_data_type.dart</strong><dd><code>Register OvulationTestDataType in HealthDataType registry</code></dd></summary>
<hr>

packages/health_connector_core/lib/src/models/health_data_types/health_data_type.dart

<ul><li>Added import for <code>OvulationTestRecord</code><br> <li> Added part file import for <code>ovulation_test_data_type.dart</code><br> <li> Added static constant <code>ovulationTest</code> to <code>HealthDataType</code> sealed class<br> <li> Added <code>ovulationTest</code> to the list of all data types</ul>


</details>


  </td>
  <td><a href="https://github.com/fam-tung-lam/health_connector/pull/57/files#diff-a63f9d9a8b5068195f097bbbca8936cfb2e8902a5d761ee84275698bf196bb3a">+11/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>health_record.dart</strong><dd><code>Add ovulation test record parts to health_record module</code>&nbsp; &nbsp; </dd></summary>
<hr>

packages/health_connector_core/lib/src/models/health_records/health_record.dart

<ul><li>Added part file imports for <code>ovulation_test_record.dart</code> and <br><code>ovulation_test_result_type.dart</code></ul>


</details>


  </td>
  <td><a href="https://github.com/fam-tung-lam/health_connector/pull/57/files#diff-e6f4b4712636a917da8e259645e678d401aa3fb1c27198b9236e11a0192ee55d">+2/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>health_record_data_type_extension.dart</strong><dd><code>Update pattern matching and add ovulation test mapping</code>&nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/health_connector_core/lib/src/utils/health_record_data_type_extension.dart

<ul><li>Updated pattern matching syntax from <code>ClassName()</code> to <code>ClassName _</code> for <br>all record types<br> <li> Added case for <code>OvulationTestRecord _</code> mapping to <br><code>HealthDataType.ovulationTest</code><br> <li> Maintains consistent pattern matching style across extension</ul>


</details>


  </td>
  <td><a href="https://github.com/fam-tung-lam/health_connector/pull/57/files#diff-e10b12805d52a227284da241f3b9126f622d7ff177368acbc66af8131b53ffc6">+81/-80</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>health_connector_hk_ios_api.dart</strong><dd><code>Add ovulation test DTOs for iOS platform interface</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/health_connector_hk_ios/pigeons/health_connector_hk_ios_api.dart

<ul><li>Added <code>OvulationTestResultTypeDto</code> enum with four values (negative, <br>inconclusive, high, positive)<br> <li> Added <code>OvulationTestRecordDto</code> class with id, metadata, time, <br>zoneOffsetSeconds, and result fields<br> <li> Added <code>ovulationTest</code> to <code>HealthDataTypeDto</code> enum</ul>


</details>


  </td>
  <td><a href="https://github.com/fam-tung-lam/health_connector/pull/57/files#diff-2ba85ae98b6f41e793ad4b7c5e66ae028097b221f56db46e557be72d8645e2db">+47/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>health_connector_hk_ios_api.g.dart</strong><dd><code>Generate iOS pigeon code for ovulation test support</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/health_connector_hk_ios/lib/src/pigeon/health_connector_hk_ios_api.g.dart

<ul><li>Generated code for <code>OvulationTestResultTypeDto</code> enum with documentation<br> <li> Generated <code>OvulationTestRecordDto</code> class with encode/decode methods and <br>equality operators<br> <li> Added <code>ovulationTest</code> to <code>HealthDataTypeDto</code> enum<br> <li> Updated codec type IDs, shifting all subsequent types by 1 (156 for <br>new enum, 198 for new record)</ul>


</details>


  </td>
  <td><a href="https://github.com/fam-tung-lam/health_connector/pull/57/files#diff-9ad05626e79e8f46ffae298de63c6a7c5722d1fb5648fbe2afd1f3120da342f0">+284/-185</a></td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>health_connector_hc_android_api.dart</strong><dd><code>Add ovulation test DTOs for Android platform interface</code>&nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/health_connector_hc_android/pigeons/health_connector_hc_android_api.dart

<ul><li>Added <code>OvulationTestResultTypeDto</code> enum with four values (negative, <br>inconclusive, high, positive)<br> <li> Added <code>OvulationTestRecordDto</code> class with id, metadata, time, <br>zoneOffsetSeconds, and result fields<br> <li> Added <code>ovulationTest</code> to <code>HealthDataTypeDto</code> enum</ul>


</details>


  </td>
  <td><a href="https://github.com/fam-tung-lam/health_connector/pull/57/files#diff-94b53bdf5324682c4271d77979aab294e56468fa03aed4e47f457cb47037cbf9">+47/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>health_connector_hc_android_api.g.dart</strong><dd><code>Generate Android pigeon code for ovulation test support</code>&nbsp; &nbsp; </dd></summary>
<hr>

packages/health_connector_hc_android/lib/src/pigeon/health_connector_hc_android_api.g.dart

<ul><li>Generated code for <code>OvulationTestResultTypeDto</code> enum with documentation<br> <li> Generated <code>OvulationTestRecordDto</code> class with encode/decode methods and <br>equality operators<br> <li> Added <code>ovulationTest</code> to <code>HealthDataTypeDto</code> enum<br> <li> Updated codec type IDs, shifting all subsequent types by 1 (157 for <br>new enum, 180 for new record)</ul>


</details>


  </td>
  <td><a href="https://github.com/fam-tung-lam/health_connector/pull/57/files#diff-d756b64a1ed711851582d2a643d79e51d3b0456b5558db0d3352196bb92d9fcc">+228/-129</a></td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>health_data_type_mappers.dart</strong><dd><code>Add ovulation test data type mapping for iOS</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/health_connector_hk_ios/lib/src/mappers/health_data_type_mappers.dart

<ul><li>Added import for <code>OvulationTestDataType</code><br> <li> Added mapping from <code>HealthDataTypeDto.ovulationTest</code> to <br><code>HealthDataType.ovulationTest</code> in both directions</ul>


</details>


  </td>
  <td><a href="https://github.com/fam-tung-lam/health_connector/pull/57/files#diff-6db3360a631b968136d46dc7cf3368e40eed4e14448803afd68bd6077e483b05">+5/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>health_data_type_mappers.dart</strong><dd><code>Add ovulation test data type mapping for Android</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/health_connector_hc_android/lib/src/mappers/health_data_type_mappers.dart

<ul><li>Added import for <code>OvulationTestDataType</code><br> <li> Added mapping from <code>HealthDataTypeDto.ovulationTest</code> to <br><code>HealthDataType.ovulationTest</code> in both directions</ul>


</details>


  </td>
  <td><a href="https://github.com/fam-tung-lam/health_connector/pull/57/files#diff-0b9e5d0773ed274409d9e39de40bdf4ad88152ae2c90bc551d2bfc0bf0d13f53">+5/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>health_record_mapper.dart</strong><dd><code>Add ovulation test record mapping for iOS</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/health_connector_hk_ios/lib/src/mappers/health_record_mappers/health_record_mapper.dart

<ul><li>Added imports for <code>OvulationTestRecord</code>, <code>OvulationTestRecordDto</code>, and <br>ovulation test record mappers<br> <li> Added conversion cases for <code>OvulationTestRecord</code> to/from <br><code>OvulationTestRecordDto</code> in extension methods</ul>


</details>


  </td>
  <td><a href="https://github.com/fam-tung-lam/health_connector/pull/57/files#diff-59d0fb8b80a308ae0936763493a0d34325670e41e6ff8fad4fdaa75e883141e7">+7/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>health_record_mapper.dart</strong><dd><code>Add ovulation test record mapping for Android</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/health_connector_hc_android/lib/src/mappers/health_record_mappers/health_record_mapper.dart

<ul><li>Added imports for <code>OvulationTestRecord</code>, <code>OvulationTestRecordDto</code>, and <br>ovulation test record mappers<br> <li> Added conversion cases for <code>OvulationTestRecord</code> to/from <br><code>OvulationTestRecordDto</code> in extension methods</ul>


</details>


  </td>
  <td><a href="https://github.com/fam-tung-lam/health_connector/pull/57/files#diff-a25ffea74b1a218846cbbe304a04d5dc1540607471cf2281f3d1b10c1b76124f">+7/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>ovulation_test_record_mappers.dart</strong><dd><code>Add ovulation test record mappers for iOS</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/health_connector_hk_ios/lib/src/mappers/health_record_mappers/ovulation_test_record_mappers.dart

<ul><li>New file with extensions to convert <code>OvulationTestRecord</code> to/from <br><code>OvulationTestRecordDto</code><br> <li> Handles id, metadata, time, zoneOffsetSeconds, and result field <br>conversions<br> <li> Includes proper timestamp conversion between milliseconds and DateTime</ul>


</details>


  </td>
  <td><a href="https://github.com/fam-tung-lam/health_connector/pull/57/files#diff-506011b388a4e5d2ef7a89eaa5d4fb2ab0369acd18c7f9c0fabb255274f804d9">+38/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>ovulation_test_record_mappers.dart</strong><dd><code>Add ovulation test record mappers for Android</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/health_connector_hc_android/lib/src/mappers/health_record_mappers/ovulation_test_record_mappers.dart

<ul><li>New file with extensions to convert <code>OvulationTestRecord</code> to/from <br><code>OvulationTestRecordDto</code><br> <li> Handles id, metadata, time, zoneOffsetSeconds, and result field <br>conversions<br> <li> Includes proper timestamp conversion between milliseconds and DateTime</ul>


</details>


  </td>
  <td><a href="https://github.com/fam-tung-lam/health_connector/pull/57/files#diff-08dbf42fad1ad96baa4f4416044b31629f7be448f4e279122c9978e25180effb">+38/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>ovulation_test_result_type_mappers.dart</strong><dd><code>Add ovulation test result type mappers for iOS</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/health_connector_hk_ios/lib/src/mappers/health_record_mappers/ovulation_test_result_type_mappers.dart

<ul><li>New file with extensions to convert <code>OvulationTestResultType</code> to/from <br><code>OvulationTestResultTypeDto</code><br> <li> Maps between domain enum and DTO enum values</ul>


</details>


  </td>
  <td><a href="https://github.com/fam-tung-lam/health_connector/pull/57/files#diff-649ba50b8658f27ee9c8c64b56ae0d9ec7f0dff5818e4554a243b45fbbea86a5">+40/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>ovulation_test_result_type_mappers.dart</strong><dd><code>Add ovulation test result type mappers for Android</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/health_connector_hc_android/lib/src/mappers/health_record_mappers/ovulation_test_result_type_mappers.dart

<ul><li>New file with extensions to convert <code>OvulationTestResultType</code> to/from <br><code>OvulationTestResultTypeDto</code><br> <li> Maps between domain enum and DTO enum values</ul>


</details>


  </td>
  <td><a href="https://github.com/fam-tung-lam/health_connector/pull/57/files#diff-59ce997bb6616dc7cf4e93053165b841bfc07df4bdde1922b393cc7a704cfddd">+40/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>aggregate_request_mapper.dart</strong><dd><code>Mark ovulation test as non-aggregatable in Android</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/health_connector_hc_android/lib/src/mappers/request_and_response_mappers/aggregate_request_mapper.dart

<ul><li>Added import for <code>OvulationTestDataType</code><br> <li> Added case for <code>OvulationTestDataType</code> in aggregation validation to <br>throw unsupported error</ul>


</details>


  </td>
  <td><a href="https://github.com/fam-tung-lam/health_connector/pull/57/files#diff-8492500425e410df1bfac0fd61cbd51d801bd9e29141ca13ab932d2ccd85ceaf">+2/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>OvulationTestHandler.swift</strong><dd><code>Add OvulationTestHandler for iOS HealthKit integration</code>&nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/health_connector_hk_ios/ios/health_connector_hk_ios/Sources/health_connector_hk_ios/handlers/health_record_handlers/OvulationTestHandler.swift

<ul><li>New Swift handler implementing readable, writable, and deletable <br>protocols<br> <li> Handles <code>OvulationTestRecordDto</code> and <code>HKCategorySample</code> conversions<br> <li> Registered with <code>HealthRecordHandlerRegistry</code></ul>


</details>


  </td>
  <td><a href="https://github.com/fam-tung-lam/health_connector/pull/57/files#diff-036ea4ed875df47fa7337fd64ed5dd695da7980244978652a9471357405b75e6">+20/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>OvulationTestRecordMapper.swift</strong><dd><code>Add OvulationTestRecordMapper for iOS HealthKit conversion</code></dd></summary>
<hr>

packages/health_connector_hk_ios/ios/health_connector_hk_ios/Sources/health_connector_hk_ios/mappers/health_record_mappers/OvulationTestRecordMapper.swift

<ul><li>New file with bidirectional conversion between <code>HKCategorySample</code> and <br><code>OvulationTestRecordDto</code><br> <li> Implements enum mapping between <code>HKCategoryValueOvulationTestResult</code> and <br><code>OvulationTestResultTypeDto</code><br> <li> Handles metadata extraction and timezone offset conversion</ul>


</details>


  </td>
  <td><a href="https://github.com/fam-tung-lam/health_connector/pull/57/files#diff-421107ac783c7e48c8a60201e5c77b1b04a2bd17406f09367ddab30e008b01dc">+105/-0</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>HealthDataTypeMapper.swift</strong><dd><code>Add ovulation test data type mapping in iOS HealthKit</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/health_connector_hk_ios/ios/health_connector_hk_ios/Sources/health_connector_hk_ios/mappers/HealthDataTypeMapper.swift

<ul><li>Added case for <code>HealthDataTypeDto.ovulationTest</code> mapping to <br><code>HKCategoryType.ovulationTestResult</code></ul>


</details>


  </td>
  <td><a href="https://github.com/fam-tung-lam/health_connector/pull/57/files#diff-7d603469e29dfaa590f688e14dc316d94744728e659522148b9bec98110efe89">+2/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>HealthKitExtensions.swift</strong><dd><code>Add ovulation test identifier mapping in iOS extensions</code>&nbsp; &nbsp; </dd></summary>
<hr>

packages/health_connector_hk_ios/ios/health_connector_hk_ios/Sources/health_connector_hk_ios/utils/HealthKitExtensions.swift

<ul><li>Added case for <code>HKCategoryTypeIdentifier.ovulationTestResult</code> mapping to <br><code>HealthDataTypeDto.ovulationTest</code></ul>


</details>


  </td>
  <td><a href="https://github.com/fam-tung-lam/health_connector/pull/57/files#diff-bd36f05330e930c5bcdd68407566997ed46ee65e7c0ec92144aa2497079796fa">+2/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>HealthConnectorDtoExtensions.swift</strong><dd><code>Add ovulation test DTO extension methods for iOS</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/health_connector_hk_ios/ios/health_connector_hk_ios/Sources/health_connector_hk_ios/utils/HealthConnectorDtoExtensions.swift

<ul><li>Added case for <code>OvulationTestRecordDto</code> to extract id<br> <li> Added case for <code>OvulationTestRecordDto</code> to return <br><code>HealthDataTypeDto.ovulationTest</code><br> <li> Added case for <code>OvulationTestRecordDto</code> to extract time</ul>


</details>


  </td>
  <td><a href="https://github.com/fam-tung-lam/health_connector/pull/57/files#diff-90d0c007e472618edd33163a9caafe80d4ea9d84f55c25b1c8075cb371a34287">+6/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>HealthRecordMapper.swift</strong><dd><code>Add ovulation test conversion in iOS HealthRecordMapper</code>&nbsp; &nbsp; </dd></summary>
<hr>

packages/health_connector_hk_ios/ios/health_connector_hk_ios/Sources/health_connector_hk_ios/mappers/health_record_mappers/HealthRecordMapper.swift

<ul><li>Added case for <code>OvulationTestRecordDto</code> to convert to HealthKit<br> <li> Added case for <code>HKCategorySample</code> with <code>ovulationTest</code> data type to <br>convert to DTO</ul>


</details>


  </td>
  <td><a href="https://github.com/fam-tung-lam/health_connector/pull/57/files#diff-35b9e7b3d62e5cb54566ea2f201fe53433b28ac161abf3a47fbd7e4fbd1006e3">+4/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>PermissionMapper.swift</strong><dd><code>Add ovulation test permission mapping for iOS</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/health_connector_hk_ios/ios/health_connector_hk_ios/Sources/health_connector_hk_ios/mappers/PermissionMapper.swift

<ul><li>Added <code>ovulationTest</code> case alongside <code>cervicalMucus</code> in permission mapping</ul>


</details>


  </td>
  <td><a href="https://github.com/fam-tung-lam/health_connector/pull/57/files#diff-c8e19aebb547f44b885902ee5e16ad967277866c4f7ca80207a994c38fa3fd64">+2/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>HealthRecordHandlerRegistry.swift</strong><dd><code>Register OvulationTestHandler in iOS handler registry</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/health_connector_hk_ios/ios/health_connector_hk_ios/Sources/health_connector_hk_ios/handlers/HealthRecordHandlerRegistry.swift

- Registered `OvulationTestHandler` in the handler registry


</details>


  </td>
  <td><a href="https://github.com/fam-tung-lam/health_connector/pull/57/files#diff-442a14ebe63740bb24123c460cd6f2c8a474f1425793aaad0037a80dfe9540e1">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>HealthRecordHandlerRegistry.kt</strong><dd><code>Register OvulationTestHandler in Android handler registry</code></dd></summary>
<hr>

packages/health_connector_hc_android/android/src/main/kotlin/com/phamtunglam/health_connector_hc_android/handlers/HealthRecordHandlerRegistry.kt

<ul><li>Added import for <code>OvulationTestHandler</code><br> <li> Registered <code>OvulationTestHandler</code> in the handler registry</ul>


</details>


  </td>
  <td><a href="https://github.com/fam-tung-lam/health_connector/pull/57/files#diff-8617d12bf79dc3b6bc33579867501744c23b8c9d36d0f6a57f647f8d8968d0a7">+2/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>app_texts.dart</strong><dd><code>Add ovulation test UI text constants</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

examples/health_connector_toolbox/lib/src/common/constants/app_texts.dart

<ul><li>Added text constants for ovulation test UI: <code>ovulationTest</code>, <code>testResult</code>, <br><code>selectTestResult</code><br> <li> Added text constants for test result values: <code>negative</code>, <code>inconclusive</code>, <br><code>high</code>, <code>positive</code><br> <li> Added description text for ovulation test feature</ul>


</details>


  </td>
  <td><a href="https://github.com/fam-tung-lam/health_connector/pull/57/files#diff-07b8e00f27991c2402b6645cc31d6c9841375152740ab1048854bd2f507adc41">+14/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>app_icons.dart</strong><dd><code>Add science icon for ovulation test display</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

examples/health_connector_toolbox/lib/src/common/constants/app_icons.dart

- Added `science` icon constant for ovulation test UI representation


</details>


  </td>
  <td><a href="https://github.com/fam-tung-lam/health_connector/pull/57/files#diff-1e59d50e0af0ea761029ca931bb38a16e31a52967335c268342513def963c64e">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>ovulation_test_result_type_extension.dart</strong><dd><code>Add ovulation test result type UI extension</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

examples/health_connector_toolbox/lib/src/common/utils/extensions/ovulation_test_result_type_extension.dart

<ul><li>New file with extension providing <code>displayName</code> getter for <br><code>OvulationTestResultType</code><br> <li> Maps enum values to user-friendly text labels</ul>


</details>


  </td>
  <td><a href="https://github.com/fam-tung-lam/health_connector/pull/57/files#diff-daf7867176db2c743702ea32e0ea96a8d108b67513a5504aa69ee3aa1cd17bd2">+16/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>HealthConnectorHKIOSApi.g.swift</strong><dd><code>Add ovulation test result type and record support</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/health_connector_hk_ios/ios/health_connector_hk_ios/Sources/health_connector_hk_ios/pigeon/HealthConnectorHKIOSApi.g.swift

<ul><li>Added <code>OvulationTestResultTypeDto</code> enum with four cases: <code>negative</code>, <br><code>inconclusive</code>, <code>high</code>, and <code>positive</code><br> <li> Added <code>ovulationTest</code> case to <code>HealthDataTypeDto</code> enum and renumbered <br>subsequent cases<br> <li> Added <code>OvulationTestRecordDto</code> struct with serialization/deserialization <br>methods<br> <li> Updated codec reader and writer to handle the new ovulation test types <br>with adjusted byte codes</ul>


</details>


  </td>
  <td><a href="https://github.com/fam-tung-lam/health_connector/pull/57/files#diff-8915112a513087f5a784b5d07c5248abb8e74d47ec1c06089a3d9774f535f925">+270/-191</a></td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>HealthConnectorHCAndroidApi.g.kt</strong><dd><code>Add ovulation test result type and record support</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/health_connector_hc_android/android/src/main/kotlin/com/phamtunglam/health_connector_hc_android/pigeon/HealthConnectorHCAndroidApi.g.kt

<ul><li>Added <code>OvulationTestResultTypeDto</code> enum with four values: <code>NEGATIVE</code>, <br><code>INCONCLUSIVE</code>, <code>HIGH</code>, and <code>POSITIVE</code><br> <li> Added <code>OVULATION_TEST</code> case to <code>HealthDataTypeDto</code> enum and renumbered <br>subsequent cases<br> <li> Added <code>OvulationTestRecordDto</code> data class with <br>serialization/deserialization methods<br> <li> Updated codec reader and writer to handle the new ovulation test types <br>with adjusted byte codes</ul>


</details>


  </td>
  <td><a href="https://github.com/fam-tung-lam/health_connector/pull/57/files#diff-e6f9aac35ab0f3a96117362ead91b0ee359674294103ce3b59a72675da86b028">+228/-136</a></td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>HealthRecordMappers.kt</strong><dd><code>Add ovulation test record mapping support</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/health_connector_hc_android/android/src/main/kotlin/com/phamtunglam/health_connector_hc_android/mappers/health_record_mappers/HealthRecordMappers.kt

<ul><li>Added import for <code>OvulationTestRecord</code> and <code>OvulationTestRecordDto</code><br> <li> Added mapping for <code>OvulationTestRecordDto</code> to <br><code>HealthDataTypeDto.OVULATION_TEST</code> in the <code>dataType</code> property<br> <li> Added conversion case for <code>OvulationTestRecordDto</code> in <code>toHealthConnect()</code> <br>function<br> <li> Added conversion case for <code>OvulationTestRecord</code> in <code>Record.toDto()</code> <br>function</ul>


</details>


  </td>
  <td><a href="https://github.com/fam-tung-lam/health_connector/pull/57/files#diff-b46acbc5c4bf7e37fa014b122641d13c24a6c469213d234d97727c0768b212b4">+7/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>HealthDataPermissionMapper.kt</strong><dd><code>Add ovulation test permission mapping</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/health_connector_hc_android/android/src/main/kotlin/com/phamtunglam/health_connector_hc_android/mappers/permission_mappers/HealthDataPermissionMapper.kt

<ul><li>Added import for <code>OvulationTestRecord</code><br> <li> Added permission mapping for <code>HealthDataTypeDto.OVULATION_TEST</code> <br>supporting both read and write access types<br> <li> Added string-to-enum conversion for <code>"OVULATION_TEST"</code> in <br><code>toHealthDataPermissionDto()</code> function</ul>


</details>


  </td>
  <td><a href="https://github.com/fam-tung-lam/health_connector/pull/57/files#diff-53732ef1be9f71c35aec3d299fd6500f74bdde8040391f63aea57c4461193616">+14/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>HealthDataTypeMappers.kt</strong><dd><code>Add ovulation test data type mapping</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/health_connector_hc_android/android/src/main/kotlin/com/phamtunglam/health_connector_hc_android/mappers/HealthDataTypeMappers.kt

<ul><li>Added import for <code>OvulationTestRecord</code><br> <li> Added mapping from <code>HealthDataTypeDto.OVULATION_TEST</code> to <br><code>OvulationTestRecord::class</code> in <code>toHealthConnectRecordClass()</code> function</ul>


</details>


  </td>
  <td><a href="https://github.com/fam-tung-lam/health_connector/pull/57/files#diff-41f32ba89e720f4e9133ecbd6d58064b43af2e089e620906f2418ea1a59822c3">+2/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>OvulationTestResultTypeMappers.kt</strong><dd><code>Add ovulation test result type conversion mappers</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/health_connector_hc_android/android/src/main/kotlin/com/phamtunglam/health_connector_hc_android/mappers/health_record_mappers/OvulationTestResultTypeMappers.kt

<ul><li>Created new file with conversion functions between Health Connect <br>ovulation test result constants and <code>OvulationTestResultTypeDto</code><br> <li> Implemented <code>toOvulationTestResultTypeDto()</code> extension function to <br>convert Int values to enum<br> <li> Implemented <code>toHealthConnect()</code> extension function to convert enum back <br>to Health Connect Int constants</ul>


</details>


  </td>
  <td><a href="https://github.com/fam-tung-lam/health_connector/pull/57/files#diff-38a47ae18ac7b5ace74f6e4468c138825d1be490cc4b59944b6d87c0fe6fdf0f">+33/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>HealthRecordIdMappers.kt</strong><dd><code>Add ovulation test record ID mapping</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/health_connector_hc_android/android/src/main/kotlin/com/phamtunglam/health_connector_hc_android/mappers/health_record_mappers/HealthRecordIdMappers.kt

<ul><li>Added import for <code>OvulationTestRecordDto</code><br> <li> Added case for <code>OvulationTestRecordDto</code> in the <code>id</code> property getter to <br>extract the record identifier</ul>


</details>


  </td>
  <td><a href="https://github.com/fam-tung-lam/health_connector/pull/57/files#diff-f1b5f546572492f6d31694db7f50589b2aa5385d1ab6fdd4609f58a7469a8a92">+2/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>OvulationTestRecordMappers.kt</strong><dd><code>Add ovulation test record conversion mappers</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/health_connector_hc_android/android/src/main/kotlin/com/phamtunglam/health_connector_hc_android/mappers/health_record_mappers/OvulationTestRecordMappers.kt

<ul><li>Created new file with bidirectional conversion functions between <br>Health Connect <code>OvulationTestRecord</code> and <code>OvulationTestRecordDto</code><br> <li> Implemented <code>toDto()</code> extension function to convert Health Connect <br>record to DTO with metadata and result mapping<br> <li> Implemented <code>toHealthConnect()</code> extension function to convert DTO back <br>to Health Connect record</ul>


</details>


  </td>
  <td><a href="https://github.com/fam-tung-lam/health_connector/pull/57/files#diff-7b048061add903ce030ad579cdef6cdf654e9433fc8b0fb197e3987572cb869a">+29/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>OvulationTestHandler.kt</strong><dd><code>Add ovulation test record handler</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/health_connector_hc_android/android/src/main/kotlin/com/phamtunglam/health_connector_hc_android/handlers/health_record_handlers/OvulationTestHandler.kt

<ul><li>Created new handler class for ovulation test records<br> <li> Implements <code>ReadableHealthRecordHandler</code>, <code>WritableHealthRecordHandler</code>, <br>and <code>DeletableHealthRecordHandler</code> interfaces<br> <li> Sets <code>dataType</code> to <code>HealthDataTypeDto.OVULATION_TEST</code></ul>


</details>


  </td>
  <td><a href="https://github.com/fam-tung-lam/health_connector/pull/57/files#diff-7c8cbac486ffe3dfc996a17d8f5f8a649067a4236ce3f14ee5bf179698dfbaba">+18/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Documentation</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td>
    <details>
      <summary><strong>README.md</strong><dd><code>Update README with new data type guidance</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

README.md

<ul><li>Replaced comprehensive project overview and documentation with <br>guidance for adding new health data types<br> <li> Added sections for Android Health Connect types: <br><code>BasalMetabolicRateRecord</code> and <code>TotalCaloriesBurnedRecord</code><br> <li> Added sections for iOS HealthKit types: <code>BasalEnergyBurnedRecord</code><br> <li> Included aggregation metrics and API references for each type</ul>


</details>


  </td>
  <td><a href="https://github.com/fam-tung-lam/health_connector/pull/57/files#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5">+32/-62</a>&nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Additional files</strong></td><td><details><summary>6 files</summary><table>
<tr>
  <td><strong>measurement_unit_value_parser.dart</strong></td>
  <td><a href="https://github.com/fam-tung-lam/health_connector/pull/57/files#diff-ac7b697e877c3aea6173377bf5995c439eeaeb2eea0499f59b6c864beea80c30">+17/-13</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>aggregate_health_data_change_notifier.dart</strong></td>
  <td><a href="https://github.com/fam-tung-lam/health_connector/pull/57/files#diff-979e43d586942a4803fec58091dd57411bb8b8962404d175522c81dfb116c967">+5/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>health_record_list_tile.dart</strong></td>
  <td><a href="https://github.com/fam-tung-lam/health_connector/pull/57/files#diff-57decaab37c9c0e5974d2b5c3343d072c3ca1c624979eacfd7e806f41f09b97c">+5/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>ovulation_test_list_tile.dart</strong></td>
  <td><a href="https://github.com/fam-tung-lam/health_connector/pull/57/files#diff-b4b8f6c0628f7c6df262e8f6109abff031ece0e4a98dfbab192f548c2fc3c284">+76/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>health_record_write_page.dart</strong></td>
  <td><a href="https://github.com/fam-tung-lam/health_connector/pull/57/files#diff-95359aee57dcc236b8fffbbde90f8dd07112fc4553b5b119d8a8346684615a96">+5/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>ovulation_test_health_record_write_form.dart</strong></td>
  <td><a href="https://github.com/fam-tung-lam/health_connector/pull/57/files#diff-bbaef2079c798a87a40c6370deef56af2748c0defb85a81b665b8d95c92d5897">+52/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></details></td></tr></tbody></table>

</details>

___

