### PR TITLE
fix(health_connector_hk_ios): add 'any' keyword for protocol existential types. Fixes Swift 5.7+ compiler error in HealthConnectorClient.swift

### DIFF
--- a/packages/health_connector_hk_ios/ios/health_connector_hk_ios/Sources/health_connector_hk_ios/HealthConnectorClient.swift
+++ b/packages/health_connector_hk_ios/ios/health_connector_hk_ios/Sources/health_connector_hk_ios/HealthConnectorClient.swift
@@ -172,7 +172,7 @@ actor HealthConnectorClient: Taggable {
 
             let handler = try handlerRegistry.handler(
                 for: request.dataType,
-                withCapability: ReadableHealthRecordHandler.self
+                withCapability: (any ReadableHealthRecordHandler).self
             )
 
             let recordDto = try await handler.readRecord(id: request.recordId)
@@ -266,7 +266,7 @@ actor HealthConnectorClient: Taggable {
 
             let handler = try handlerRegistry.handler(
                 for: request.dataType,
-                withCapability: ReadableHealthRecordHandler.self
+                withCapability: (any ReadableHealthRecordHandler).self
             )
 
             // Convert string page token to PaginationToken
@@ -342,7 +342,7 @@ actor HealthConnectorClient: Taggable {
 
             let handler = try handlerRegistry.handler(
                 for: dataType,
-                withCapability: WritableHealthRecordHandler.self
+                withCapability: (any WritableHealthRecordHandler).self
             )
 
             // Delegate to handler
@@ -406,7 +406,7 @@ actor HealthConnectorClient: Taggable {
                 // Validate: Handler exists and supports writes
                 _ = try handlerRegistry.handler(
                     for: dataType,
-                    withCapability: WritableHealthRecordHandler.self
+                    withCapability: (any WritableHealthRecordHandler).self
                 )
 
                 let sample = try record.toHealthKit()
@@ -483,8 +483,8 @@ actor HealthConnectorClient: Taggable {
 
             let handler = try handlerRegistry.handler(
                 for: request.dataType,
-                withCapability: AggregatableHealthRecordHandler.self
-            )
+                withCapability: (any AggregatableHealthRecordHandler).self
+            ) 
 
             // Convert milliseconds since epoch to Date
             let startTime = Date(millisecondsSince1970: request.startTime)
@@ -546,7 +546,7 @@ actor HealthConnectorClient: Taggable {
 
             let handler = try handlerRegistry.handler(
                 for: request.dataType,
-                withCapability: DeletableHealthRecordHandler.self
+                withCapability: (any DeletableHealthRecordHandler).self
             )
 
             // Convert milliseconds since epoch to Date
@@ -600,7 +600,7 @@ actor HealthConnectorClient: Taggable {
 
             let handler = try handlerRegistry.handler(
                 for: request.dataType,
-                withCapability: DeletableHealthRecordHandler.self
+                withCapability: (any DeletableHealthRecordHandler).self
             )
 
             try await handler.deleteRecords(ids: request.recordIds)


### PR DESCRIPTION
### **User description**
Add 'any' keyword for protocol existential types. Fixes Swift 5.7+ compiler error in HealthConnectorClient.swift


___

### **PR Type**
Bug fix


___

### **Description**
- Add `any` keyword to protocol existential types in handler registry calls

- Fixes Swift 5.7+ compiler error requiring explicit existential type syntax

- Updates 6 handler capability references across read, write, aggregate, and delete operations


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["HealthConnectorClient.swift"] -->|Update handler calls| B["ReadableHealthRecordHandler"]
  A -->|Update handler calls| C["WritableHealthRecordHandler"]
  A -->|Update handler calls| D["AggregatableHealthRecordHandler"]
  A -->|Update handler calls| E["DeletableHealthRecordHandler"]
  B -->|Add 'any' keyword| F["Swift 5.7+ compliance"]
  C -->|Add 'any' keyword| F
  D -->|Add 'any' keyword| F
  E -->|Add 'any' keyword| F
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>HealthConnectorClient.swift</strong><dd><code>Add 'any' keyword to protocol existential types</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/health_connector_hk_ios/ios/health_connector_hk_ios/Sources/health_connector_hk_ios/HealthConnectorClient.swift

<ul><li>Add <code>any</code> keyword to 6 protocol existential type references in handler <br>registry calls<br> <li> Update <code>ReadableHealthRecordHandler.self</code> to <code>(any </code><br><code>ReadableHealthRecordHandler).self</code> in 2 locations<br> <li> Update <code>WritableHealthRecordHandler.self</code> to <code>(any </code><br><code>WritableHealthRecordHandler).self</code> in 2 locations<br> <li> Update <code>AggregatableHealthRecordHandler.self</code> and <br><code>DeletableHealthRecordHandler.self</code> to use <code>any</code> keyword in 2 locations <br>each</ul>


</details>


  </td>
  <td><a href="https://github.com/fam-tung-lam/health_connector/pull/75/files#diff-7ba7a6730c323361114ecfcd6fd7f2c783b62de742fd417e2b020ed14ed961fb">+8/-8</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

