### PR TITLE
refactor(health_connector_core,health_connector_hc_android,health_connector_hk_ios)!: Change `HeartRateVariabilityRMSSDRecord` to use `Number` type

### DIFF
--- a/examples/health_connector_toolbox/lib/src/features/read_health_records/widgets/health_record_list_tiles/instant_health_record_list_tiles/heart_rate_variability_rmssd_list_tile.dart
+++ b/examples/health_connector_toolbox/lib/src/features/read_health_records/widgets/health_record_list_tiles/instant_health_record_list_tiles/heart_rate_variability_rmssd_list_tile.dart
@@ -20,7 +20,7 @@ final class HeartRateVariabilityRMSSDTile extends StatelessWidget {
     return InstantHealthRecordTile<HeartRateVariabilityRMSSDRecord>(
       record: record,
       icon: AppIcons.favorite,
-      title: '${record.heartRateVariabilityMillis.toStringAsFixed(1)} ms',
+      title: '${record.heartRateVariabilityMillis.value.toStringAsFixed(1)} ms',
       subtitleBuilder: (r, ctx) => HealthRecordListTileSubtitle.instant(
         time: r.time,
         recordingMethod: r.metadata.recordingMethod.name,

--- a/examples/health_connector_toolbox/lib/src/features/write_health_record/widgets/write_forms/instant_health_record_write_forms/heart_rate_variability_rmssd_health_record_write_form.dart
+++ b/examples/health_connector_toolbox/lib/src/features/write_health_record/widgets/write_forms/instant_health_record_write_forms/heart_rate_variability_rmssd_health_record_write_form.dart
@@ -24,7 +24,7 @@ final class HeartRateVariabilityRMSSDFormState
   HealthRecord buildRecord() {
     return HeartRateVariabilityRMSSDRecord(
       time: startDateTime!,
-      heartRateVariabilityMillis: (value! as Number).value.toDouble(),
+      heartRateVariabilityMillis: value! as Number,
       metadata: metadata,
     );
   }

--- a/packages/health_connector_core/lib/src/models/health_records/heart_rate/heart_rate_variability_rmssd_record.dart
+++ b/packages/health_connector_core/lib/src/models/health_records/heart_rate/heart_rate_variability_rmssd_record.dart
@@ -16,7 +16,7 @@ part of '../health_record.dart';
 /// ```dart
 /// final record = HeartRateVariabilityRMSSDRecord(
 ///   time: DateTime.now(),
-///   heartRateVariabilityMillis: 45.0, // ms
+///   heartRateVariabilityMillis: Number(45.0), // ms
 ///   metadata: Metadata.manualEntry(),
 /// );
 /// ```
@@ -40,7 +40,35 @@ final class HeartRateVariabilityRMSSDRecord extends InstantHealthRecord {
   /// - [metadata]: Metadata about the origin and recording method.
   /// - [id]: The unique identifier for this record.
   /// - [zoneOffsetSeconds]: Optional timezone offset for the measurement time.
-  const HeartRateVariabilityRMSSDRecord({
+  ///
+  /// ## Throws
+  ///
+  /// - [ArgumentError] if [heartRateVariabilityMillis] is negative.
+  factory HeartRateVariabilityRMSSDRecord({
+    required DateTime time,
+    required Metadata metadata,
+    required Number heartRateVariabilityMillis,
+    HealthRecordId id = HealthRecordId.none,
+    int? zoneOffsetSeconds,
+  }) {
+    if (heartRateVariabilityMillis < Number.zero) {
+      throw ArgumentError.value(
+        heartRateVariabilityMillis,
+        'heartRateVariabilityMillis',
+        'Heart rate variability RMSSD must be non-negative',
+      );
+    }
+    return HeartRateVariabilityRMSSDRecord._(
+      time: time,
+      metadata: metadata,
+      heartRateVariabilityMillis: heartRateVariabilityMillis,
+      id: id,
+      zoneOffsetSeconds: zoneOffsetSeconds,
+    );
+  }
+
+  /// Private constructor for internal use.
+  const HeartRateVariabilityRMSSDRecord._({
     required super.time,
     required super.metadata,
     required this.heartRateVariabilityMillis,
@@ -49,17 +77,17 @@ final class HeartRateVariabilityRMSSDRecord extends InstantHealthRecord {
   });
 
   /// The heart rate variability in milliseconds.
-  final double heartRateVariabilityMillis;
+  final Number heartRateVariabilityMillis;
 
   /// Creates a copy with the given fields replaced with the new values.
   HeartRateVariabilityRMSSDRecord copyWith({
     DateTime? time,
     Metadata? metadata,
-    double? heartRateVariabilityMillis,
+    Number? heartRateVariabilityMillis,
     HealthRecordId? id,
     int? zoneOffsetSeconds,
   }) {
-    return HeartRateVariabilityRMSSDRecord(
+    return HeartRateVariabilityRMSSDRecord._(
       time: time ?? this.time,
       metadata: metadata ?? this.metadata,
       heartRateVariabilityMillis:

--- a/packages/health_connector_core/test/utils/health_record_data_type_extension_test.dart
+++ b/packages/health_connector_core/test/utils/health_record_data_type_extension_test.dart
@@ -255,7 +255,7 @@ void main() {
               ],
               [
                 HeartRateVariabilityRMSSDRecord(
-                  heartRateVariabilityMillis: 50.0,
+                  heartRateVariabilityMillis: Number(50.0),
                   time: createTestTime(),
                   metadata: createTestMetadata(),
                 ),

--- a/packages/health_connector_hc_android/lib/src/mappers/health_record_mappers/heart_rate/heart_rate_variability_rmssd_record_mapper.dart
+++ b/packages/health_connector_hc_android/lib/src/mappers/health_record_mappers/heart_rate/heart_rate_variability_rmssd_record_mapper.dart
@@ -1,5 +1,5 @@
 import 'package:health_connector_core/health_connector_core_internal.dart'
-    show HeartRateVariabilityRMSSDRecord, HealthRecordId, sinceV2_2_0;
+    show HeartRateVariabilityRMSSDRecord, HealthRecordId, Number, sinceV2_2_0;
 import 'package:health_connector_hc_android/src/mappers/health_record_mappers/health_record_id_mapper.dart';
 import 'package:health_connector_hc_android/src/mappers/metadata_mappers/metadata_mapper.dart';
 import 'package:health_connector_hc_android/src/pigeon/health_connector_hc_android_api.g.dart'
@@ -18,7 +18,7 @@ extension HeartRateVariabilityRMSSDRecordToDto
       time: time.millisecondsSinceEpoch,
       zoneOffsetSeconds: zoneOffsetSeconds,
       metadata: metadata.toDto(),
-      heartRateVariabilityMillis: heartRateVariabilityMillis,
+      heartRateVariabilityMillis: heartRateVariabilityMillis.value.toDouble(),
     );
   }
 }
@@ -35,7 +35,7 @@ extension HeartRateVariabilityRMSSDRecordDtoToDomain
       time: DateTime.fromMillisecondsSinceEpoch(time, isUtc: true),
       zoneOffsetSeconds: zoneOffsetSeconds,
       metadata: metadata.toDomain(),
-      heartRateVariabilityMillis: heartRateVariabilityMillis,
+      heartRateVariabilityMillis: Number(heartRateVariabilityMillis),
     );
   }
 }

--- a/packages/health_connector_hc_android/test/unit_tests/src/mappers/health_record_mappers/heart_rate/heart_rate_variability_rmssd_record_mapper_test.dart
+++ b/packages/health_connector_hc_android/test/unit_tests/src/mappers/health_record_mappers/heart_rate/heart_rate_variability_rmssd_record_mapper_test.dart
@@ -26,7 +26,7 @@ void main() {
                   clientRecordVersion: 1,
                   device: Device(type: DeviceType.watch),
                 ),
-                heartRateVariabilityMillis: 45.0,
+                heartRateVariabilityMillis: Number(45.0),
               );
 
               final dto = record.toDto();
@@ -76,7 +76,7 @@ void main() {
                 record.metadata.dataOrigin.packageName,
                 FakeData.fakeDataOrigin,
               );
-              expect(record.heartRateVariabilityMillis, 50.0);
+              expect(record.heartRateVariabilityMillis, Number(50.0));
             },
           );
 


### PR DESCRIPTION
### **User description**
BREAKING CHANGE: `HeartRateVariabilityRMSSDRecord.heartRateVariabilityMillis` field type changed from `double` to `Number`.

Issue: [#84](https://github.com/fam-tung-lam/health_connector/issues/84)


___

### **PR Type**
Enhancement


___

### **Description**
- Change `HeartRateVariabilityRMSSDRecord.heartRateVariabilityMillis` field type from `double` to `Number`

- Add validation in factory constructor to ensure non-negative values

- Update all usages across core, Android mapper, and example code

- Refactor constructor to use factory pattern with private implementation


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["HeartRateVariabilityRMSSDRecord<br/>heartRateVariabilityMillis: double"] -->|"Change type to Number"| B["HeartRateVariabilityRMSSDRecord<br/>heartRateVariabilityMillis: Number"]
  B -->|"Add validation"| C["Factory constructor<br/>with ArgumentError check"]
  C -->|"Update mappers"| D["Android mapper<br/>converts Number to/from double"]
  D -->|"Update usages"| E["Example code & tests<br/>use Number wrapper"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>heart_rate_variability_rmssd_record.dart</strong><dd><code>Refactor to use Number type with validation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/health_connector_core/lib/src/models/health_records/heart_rate/heart_rate_variability_rmssd_record.dart

<ul><li>Changed <code>heartRateVariabilityMillis</code> field type from <code>double</code> to <code>Number</code><br> <li> Converted constructor to factory pattern with validation<br> <li> Added private <code>_</code> constructor for internal use<br> <li> Updated <code>copyWith</code> method to use private constructor<br> <li> Added documentation example showing <code>Number</code> usage<br> <li> Added <code>ArgumentError</code> validation for non-negative values</ul>


</details>


  </td>
  <td><a href="https://github.com/fam-tung-lam/health_connector/pull/86/files#diff-181884f74e36e6b46e20837c30cdf1e82260badc4f897fe406cb2b12ca32e588">+33/-5</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>heart_rate_variability_rmssd_record_mapper.dart</strong><dd><code>Update mapper for Number type conversion</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/health_connector_hc_android/lib/src/mappers/health_record_mappers/heart_rate/heart_rate_variability_rmssd_record_mapper.dart

<ul><li>Added <code>Number</code> to imports<br> <li> Updated <code>toDto()</code> to convert <code>Number.value</code> to <code>double</code> for serialization<br> <li> Updated <code>toDomain()</code> to wrap <code>double</code> in <code>Number</code> constructor</ul>


</details>


  </td>
  <td><a href="https://github.com/fam-tung-lam/health_connector/pull/86/files#diff-fd0502de3d85b6ef57e6f30a73267276c49ea076c2079e74be943379238ddce2">+3/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>heart_rate_variability_rmssd_list_tile.dart</strong><dd><code>Update UI to access Number value property</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

examples/health_connector_toolbox/lib/src/features/read_health_records/widgets/health_record_list_tiles/instant_health_record_list_tiles/heart_rate_variability_rmssd_list_tile.dart

<ul><li>Updated title display to access <code>.value</code> property on <code>Number</code> type before <br>calling <code>toStringAsFixed(1)</code></ul>


</details>


  </td>
  <td><a href="https://github.com/fam-tung-lam/health_connector/pull/86/files#diff-9bc02229254d455d97ce699b4974b75c06a36414cc29f53728d052d069d5c246">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>heart_rate_variability_rmssd_health_record_write_form.dart</strong><dd><code>Simplify form record building logic</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

examples/health_connector_toolbox/lib/src/features/write_health_record/widgets/write_forms/instant_health_record_write_forms/heart_rate_variability_rmssd_health_record_write_form.dart

<ul><li>Simplified record building to directly cast and assign <code>Number</code> type <br>instead of extracting <code>.value</code> and converting to <code>double</code></ul>


</details>


  </td>
  <td><a href="https://github.com/fam-tung-lam/health_connector/pull/86/files#diff-aef2cef8daf10a76252ae511e03615900f5fbc085c21e34be1e4b1462a2a45d3">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>heart_rate_variability_rmssd_record_mapper_test.dart</strong><dd><code>Update mapper tests for Number type</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/health_connector_hc_android/test/unit_tests/src/mappers/health_record_mappers/heart_rate/heart_rate_variability_rmssd_record_mapper_test.dart

<ul><li>Updated test record creation to use <code>Number(45.0)</code> instead of <code>45.0</code><br> <li> Updated assertion to expect <code>Number(50.0)</code> instead of <code>50.0</code></ul>


</details>


  </td>
  <td><a href="https://github.com/fam-tung-lam/health_connector/pull/86/files#diff-1818d8fea52b14ba0f18d6f5633f602a00ae69ef1ef365dc7c45171e3cd95752">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>health_record_data_type_extension_test.dart</strong><dd><code>Update test data for Number type</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/health_connector_core/test/utils/health_record_data_type_extension_test.dart

<ul><li>Updated test data to use <code>Number(50.0)</code> instead of <code>50.0</code> for <br><code>heartRateVariabilityMillis</code></ul>


</details>


  </td>
  <td><a href="https://github.com/fam-tung-lam/health_connector/pull/86/files#diff-63304542f81d9d52801b03aa1d9bf280ed64629d7131c5b827131d0bad338aa6">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

