### PR TITLE
fix(health_connector_core)!: Remove non-functional `dataOrigin` parameters from `Metadata` constructors

### DIFF
--- a/examples/health_connector_toolbox/lib/src/features/read_health_records/widgets/health_record_metadata_info.dart
+++ b/examples/health_connector_toolbox/lib/src/features/read_health_records/widgets/health_record_metadata_info.dart
@@ -24,7 +24,7 @@ final class HealthRecordMetadataInfo extends StatelessWidget {
       children: [
         _MetadataInfoRow(
           label: AppTexts.dataOrigin,
-          value: metadata.dataOrigin.packageName,
+          value: metadata.dataOrigin?.packageName,
         ),
         _MetadataInfoRow(
           label: AppTexts.recordingMethod,

--- a/examples/health_connector_toolbox/lib/src/features/write_health_record/widgets/write_forms/base_health_record_write_form.dart
+++ b/examples/health_connector_toolbox/lib/src/features/write_health_record/widgets/write_forms/base_health_record_write_form.dart
@@ -41,10 +41,6 @@ abstract class BaseHealthRecordWriteFormState<
 >
     extends State<T>
     with StartDateTimePickerPageStateMixin<T> {
-  static const _dataOrigin = DataOrigin(
-    'com.phamtunglam.health_connector_toolbox',
-  );
-
   /// Form key for validation
   final formKey = GlobalKey<FormState>();
 
@@ -54,19 +50,14 @@ abstract class BaseHealthRecordWriteFormState<
   /// Current metadata built from form state.
   Metadata get metadata {
     return switch (_recordingMethod) {
-      RecordingMethod.manualEntry => Metadata.manualEntry(
-        dataOrigin: _dataOrigin,
-      ),
+      RecordingMethod.manualEntry => Metadata.manualEntry(),
       RecordingMethod.automaticallyRecorded => Metadata.automaticallyRecorded(
-        dataOrigin: _dataOrigin,
         device: _device!,
       ),
       RecordingMethod.activelyRecorded => Metadata.activelyRecorded(
-        dataOrigin: _dataOrigin,
         device: _device!,
       ),
       RecordingMethod.unknown => Metadata.unknownRecordingMethod(
-        dataOrigin: _dataOrigin,
         device: _device,
       ),
     };

--- a/packages/health_connector/README.md
+++ b/packages/health_connector/README.md
@@ -311,7 +311,6 @@ StepsRecord _createStepsRecord(DateTime time, int steps) {
     endTime: time.add(Duration(hours: 1)),
     count: Number(steps),
     metadata: Metadata.automaticallyRecorded(
-      dataOrigin: DataOrigin('com.example'),
       device: Device.fromType(DeviceType.phone),
     ),
   );

--- a/packages/health_connector/example/lib/main.dart
+++ b/packages/health_connector/example/lib/main.dart
@@ -356,7 +356,6 @@ class _ExampleAppHomePageState extends State<ExampleAppHomePage> {
         endTime: now,
         count: const Number(1000),
         metadata: Metadata.automaticallyRecorded(
-          dataOrigin: const DataOrigin('com.example.health_connector'),
           device: const Device.fromType(DeviceType.phone),
         ),
       );
@@ -389,7 +388,6 @@ class _ExampleAppHomePageState extends State<ExampleAppHomePage> {
           endTime: now.subtract(const Duration(hours: 2)),
           count: const Number(1500),
           metadata: Metadata.automaticallyRecorded(
-            dataOrigin: const DataOrigin('com.example.health_connector'),
             device: const Device.fromType(DeviceType.watch),
           ),
         ),
@@ -398,7 +396,6 @@ class _ExampleAppHomePageState extends State<ExampleAppHomePage> {
           endTime: now.subtract(const Duration(hours: 1)),
           count: const Number(2000),
           metadata: Metadata.automaticallyRecorded(
-            dataOrigin: const DataOrigin('com.example.health_connector'),
             device: const Device.fromType(DeviceType.watch),
           ),
         ),

--- a/packages/health_connector/test/unit_tests/src/health_connector_impl_test.dart
+++ b/packages/health_connector/test/unit_tests/src/health_connector_impl_test.dart
@@ -60,9 +60,7 @@ void main() {
           count: const Number(100),
           startTime: FakeData.fakeStartTime,
           endTime: FakeData.fakeEndTime,
-          metadata: Metadata.manualEntry(
-            dataOrigin: const DataOrigin(FakeData.fakeDataOrigin),
-          ),
+          metadata: Metadata.manualEntry(),
         ),
       );
       registerFallbackValue(const <StepsRecord>[]);
@@ -265,9 +263,7 @@ void main() {
                 startTime: FakeData.fakeStartTime,
                 endTime: FakeData.fakeEndTime,
                 id: HealthRecordId(FakeData.fakeId),
-                metadata: Metadata.manualEntry(
-                  dataOrigin: const DataOrigin(FakeData.fakeDataOrigin),
-                ),
+                metadata: Metadata.manualEntry(),
               );
 
               when(
@@ -375,9 +371,7 @@ void main() {
                     count: const Number(100),
                     startTime: FakeData.fakeStartTime,
                     endTime: FakeData.fakeEndTime,
-                    metadata: Metadata.manualEntry(
-                      dataOrigin: const DataOrigin(FakeData.fakeDataOrigin),
-                    ),
+                    metadata: Metadata.manualEntry(),
                   ),
                 ],
               );
@@ -450,9 +444,7 @@ void main() {
                 count: const Number(100),
                 startTime: FakeData.fakeStartTime,
                 endTime: FakeData.fakeEndTime,
-                metadata: Metadata.manualEntry(
-                  dataOrigin: const DataOrigin(FakeData.fakeDataOrigin),
-                ),
+                metadata: Metadata.manualEntry(),
               );
               final expectedId = HealthRecordId('new-id');
 
@@ -487,9 +479,7 @@ void main() {
                 startTime: FakeData.fakeStartTime,
                 endTime: FakeData.fakeEndTime,
                 id: HealthRecordId('existing-id'),
-                metadata: Metadata.manualEntry(
-                  dataOrigin: const DataOrigin(FakeData.fakeDataOrigin),
-                ),
+                metadata: Metadata.manualEntry(),
               );
 
               // WHEN & THEN
@@ -520,9 +510,7 @@ void main() {
                 count: const Number(100),
                 startTime: FakeData.fakeStartTime,
                 endTime: FakeData.fakeEndTime,
-                metadata: Metadata.manualEntry(
-                  dataOrigin: const DataOrigin(FakeData.fakeDataOrigin),
-                ),
+                metadata: Metadata.manualEntry(),
               );
 
               when(
@@ -587,17 +575,13 @@ void main() {
                   count: const Number(100),
                   startTime: FakeData.fakeStartTime,
                   endTime: FakeData.fakeEndTime,
-                  metadata: Metadata.manualEntry(
-                    dataOrigin: const DataOrigin(FakeData.fakeDataOrigin),
-                  ),
+                  metadata: Metadata.manualEntry(),
                 ),
                 StepsRecord(
                   count: const Number(200),
                   startTime: FakeData.fakeStartTime,
                   endTime: FakeData.fakeEndTime,
-                  metadata: Metadata.manualEntry(
-                    dataOrigin: const DataOrigin(FakeData.fakeDataOrigin),
-                  ),
+                  metadata: Metadata.manualEntry(),
                 ),
               ];
               final expectedIds = [
@@ -637,9 +621,7 @@ void main() {
                   startTime: FakeData.fakeStartTime,
                   endTime: FakeData.fakeEndTime,
                   id: HealthRecordId('existing-id'),
-                  metadata: Metadata.manualEntry(
-                    dataOrigin: const DataOrigin(FakeData.fakeDataOrigin),
-                  ),
+                  metadata: Metadata.manualEntry(),
                 ),
               ];
 
@@ -672,9 +654,7 @@ void main() {
                   count: const Number(100),
                   startTime: FakeData.fakeStartTime,
                   endTime: FakeData.fakeEndTime,
-                  metadata: Metadata.manualEntry(
-                    dataOrigin: const DataOrigin(FakeData.fakeDataOrigin),
-                  ),
+                  metadata: Metadata.manualEntry(),
                 ),
               ];
 
@@ -916,9 +896,7 @@ void main() {
                 startTime: FakeData.fakeStartTime,
                 endTime: FakeData.fakeEndTime,
                 id: HealthRecordId('existing-id'),
-                metadata: Metadata.manualEntry(
-                  dataOrigin: const DataOrigin(FakeData.fakeDataOrigin),
-                ),
+                metadata: Metadata.manualEntry(),
               );
 
               // WHEN & THEN
@@ -948,9 +926,7 @@ void main() {
                 startTime: FakeData.fakeStartTime,
                 endTime: FakeData.fakeEndTime,
                 id: HealthRecordId('existing-id'),
-                metadata: Metadata.manualEntry(
-                  dataOrigin: const DataOrigin(FakeData.fakeDataOrigin),
-                ),
+                metadata: Metadata.manualEntry(),
               );
 
               when(
@@ -982,9 +958,7 @@ void main() {
                 count: const Number(100),
                 startTime: FakeData.fakeStartTime,
                 endTime: FakeData.fakeEndTime,
-                metadata: Metadata.manualEntry(
-                  dataOrigin: const DataOrigin(FakeData.fakeDataOrigin),
-                ),
+                metadata: Metadata.manualEntry(),
               );
 
               // WHEN & THEN
@@ -1016,9 +990,7 @@ void main() {
                 startTime: FakeData.fakeStartTime,
                 endTime: FakeData.fakeEndTime,
                 id: HealthRecordId('existing-id'),
-                metadata: Metadata.manualEntry(
-                  dataOrigin: const DataOrigin(FakeData.fakeDataOrigin),
-                ),
+                metadata: Metadata.manualEntry(),
               );
 
               when(
@@ -1057,9 +1029,7 @@ void main() {
                   startTime: FakeData.fakeStartTime,
                   endTime: FakeData.fakeEndTime,
                   id: HealthRecordId('existing-id'),
-                  metadata: Metadata.manualEntry(
-                    dataOrigin: const DataOrigin(FakeData.fakeDataOrigin),
-                  ),
+                  metadata: Metadata.manualEntry(),
                 ),
               ];
 
@@ -1093,18 +1063,14 @@ void main() {
                   startTime: FakeData.fakeStartTime,
                   endTime: FakeData.fakeEndTime,
                   id: HealthRecordId('id-1'),
-                  metadata: Metadata.manualEntry(
-                    dataOrigin: const DataOrigin(FakeData.fakeDataOrigin),
-                  ),
+                  metadata: Metadata.manualEntry(),
                 ),
                 StepsRecord(
                   count: const Number(200),
                   startTime: FakeData.fakeStartTime,
                   endTime: FakeData.fakeEndTime,
                   id: HealthRecordId('id-2'),
-                  metadata: Metadata.manualEntry(
-                    dataOrigin: const DataOrigin(FakeData.fakeDataOrigin),
-                  ),
+                  metadata: Metadata.manualEntry(),
                 ),
               ];
 
@@ -1138,9 +1104,7 @@ void main() {
                   count: const Number(100),
                   startTime: FakeData.fakeStartTime,
                   endTime: FakeData.fakeEndTime,
-                  metadata: Metadata.manualEntry(
-                    dataOrigin: const DataOrigin(FakeData.fakeDataOrigin),
-                  ),
+                  metadata: Metadata.manualEntry(),
                 ),
               ];
 
@@ -1174,9 +1138,7 @@ void main() {
                   startTime: FakeData.fakeStartTime,
                   endTime: FakeData.fakeEndTime,
                   id: HealthRecordId('id-1'),
-                  metadata: Metadata.manualEntry(
-                    dataOrigin: const DataOrigin(FakeData.fakeDataOrigin),
-                  ),
+                  metadata: Metadata.manualEntry(),
                 ),
               ];
 

--- a/packages/health_connector_core/lib/src/models/health_records/blood_glucose/blood_glucose_record.dart
+++ b/packages/health_connector_core/lib/src/models/health_records/blood_glucose/blood_glucose_record.dart
@@ -22,9 +22,7 @@ part of '../health_record.dart';
 ///   relationToMeal: BloodGlucoseRelationToMeal.fasting,
 ///   mealType: MealType.breakfast,
 ///   specimenSource: BloodGlucoseSpecimenSource.capillaryBlood,
-///   metadata: Metadata.manualEntry(
-///     dataOrigin: DataOrigin(packageName: 'com.example.app'),
-///   ),
+///   metadata: Metadata.manualEntry(),
 /// );
 /// ```
 ///

--- a/packages/health_connector_core/lib/src/models/health_records/blood_pressure/blood_pressure_record.dart
+++ b/packages/health_connector_core/lib/src/models/health_records/blood_pressure/blood_pressure_record.dart
@@ -23,9 +23,7 @@ part of '../health_record.dart';
 ///   diastolic: Pressure.millimetersOfMercury(80),
 ///   bodyPosition: BloodPressureBodyPosition.sitting,
 ///   measurementLocation: BloodPressureMeasurementLocation.leftUpperArm,
-///   metadata: Metadata.manualEntry(
-///     dataOrigin: DataOrigin(packageName: 'com.example.app'),
-///   ),
+///   metadata: Metadata.manualEntry(),
 /// );
 /// ```
 ///

--- a/packages/health_connector_core/lib/src/models/health_records/blood_pressure/diastolic_blood_pressure_record.dart
+++ b/packages/health_connector_core/lib/src/models/health_records/blood_pressure/diastolic_blood_pressure_record.dart
@@ -20,9 +20,7 @@ part of '../health_record.dart';
 /// final record = DiastolicBloodPressureRecord(
 ///   time: DateTime.now(),
 ///   pressure: Pressure.millimetersOfMercury(80),
-///   metadata: Metadata.manualEntry(
-///     dataOrigin: DataOrigin(packageName: 'com.example.app'),
-///   ),
+///   metadata: Metadata.manualEntry(),
 /// );
 /// ```
 ///

--- a/packages/health_connector_core/lib/src/models/health_records/blood_pressure/systolic_blood_pressure_record.dart
+++ b/packages/health_connector_core/lib/src/models/health_records/blood_pressure/systolic_blood_pressure_record.dart
@@ -20,9 +20,7 @@ part of '../health_record.dart';
 /// final record = SystolicBloodPressureRecord(
 ///   time: DateTime.now(),
 ///   pressure: Pressure.millimetersOfMercury(120),
-///   metadata: Metadata.manualEntry(
-///     dataOrigin: DataOrigin(packageName: 'com.example.app'),
-///   ),
+///   metadata: Metadata.manualEntry(),
 /// );
 /// ```
 ///

--- a/packages/health_connector_core/lib/src/models/health_records/body_fat_percentage_record.dart
+++ b/packages/health_connector_core/lib/src/models/health_records/body_fat_percentage_record.dart
@@ -19,7 +19,7 @@ part of 'health_record.dart';
 ///   time: DateTime.now(),
 ///   percentage: Percentage.fromWhole(25), // 25% body fat
 ///   metadata: Metadata.automaticallyRecorded(
-///     dataOrigin: DataOrigin(packageName: 'com.example.app'),
+///     device: Device.fromType(DeviceType.watch),
 ///   ),
 /// );
 /// ```

--- a/packages/health_connector_core/lib/src/models/health_records/body_mass_index_record.dart
+++ b/packages/health_connector_core/lib/src/models/health_records/body_mass_index_record.dart
@@ -17,9 +17,7 @@ part of 'health_record.dart';
 /// final record = BodyMassIndexRecord(
 ///   time: DateTime.now(),
 ///   bodyMassIndex: Number(22.5),
-///   metadata: Metadata.manualEntry(
-///     dataOrigin: DataOrigin(packageName: 'com.example.app'),
-///   ),
+///   metadata: Metadata.manualEntry(),
 /// );
 /// ```
 ///

--- a/packages/health_connector_core/lib/src/models/health_records/cycling_pedaling_cadence/cycling_pedaling_cadence_measurement_record.dart
+++ b/packages/health_connector_core/lib/src/models/health_records/cycling_pedaling_cadence/cycling_pedaling_cadence_measurement_record.dart
@@ -23,7 +23,7 @@ part of '../health_record.dart';
 ///     revolutionsPerMinute: Number(85),
 ///   ),
 ///   metadata: Metadata.automaticallyRecorded(
-///     dataOrigin: DataOrigin(packageName: 'com.apple.health'),
+///     device: Device.fromType(DeviceType.watch),
 ///   ),
 /// );
 /// ```

--- a/packages/health_connector_core/lib/src/models/health_records/cycling_pedaling_cadence/cycling_pedaling_cadence_series_record.dart
+++ b/packages/health_connector_core/lib/src/models/health_records/cycling_pedaling_cadence/cycling_pedaling_cadence_series_record.dart
@@ -35,7 +35,7 @@ part of '../health_record.dart';
 ///     ),
 ///   ],
 ///   metadata: Metadata.automaticallyRecorded(
-///     dataOrigin: DataOrigin(packageName: 'com.example.app'),
+///     device: Device.fromType(DeviceType.watch),
 ///   ),
 /// );
 /// ```

--- a/packages/health_connector_core/lib/src/models/health_records/distance/distance_record.dart
+++ b/packages/health_connector_core/lib/src/models/health_records/distance/distance_record.dart
@@ -18,7 +18,7 @@ part of '../health_record.dart';
 ///   endTime: DateTime.now(),
 ///   distance: Length.meters(5000), // 5 km
 ///   metadata: Metadata.automaticallyRecorded(
-///     dataOrigin: DataOrigin(packageName: 'com.example.app'),
+///     device: Device.fromType(DeviceType.watch),
 ///   ),
 /// );
 /// ```

--- a/packages/health_connector_core/lib/src/models/health_records/energy_burned/active_calories_burned_record.dart
+++ b/packages/health_connector_core/lib/src/models/health_records/energy_burned/active_calories_burned_record.dart
@@ -19,7 +19,7 @@ part of '../health_record.dart';
 ///   endTime: DateTime.now(),
 ///   energy: Energy.kilocalories(300), // 300 kcal burned
 ///   metadata: Metadata.automaticallyRecorded(
-///     dataOrigin: DataOrigin(packageName: 'com.example.app'),
+///     device: Device.fromType(DeviceType.watch),
 ///   ),
 /// );
 /// ```

--- a/packages/health_connector_core/lib/src/models/health_records/energy_burned/basal_energy_burned_record.dart
+++ b/packages/health_connector_core/lib/src/models/health_records/energy_burned/basal_energy_burned_record.dart
@@ -18,7 +18,7 @@ part of '../health_record.dart';
 ///   endTime: DateTime.now(),
 ///   energy: Energy.kilocalories(60), // 60 kcal basal burn
 ///   metadata: Metadata.automaticallyRecorded(
-///     dataOrigin: DataOrigin(packageName: 'com.example.app'),
+///     device: Device.fromType(DeviceType.watch),
 ///   ),
 /// );
 /// ```

--- a/packages/health_connector_core/lib/src/models/health_records/energy_burned/total_calories_burned_record.dart
+++ b/packages/health_connector_core/lib/src/models/health_records/energy_burned/total_calories_burned_record.dart
@@ -19,7 +19,7 @@ part of '../health_record.dart';
 ///   endTime: DateTime.now(),
 ///   energy: Energy.kilocalories(450), // 450 kcal total (active + basal)
 ///   metadata: Metadata.automaticallyRecorded(
-///     dataOrigin: DataOrigin(packageName: 'com.example.app'),
+///     device: Device.fromType(DeviceType.watch),
 ///   ),
 /// );
 /// ```

--- a/packages/health_connector_core/lib/src/models/health_records/exercise/exercise_session_record.dart
+++ b/packages/health_connector_core/lib/src/models/health_records/exercise/exercise_session_record.dart
@@ -21,7 +21,7 @@ part of '../health_record.dart';
 ///   title: 'Morning Run',
 ///   notes: 'Felt great!',
 ///   metadata: Metadata.automaticallyRecorded(
-///     dataOrigin: DataOrigin(packageName: 'com.example.app'),
+///     device: Device.fromType(DeviceType.watch),
 ///   ),
 /// );
 /// ```

--- a/packages/health_connector_core/lib/src/models/health_records/floors_climbed_record.dart
+++ b/packages/health_connector_core/lib/src/models/health_records/floors_climbed_record.dart
@@ -19,7 +19,7 @@ part of 'health_record.dart';
 ///   endTime: DateTime.now(),
 ///   floors: Numeric(5), // 5 floors climbed
 ///   metadata: Metadata.automaticallyRecorded(
-///     dataOrigin: DataOrigin(packageName: 'com.example.app'),
+///     device: Device.fromType(DeviceType.watch),
 ///   ),
 /// );
 /// ```

--- a/packages/health_connector_core/lib/src/models/health_records/heart_rate/heart_rate_measurement_record.dart
+++ b/packages/health_connector_core/lib/src/models/health_records/heart_rate/heart_rate_measurement_record.dart
@@ -18,7 +18,7 @@ part of '../health_record.dart';
 ///   time: DateTime.now(),
 ///   beatsPerMinute: Frequency.perMinute(72),
 ///   metadata: Metadata.automaticallyRecorded(
-///     dataOrigin: DataOrigin(packageName: 'com.apple.health'),
+///     device: Device.fromType(DeviceType.watch),
 ///   ),
 /// );
 /// ```

--- a/packages/health_connector_core/lib/src/models/health_records/heart_rate/heart_rate_series_record.dart
+++ b/packages/health_connector_core/lib/src/models/health_records/heart_rate/heart_rate_series_record.dart
@@ -32,7 +32,7 @@ part of '../health_record.dart';
 ///     ),
 ///   ],
 ///   metadata: Metadata.automaticallyRecorded(
-///     dataOrigin: DataOrigin(packageName: 'com.example.app'),
+///     device: Device.fromType(DeviceType.watch),
 ///   ),
 /// );
 /// ```

--- a/packages/health_connector_core/lib/src/models/health_records/heart_rate/heart_rate_variability_sdnn_record.dart
+++ b/packages/health_connector_core/lib/src/models/health_records/heart_rate/heart_rate_variability_sdnn_record.dart
@@ -19,9 +19,7 @@ part of '../health_record.dart';
 /// final record = HeartRateVariabilitySDNNRecord(
 ///   time: DateTime.now(),
 ///   heartRateVariabilitySDNN: Number(50.0), // milliseconds
-///   metadata: Metadata.manualEntry(
-///     dataOrigin: DataOrigin(packageName: 'com.example.app'),
-///   ),
+///   metadata: Metadata.manualEntry(),
 /// );
 /// ```
 ///

--- a/packages/health_connector_core/lib/src/models/health_records/heart_rate/resting_heart_rate_record.dart
+++ b/packages/health_connector_core/lib/src/models/health_records/heart_rate/resting_heart_rate_record.dart
@@ -20,9 +20,7 @@ part of '../health_record.dart';
 /// final record = RestingHeartRateRecord(
 ///   time: DateTime.now(),
 ///   beatsPerMinute: Frequency.perMinute(60),
-///   metadata: Metadata.manualEntry(
-///     dataOrigin: DataOrigin(packageName: 'com.example.app'),
-///   ),
+///   metadata: Metadata.manualEntry(),
 /// );
 /// ```
 ///

--- a/packages/health_connector_core/lib/src/models/health_records/height_record.dart
+++ b/packages/health_connector_core/lib/src/models/health_records/height_record.dart
@@ -16,9 +16,7 @@ part of 'health_record.dart';
 /// final record = HeightRecord(
 ///   time: DateTime.now(),
 ///   height: Length.centimeters(175),
-///   metadata: Metadata.manualEntry(
-///     dataOrigin: DataOrigin(packageName: 'com.example.app'),
-///   ),
+///   metadata: Metadata.manualEntry(),
 /// );
 /// ```
 ///

--- a/packages/health_connector_core/lib/src/models/health_records/hydration_record.dart
+++ b/packages/health_connector_core/lib/src/models/health_records/hydration_record.dart
@@ -18,7 +18,7 @@ part of 'health_record.dart';
 ///   endTime: DateTime.now(),
 ///   volume: Volume.milliliters(500),
 ///   metadata: Metadata.automaticallyRecorded(
-///     dataOrigin: DataOrigin(packageName: 'com.example.hydration_tracker'),
+///     device: Device.fromType(DeviceType.phone),
 ///   ),
 /// );
 /// ```

--- a/packages/health_connector_core/lib/src/models/health_records/lean_body_mass_record.dart
+++ b/packages/health_connector_core/lib/src/models/health_records/lean_body_mass_record.dart
@@ -18,7 +18,7 @@ part of 'health_record.dart';
 ///   time: DateTime.now(),
 ///   mass: Mass.kilograms(60.0),
 ///   metadata: Metadata.automaticallyRecorded(
-///     dataOrigin: DataOrigin(packageName: 'com.example.app'),
+///     device: Device.fromType(DeviceType.watch),
 ///   ),
 /// );
 /// ```

--- a/packages/health_connector_core/lib/src/models/health_records/menstruation/intermenstrual_bleeding_record.dart
+++ b/packages/health_connector_core/lib/src/models/health_records/menstruation/intermenstrual_bleeding_record.dart
@@ -19,7 +19,7 @@ part of '../health_record.dart';
 ///   id: HealthRecordId.none,
 ///   time: DateTime(2024, 1, 15, 10, 30),
 ///   metadata: Metadata.automaticallyRecorded(
-///     dataOrigin: DataOrigin(packageName: 'com.example.app'),
+///     device: Device.fromType(DeviceType.watch),
 ///   ),
 /// );
 /// ```

--- a/packages/health_connector_core/lib/src/models/health_records/menstruation/menstrual_flow_instant_record.dart
+++ b/packages/health_connector_core/lib/src/models/health_records/menstruation/menstrual_flow_instant_record.dart
@@ -15,9 +15,7 @@ part of '../health_record.dart';
 /// final record = MenstrualFlowInstantRecord(
 ///   time: DateTime(2024, 1, 15, 8, 30),
 ///   flow: MenstrualFlowType.medium,
-///   metadata: Metadata.manualEntry(
-///     dataOrigin: DataOrigin(packageName: 'com.example.app'),
-///   ),
+///   metadata: Metadata.manualEntry(),
 /// );
 /// ```
 ///

--- a/packages/health_connector_core/lib/src/models/health_records/menstruation/menstrual_flow_record.dart
+++ b/packages/health_connector_core/lib/src/models/health_records/menstruation/menstrual_flow_record.dart
@@ -21,9 +21,7 @@ part of '../health_record.dart';
 ///   endTime: DateTime(2024, 1, 18, 20, 0),
 ///   flow: MenstrualFlowType.medium,
 ///   isCycleStart: true,
-///   metadata: Metadata.manualEntry(
-///     dataOrigin: DataOrigin(packageName: 'com.example.app'),
-///   ),
+///   metadata: Metadata.manualEntry(),
 /// );
 ///
 /// // Multi-sample period (first sample)
@@ -32,9 +30,7 @@ part of '../health_record.dart';
 ///   endTime: DateTime(2024, 1, 15, 14, 0),
 ///   flow: MenstrualFlowType.heavy,
 ///   isCycleStart: true,
-///   metadata: Metadata.manualEntry(
-///     dataOrigin: DataOrigin(packageName: 'com.example.app'),
-///   ),
+///   metadata: Metadata.manualEntry(),
 /// );
 ///
 /// // Multi-sample period (subsequent sample)
@@ -43,9 +39,7 @@ part of '../health_record.dart';
 ///   endTime: DateTime(2024, 1, 15, 20, 0),
 ///   flow: MenstrualFlowType.medium,
 ///   isCycleStart: false,
-///   metadata: Metadata.manualEntry(
-///     dataOrigin: DataOrigin(packageName: 'com.example.app'),
-///   ),
+///   metadata: Metadata.manualEntry(),
 /// );
 /// ```
 ///

--- a/packages/health_connector_core/lib/src/models/health_records/menstruation/ovulation_test_record.dart
+++ b/packages/health_connector_core/lib/src/models/health_records/menstruation/ovulation_test_record.dart
@@ -19,7 +19,7 @@ part of '../health_record.dart';
 ///   time: DateTime(2024, 1, 15, 8, 30),
 ///   result: OvulationTestResultType.positive,
 ///   metadata: Metadata.automaticallyRecorded(
-///     dataOrigin: DataOrigin(packageName: 'com.example.app'),
+///     device: Device.fromType(DeviceType.watch),
 ///   ),
 /// );
 /// ```

--- a/packages/health_connector_core/lib/src/models/health_records/mindfulness/mindfulness_session_record.dart
+++ b/packages/health_connector_core/lib/src/models/health_records/mindfulness/mindfulness_session_record.dart
@@ -20,7 +20,7 @@ part of '../health_record.dart';
 ///   title: 'Morning Meditation',
 ///   notes: 'Focused on breath awareness',
 ///   metadata: Metadata.automaticallyRecorded(
-///     dataOrigin: DataOrigin(packageName: 'com.example.app'),
+///     device: Device.fromType(DeviceType.watch),
 ///   ),
 /// );
 /// ```

--- a/packages/health_connector_core/lib/src/models/health_records/nutrition/biotin_nutrient_record.dart
+++ b/packages/health_connector_core/lib/src/models/health_records/nutrition/biotin_nutrient_record.dart
@@ -19,9 +19,7 @@ part of '../health_record.dart';
 ///   value: Mass.micrograms(10),
 ///   foodName: 'Egg',
 ///   mealType: MealType.breakfast,
-///   metadata: Metadata.manualEntry(
-///     dataOrigin: DataOrigin(packageName: 'com.example.app'),
-///   ),
+///   metadata: Metadata.manualEntry(),
 /// );
 /// ```
 ///

--- a/packages/health_connector_core/lib/src/models/health_records/nutrition/caffeine_nutrient_record.dart
+++ b/packages/health_connector_core/lib/src/models/health_records/nutrition/caffeine_nutrient_record.dart
@@ -18,9 +18,7 @@ part of '../health_record.dart';
 ///   value: Mass.milligrams(95),
 ///   foodName: 'Coffee',
 ///   mealType: MealType.breakfast,
-///   metadata: Metadata.manualEntry(
-///     dataOrigin: DataOrigin(packageName: 'com.example.app'),
-///   ),
+///   metadata: Metadata.manualEntry(),
 /// );
 /// ```
 ///

--- a/packages/health_connector_core/lib/src/models/health_records/nutrition/calcium_nutrient_record.dart
+++ b/packages/health_connector_core/lib/src/models/health_records/nutrition/calcium_nutrient_record.dart
@@ -18,9 +18,7 @@ part of '../health_record.dart';
 ///   value: Mass.milligrams(300),
 ///   foodName: 'Milk',
 ///   mealType: MealType.breakfast,
-///   metadata: Metadata.manualEntry(
-///     dataOrigin: DataOrigin(packageName: 'com.example.app'),
-///   ),
+///   metadata: Metadata.manualEntry(),
 /// );
 /// ```
 ///

--- a/packages/health_connector_core/lib/src/models/health_records/nutrition/cholesterol_nutrient_record.dart
+++ b/packages/health_connector_core/lib/src/models/health_records/nutrition/cholesterol_nutrient_record.dart
@@ -19,9 +19,7 @@ part of '../health_record.dart';
 ///   value: Mass.milligrams(186),
 ///   foodName: 'Egg',
 ///   mealType: MealType.breakfast,
-///   metadata: Metadata.manualEntry(
-///     dataOrigin: DataOrigin(packageName: 'com.example.app'),
-///   ),
+///   metadata: Metadata.manualEntry(),
 /// );
 /// ```
 ///

--- a/packages/health_connector_core/lib/src/models/health_records/nutrition/dietary_fiber_nutrient_record.dart
+++ b/packages/health_connector_core/lib/src/models/health_records/nutrition/dietary_fiber_nutrient_record.dart
@@ -20,9 +20,7 @@ part of '../health_record.dart';
 ///   value: Mass.grams(4),
 ///   foodName: 'Oatmeal',
 ///   mealType: MealType.breakfast,
-///   metadata: Metadata.manualEntry(
-///     dataOrigin: DataOrigin(packageName: 'com.example.app'),
-///   ),
+///   metadata: Metadata.manualEntry(),
 /// );
 /// ```
 ///

--- a/packages/health_connector_core/lib/src/models/health_records/nutrition/energy_nutrient_record.dart
+++ b/packages/health_connector_core/lib/src/models/health_records/nutrition/energy_nutrient_record.dart
@@ -19,9 +19,7 @@ part of '../health_record.dart';
 ///   value: Energy.kilocalories(250),
 ///   foodName: 'Apple',
 ///   mealType: MealType.snack,
-///   metadata: Metadata.manualEntry(
-///     dataOrigin: DataOrigin(packageName: 'com.example.app'),
-///   ),
+///   metadata: Metadata.manualEntry(),
 /// );
 /// ```
 ///

--- a/packages/health_connector_core/lib/src/models/health_records/nutrition/folate_nutrient_record.dart
+++ b/packages/health_connector_core/lib/src/models/health_records/nutrition/folate_nutrient_record.dart
@@ -19,9 +19,7 @@ part of '../health_record.dart';
 ///   value: Mass.micrograms(180),
 ///   foodName: 'Lentils',
 ///   mealType: MealType.lunch,
-///   metadata: Metadata.manualEntry(
-///     dataOrigin: DataOrigin(packageName: 'com.example.app'),
-///   ),
+///   metadata: Metadata.manualEntry(),
 /// );
 /// ```
 ///

--- a/packages/health_connector_core/lib/src/models/health_records/nutrition/iron_nutrient_record.dart
+++ b/packages/health_connector_core/lib/src/models/health_records/nutrition/iron_nutrient_record.dart
@@ -18,9 +18,7 @@ part of '../health_record.dart';
 ///   value: Mass.milligrams(2.7),
 ///   foodName: 'Spinach',
 ///   mealType: MealType.lunch,
-///   metadata: Metadata.manualEntry(
-///     dataOrigin: DataOrigin(packageName: 'com.example.app'),
-///   ),
+///   metadata: Metadata.manualEntry(),
 /// );
 /// ```
 ///

--- a/packages/health_connector_core/lib/src/models/health_records/nutrition/magnesium_nutrient_record.dart
+++ b/packages/health_connector_core/lib/src/models/health_records/nutrition/magnesium_nutrient_record.dart
@@ -18,9 +18,7 @@ part of '../health_record.dart';
 ///   value: Mass.milligrams(80),
 ///   foodName: 'Almonds',
 ///   mealType: MealType.snack,
-///   metadata: Metadata.manualEntry(
-///     dataOrigin: DataOrigin(packageName: 'com.example.app'),
-///   ),
+///   metadata: Metadata.manualEntry(),
 /// );
 /// ```
 ///

--- a/packages/health_connector_core/lib/src/models/health_records/nutrition/manganese_nutrient_record.dart
+++ b/packages/health_connector_core/lib/src/models/health_records/nutrition/manganese_nutrient_record.dart
@@ -18,9 +18,7 @@ part of '../health_record.dart';
 ///   value: Mass.milligrams(1.5),
 ///   foodName: 'Oats',
 ///   mealType: MealType.breakfast,
-///   metadata: Metadata.manualEntry(
-///     dataOrigin: DataOrigin(packageName: 'com.example.app'),
-///   ),
+///   metadata: Metadata.manualEntry(),
 /// );
 /// ```
 ///

--- a/packages/health_connector_core/lib/src/models/health_records/nutrition/monounsaturated_fat_nutrient_record.dart
+++ b/packages/health_connector_core/lib/src/models/health_records/nutrition/monounsaturated_fat_nutrient_record.dart
@@ -21,9 +21,7 @@ part of '../health_record.dart';
 ///   value: Mass.grams(10),
 ///   foodName: 'Olive Oil',
 ///   mealType: MealType.lunch,
-///   metadata: Metadata.manualEntry(
-///     dataOrigin: DataOrigin(packageName: 'com.example.app'),
-///   ),
+///   metadata: Metadata.manualEntry(),
 /// );
 /// ```
 ///

--- a/packages/health_connector_core/lib/src/models/health_records/nutrition/niacin_nutrient_record.dart
+++ b/packages/health_connector_core/lib/src/models/health_records/nutrition/niacin_nutrient_record.dart
@@ -19,9 +19,7 @@ part of '../health_record.dart';
 ///   value: Mass.milligrams(10),
 ///   foodName: 'Chicken Breast',
 ///   mealType: MealType.lunch,
-///   metadata: Metadata.manualEntry(
-///     dataOrigin: DataOrigin(packageName: 'com.example.app'),
-///   ),
+///   metadata: Metadata.manualEntry(),
 /// );
 /// ```
 ///

--- a/packages/health_connector_core/lib/src/models/health_records/nutrition/nutrition_record.dart
+++ b/packages/health_connector_core/lib/src/models/health_records/nutrition/nutrition_record.dart
@@ -28,9 +28,7 @@ part of '../health_record.dart';
 ///   protein: Mass.grams(35),
 ///   totalCarbohydrate: Mass.grams(50),
 ///   totalFat: Mass.grams(10),
-///   metadata: Metadata.manualEntry(
-///     dataOrigin: DataOrigin(packageName: 'com.example.app'),
-///   ),
+///   metadata: Metadata.manualEntry(),
 /// );
 /// ```
 ///

--- a/packages/health_connector_core/lib/src/models/health_records/nutrition/pantothenic_acid_nutrient_record.dart
+++ b/packages/health_connector_core/lib/src/models/health_records/nutrition/pantothenic_acid_nutrient_record.dart
@@ -21,9 +21,7 @@ part of '../health_record.dart';
 ///   value: Mass.milligrams(1),
 ///   food Name: 'Avocado',
 ///   mealType: MealType.snack,
-///   metadata: Metadata.manualEntry(
-///     dataOrigin: DataOrigin(packageName: 'com.example.app'),
-///   ),
+///   metadata: Metadata.manualEntry(),
 /// );
 /// ```
 ///

--- a/packages/health_connector_core/lib/src/models/health_records/nutrition/phosphorus_nutrient_record.dart
+++ b/packages/health_connector_core/lib/src/models/health_records/nutrition/phosphorus_nutrient_record.dart
@@ -19,9 +19,7 @@ part of '../health_record.dart';
 ///   value: Mass.milligrams(200),
 ///   foodName: 'Chicken',
 ///   mealType: MealType.dinner,
-///   metadata: Metadata.manualEntry(
-///     dataOrigin: DataOrigin(packageName: 'com.example.app'),
-///   ),
+///   metadata: Metadata.manualEntry(),
 /// );
 /// ```
 ///

--- a/packages/health_connector_core/lib/src/models/health_records/nutrition/polyunsaturated_fat_nutrient_record.dart
+++ b/packages/health_connector_core/lib/src/models/health_records/nutrition/polyunsaturated_fat_nutrient_record.dart
@@ -21,9 +21,7 @@ part of '../health_record.dart';
 ///   value: Mass.grams(8),
 ///   foodName: 'Salmon',
 ///   mealType: MealType.dinner,
-///   metadata: Metadata.manualEntry(
-///     dataOrigin: DataOrigin(packageName: 'com.example.app'),
-///   ),
+///   metadata: Metadata.manualEntry(),
 /// );
 /// ```
 ///

--- a/packages/health_connector_core/lib/src/models/health_records/nutrition/potassium_nutrient_record.dart
+++ b/packages/health_connector_core/lib/src/models/health_records/nutrition/potassium_nutrient_record.dart
@@ -18,9 +18,7 @@ part of '../health_record.dart';
 ///   value: Mass.milligrams(422),
 ///   foodName: 'Banana',
 ///   mealType: MealType.snack,
-///   metadata: Metadata.manualEntry(
-///     dataOrigin: DataOrigin(packageName: 'com.example.app'),
-///   ),
+///   metadata: Metadata.manualEntry(),
 /// );
 /// ```
 ///

--- a/packages/health_connector_core/lib/src/models/health_records/nutrition/protein_nutrient_record.dart
+++ b/packages/health_connector_core/lib/src/models/health_records/nutrition/protein_nutrient_record.dart
@@ -18,9 +18,7 @@ part of '../health_record.dart';
 ///   value: Mass.grams(30),
 ///   foodName: 'Grilled Chicken',
 ///   mealType: MealType.lunch,
-///   metadata: Metadata.manualEntry(
-///     dataOrigin: DataOrigin(packageName: 'com.example.app'),
-///   ),
+///   metadata: Metadata.manualEntry(),
 /// );
 /// ```
 ///

--- a/packages/health_connector_core/lib/src/models/health_records/nutrition/riboflavin_nutrient_record.dart
+++ b/packages/health_connector_core/lib/src/models/health_records/nutrition/riboflavin_nutrient_record.dart
@@ -20,9 +20,7 @@ part of '../health_record.dart';
 ///   value: Mass.milligrams(0.3),
 ///   foodName: 'Yogurt',
 ///   mealType: MealType.breakfast,
-///   metadata: Metadata.manualEntry(
-///     dataOrigin: DataOrigin(packageName: 'com.example.app'),
-///   ),
+///   metadata: Metadata.manualEntry(),
 /// );
 /// ```
 ///

--- a/packages/health_connector_core/lib/src/models/health_records/nutrition/saturated_fat_nutrient_record.dart
+++ b/packages/health_connector_core/lib/src/models/health_records/nutrition/saturated_fat_nutrient_record.dart
@@ -20,9 +20,7 @@ part of '../health_record.dart';
 ///   value: Mass.grams(5),
 ///   foodName: 'Cheese',
 ///   mealType: MealType.snack,
-///   metadata: Metadata.manualEntry(
-///     dataOrigin: DataOrigin(packageName: 'com.example.app'),
-///   ),
+///   metadata: Metadata.manualEntry(),
 /// );
 /// ```
 ///

--- a/packages/health_connector_core/lib/src/models/health_records/nutrition/selenium_nutrient_record.dart
+++ b/packages/health_connector_core/lib/src/models/health_records/nutrition/selenium_nutrient_record.dart
@@ -18,9 +18,7 @@ part of '../health_record.dart';
 ///   value: Mass.micrograms(68),
 ///   foodName: 'Brazil Nuts',
 ///   mealType: MealType.snack,
-///   metadata: Metadata.manualEntry(
-///     dataOrigin: DataOrigin(packageName: 'com.example.app'),
-///   ),
+///   metadata: Metadata.manualEntry(),
 /// );
 /// ```
 ///

--- a/packages/health_connector_core/lib/src/models/health_records/nutrition/sodium_nutrient_record.dart
+++ b/packages/health_connector_core/lib/src/models/health_records/nutrition/sodium_nutrient_record.dart
@@ -18,9 +18,7 @@ part of '../health_record.dart';
 ///   value: Mass.milligrams(700),
 ///   foodName: 'Soup',
 ///   mealType: MealType.lunch,
-///   metadata: Metadata.manualEntry(
-///     dataOrigin: DataOrigin(packageName: 'com.example.app'),
-///   ),
+///   metadata: Metadata.manualEntry(),
 /// );
 /// ```
 ///

--- a/packages/health_connector_core/lib/src/models/health_records/nutrition/sugar_nutrient_record.dart
+++ b/packages/health_connector_core/lib/src/models/health_records/nutrition/sugar_nutrient_record.dart
@@ -18,9 +18,7 @@ part of '../health_record.dart';
 ///   value: Mass.grams(10),
 ///   foodName: 'Apple',
 ///   mealType: MealType.snack,
-///   metadata: Metadata.manualEntry(
-///     dataOrigin: DataOrigin(packageName: 'com.example.app'),
-///   ),
+///   metadata: Metadata.manualEntry(),
 /// );
 /// ```
 ///

--- a/packages/health_connector_core/lib/src/models/health_records/nutrition/thiamin_nutrient_record.dart
+++ b/packages/health_connector_core/lib/src/models/health_records/nutrition/thiamin_nutrient_record.dart
@@ -19,9 +19,7 @@ part of '../health_record.dart';
 ///   value: Mass.milligrams(0.1),
 ///   foodName: 'Whole Wheat Bread',
 ///   mealType: MealType.breakfast,
-///   metadata: Metadata.manualEntry(
-///     dataOrigin: DataOrigin(packageName: 'com.example.app'),
-///   ),
+///   metadata: Metadata.manualEntry(),
 /// );
 /// ```
 ///

--- a/packages/health_connector_core/lib/src/models/health_records/nutrition/total_carbohydrate_nutrient_record.dart
+++ b/packages/health_connector_core/lib/src/models/health_records/nutrition/total_carbohydrate_nutrient_record.dart
@@ -21,9 +21,7 @@ part of '../health_record.dart';
 ///   value: Mass.grams(45),
 ///   foodName: 'Brown Rice',
 ///   mealType: MealType.dinner,
-///   metadata: Metadata.manualEntry(
-///     dataOrigin: DataOrigin(packageName: 'com.example.app'),
-///   ),
+///   metadata: Metadata.manualEntry(),
 /// );
 /// ```
 ///

--- a/packages/health_connector_core/lib/src/models/health_records/nutrition/total_fat_nutrient_record.dart
+++ b/packages/health_connector_core/lib/src/models/health_records/nutrition/total_fat_nutrient_record.dart
@@ -18,9 +18,7 @@ part of '../health_record.dart';
 ///   value: Mass.grams(15),
 ///   foodName: 'Avocado',
 ///   mealType: MealType.snack,
-///   metadata: Metadata.manualEntry(
-///     dataOrigin: DataOrigin(packageName: 'com.example.app'),
-///   ),
+///   metadata: Metadata.manualEntry(),
 /// );
 /// ```
 ///

--- a/packages/health_connector_core/lib/src/models/health_records/nutrition/vitamin_a_nutrient_record.dart
+++ b/packages/health_connector_core/lib/src/models/health_records/nutrition/vitamin_a_nutrient_record.dart
@@ -18,9 +18,7 @@ part of '../health_record.dart';
 ///   value: Mass.micrograms(835),
 ///   foodName: 'Carrot',
 ///   mealType: MealType.snack,
-///   metadata: Metadata.manualEntry(
-///     dataOrigin: DataOrigin(packageName: 'com.example.app'),
-///   ),
+///   metadata: Metadata.manualEntry(),
 /// );
 /// ```
 ///

--- a/packages/health_connector_core/lib/src/models/health_records/nutrition/vitamin_b12_nutrient_record.dart
+++ b/packages/health_connector_core/lib/src/models/health_records/nutrition/vitamin_b12_nutrient_record.dart
@@ -19,9 +19,7 @@ part of '../health_record.dart';
 ///   value: Mass.micrograms(4.8),
 ///   foodName: 'Salmon',
 ///   mealType: MealType.dinner,
-///   metadata: Metadata.manualEntry(
-///     dataOrigin: DataOrigin(packageName: 'com.example.app'),
-///   ),
+///   metadata: Metadata.manualEntry(),
 /// );
 /// ```
 ///

--- a/packages/health_connector_core/lib/src/models/health_records/nutrition/vitamin_b6_nutrient_record.dart
+++ b/packages/health_connector_core/lib/src/models/health_records/nutrition/vitamin_b6_nutrient_record.dart
@@ -19,9 +19,7 @@ part of '../health_record.dart';
 ///   value: Mass.milligrams(0.4),
 ///   foodName: 'Banana',
 ///   mealType: MealType.snack,
-///   metadata: Metadata.manualEntry(
-///     dataOrigin: DataOrigin(packageName: 'com.example.app'),
-///   ),
+///   metadata: Metadata.manualEntry(),
 /// );
 /// ```
 ///

--- a/packages/health_connector_core/lib/src/models/health_records/nutrition/vitamin_c_nutrient_record.dart
+++ b/packages/health_connector_core/lib/src/models/health_records/nutrition/vitamin_c_nutrient_record.dart
@@ -18,9 +18,7 @@ part of '../health_record.dart';
 ///   value: Mass.milligrams(70),
 ///   foodName: 'Orange',
 ///   mealType: MealType.snack,
-///   metadata: Metadata.manualEntry(
-///     dataOrigin: DataOrigin(packageName: 'com.example.app'),
-///   ),
+///   metadata: Metadata.manualEntry(),
 /// );
 /// ```
 ///

--- a/packages/health_connector_core/lib/src/models/health_records/nutrition/vitamin_d_nutrient_record.dart
+++ b/packages/health_connector_core/lib/src/models/health_records/nutrition/vitamin_d_nutrient_record.dart
@@ -18,9 +18,7 @@ part of '../health_record.dart';
 ///   value: Mass.micrograms(2.5),
 ///   foodName: 'Fortified Milk',
 ///   mealType: MealType.breakfast,
-///   metadata: Metadata.manualEntry(
-///     dataOrigin: DataOrigin(packageName: 'com.example.app'),
-///   ),
+///   metadata: Metadata.manualEntry(),
 /// );
 /// ```
 ///

--- a/packages/health_connector_core/lib/src/models/health_records/nutrition/vitamin_e_nutrient_record.dart
+++ b/packages/health_connector_core/lib/src/models/health_records/nutrition/vitamin_e_nutrient_record.dart
@@ -18,9 +18,7 @@ part of '../health_record.dart';
 ///   value: Mass.milligrams(7.3),
 ///   foodName: 'Almonds',
 ///   mealType: MealType.snack,
-///   metadata: Metadata.manualEntry(
-///     dataOrigin: DataOrigin(packageName: 'com.example.app'),
-///   ),
+///   metadata: Metadata.manualEntry(),
 /// );
 /// ```
 ///

--- a/packages/health_connector_core/lib/src/models/health_records/nutrition/vitamin_k_nutrient_record.dart
+++ b/packages/health_connector_core/lib/src/models/health_records/nutrition/vitamin_k_nutrient_record.dart
@@ -18,9 +18,7 @@ part of '../health_record.dart';
 ///   value: Mass.micrograms(145),
 ///   foodName: 'Spinach',
 ///   mealType: MealType.lunch,
-///   metadata: Metadata.manualEntry(
-///     dataOrigin: DataOrigin(packageName: 'com.example.app'),
-///   ),
+///   metadata: Metadata.manualEntry(),
 /// );
 /// ```
 ///

--- a/packages/health_connector_core/lib/src/models/health_records/nutrition/zinc_nutrient_record.dart
+++ b/packages/health_connector_core/lib/src/models/health_records/nutrition/zinc_nutrient_record.dart
@@ -18,9 +18,7 @@ part of '../health_record.dart';
 ///   value: Mass.milligrams(5),
 ///   foodName: 'Beef',
 ///   mealType: MealType.dinner,
-///   metadata: Metadata.manualEntry(
-///     dataOrigin: DataOrigin(packageName: 'com.example.app'),
-///   ),
+///   metadata: Metadata.manualEntry(),
 /// );
 /// ```
 ///

--- a/packages/health_connector_core/lib/src/models/health_records/oxygen_saturation_record.dart
+++ b/packages/health_connector_core/lib/src/models/health_records/oxygen_saturation_record.dart
@@ -23,7 +23,7 @@ part of 'health_record.dart';
 ///   time: DateTime.now(),
 ///   percentage: Percentage.fromWhole(98), // 98% SpO₂
 ///   metadata: Metadata.automaticallyRecorded(
-///     dataOrigin: DataOrigin(packageName: 'com.example.app'),
+///     device: Device.fromType(DeviceType.watch),
 ///   ),
 /// );
 /// ```

--- a/packages/health_connector_core/lib/src/models/health_records/respiratory_rate_record.dart
+++ b/packages/health_connector_core/lib/src/models/health_records/respiratory_rate_record.dart
@@ -21,7 +21,7 @@ part of 'health_record.dart';
 ///   time: DateTime.now(),
 ///   breathsPerMin: Frequency.perMinute(16),
 ///   metadata: Metadata.automaticallyRecorded(
-///     dataOrigin: DataOrigin(packageName: 'com.example.app'),
+///     device: Device.fromType(DeviceType.watch),
 ///   ),
 /// );
 /// ```

--- a/packages/health_connector_core/lib/src/models/health_records/sexual_activity/sexual_activity_record.dart
+++ b/packages/health_connector_core/lib/src/models/health_records/sexual_activity/sexual_activity_record.dart
@@ -19,7 +19,7 @@ part of '../health_record.dart';
 ///   time: DateTime(2024, 1, 15, 22, 0),
 ///   protectionUsed: SexualActivityProtectionUsedType.protected,
 ///   metadata: Metadata.automaticallyRecorded(
-///     dataOrigin: DataOrigin(packageName: 'com.example.app'),
+///     device: Device.fromType(DeviceType.watch),
 ///   ),
 /// );
 /// ```

--- a/packages/health_connector_core/lib/src/models/health_records/sleep/sleep_session_record.dart
+++ b/packages/health_connector_core/lib/src/models/health_records/sleep/sleep_session_record.dart
@@ -31,7 +31,7 @@ part of '../health_record.dart';
 ///     // ... more stages
 ///   ],
 ///   metadata: Metadata.automaticallyRecorded(
-///     dataOrigin: DataOrigin(packageName: 'com.example.app'),
+///     device: Device.fromType(DeviceType.watch),
 ///   ),
 /// );
 /// ```

--- a/packages/health_connector_core/lib/src/models/health_records/sleep/sleep_stage_record.dart
+++ b/packages/health_connector_core/lib/src/models/health_records/sleep/sleep_stage_record.dart
@@ -23,7 +23,7 @@ part of '../health_record.dart';
 ///     stageType: SleepStageType.light,
 ///   ),
 ///   metadata: Metadata.automaticallyRecorded(
-///     dataOrigin: DataOrigin(packageName: 'com.apple.health'),
+///     device: Device.fromType(DeviceType.watch),
 ///   ),
 /// );
 /// ```

--- a/packages/health_connector_core/lib/src/models/health_records/steps_record.dart
+++ b/packages/health_connector_core/lib/src/models/health_records/steps_record.dart
@@ -19,7 +19,7 @@ part of 'health_record.dart';
 ///   endTime: DateTime.now(),
 ///   count: Number(1500),
 ///   metadata: Metadata.automaticallyRecorded(
-///     dataOrigin: DataOrigin(packageName: 'com.example.app'),
+///     device: Device.fromType(DeviceType.phone),
 ///   ),
 /// );
 /// ```

--- a/packages/health_connector_core/lib/src/models/health_records/temperature/basal_body_temperature_record.dart
+++ b/packages/health_connector_core/lib/src/models/health_records/temperature/basal_body_temperature_record.dart
@@ -20,9 +20,7 @@ part of '../health_record.dart';
 ///   time: DateTime.now(),
 ///   temperature: Temperature.celsius(36.5),
 ///   measurementLocation: BasalBodyTemperatureMeasurementLocation.mouth,
-///   metadata: Metadata.manualEntry(
-///     dataOrigin: DataOrigin(packageName: 'com.example.app'),
-///   ),
+///   metadata: Metadata.manualEntry(),
 /// );
 /// ```
 ///

--- a/packages/health_connector_core/lib/src/models/health_records/temperature/body_temperature_record.dart
+++ b/packages/health_connector_core/lib/src/models/health_records/temperature/body_temperature_record.dart
@@ -16,9 +16,7 @@ part of '../health_record.dart';
 /// final record = BodyTemperatureRecord(
 ///   time: DateTime.now(),
 ///   temperature: Temperature.celsius(36.5),
-///   metadata: Metadata.manualEntry(
-///     dataOrigin: DataOrigin(packageName: 'com.example.app'),
-///   ),
+///   metadata: Metadata.manualEntry(),
 /// );
 /// ```
 ///

--- a/packages/health_connector_core/lib/src/models/health_records/vo2_max_record.dart
+++ b/packages/health_connector_core/lib/src/models/health_records/vo2_max_record.dart
@@ -28,9 +28,7 @@ part of 'health_record.dart';
 ///   time: DateTime.now(),
 ///   mLPerKgPerMin: Number(45.2),
 ///   testType: Vo2MaxTestType.cooperTest,
-///   metadata: Metadata.manualEntry(
-///     dataOrigin: DataOrigin(packageName: 'com.example.app'),
-///   ),
+///   metadata: Metadata.manualEntry(),
 /// );
 /// ```
 ///

--- a/packages/health_connector_core/lib/src/models/health_records/waist_circumference_record.dart
+++ b/packages/health_connector_core/lib/src/models/health_records/waist_circumference_record.dart
@@ -18,9 +18,7 @@ part of 'health_record.dart';
 /// final record = WaistCircumferenceRecord(
 ///   time: DateTime.now(),
 ///   circumference: Length.meters(0.85), // 85 cm
-///   metadata: Metadata.manualEntry(
-///     dataOrigin: DataOrigin(packageName: 'com.example.app'),
-///   ),
+///   metadata: Metadata.manualEntry(),
 /// );
 /// ```
 ///

--- a/packages/health_connector_core/lib/src/models/health_records/weight_record.dart
+++ b/packages/health_connector_core/lib/src/models/health_records/weight_record.dart
@@ -16,9 +16,7 @@ part of 'health_record.dart';
 /// final record = WeightRecord(
 ///   time: DateTime.now(),
 ///   weight: Mass.kilograms(72.5),
-///   metadata: Metadata.manualEntry(
-///     dataOrigin: DataOrigin(packageName: 'com.example.app'),
-///   ),
+///   metadata: Metadata.manualEntry(),
 /// );
 /// ```
 ///

--- a/packages/health_connector_core/lib/src/models/health_records/wheelchair_pushes_record.dart
+++ b/packages/health_connector_core/lib/src/models/health_records/wheelchair_pushes_record.dart
@@ -19,7 +19,7 @@ part of 'health_record.dart';
 ///   endTime: DateTime.now(),
 ///   pushes: Numeric(150), // 150 pushes
 ///   metadata: Metadata.automaticallyRecorded(
-///     dataOrigin: DataOrigin(packageName: 'com.example.app'),
+///     device: Device.fromType(DeviceType.phone),
 ///   ),
 /// );
 /// ```

--- a/packages/health_connector_core/lib/src/models/metadata/metadata.dart
+++ b/packages/health_connector_core/lib/src/models/metadata/metadata.dart
@@ -1,5 +1,5 @@
 import 'package:health_connector_core/src/annotations/annotations.dart'
-    show sinceV1_0_0;
+    show sinceV1_0_0, internalUse;
 import 'package:meta/meta.dart' show immutable;
 
 part 'data_origin.dart';
@@ -25,14 +25,47 @@ final class Metadata {
   /// - [clientRecordId]: A custom identifier assigned by your application.
   /// - [clientRecordVersion]: A version number assigned by your application.
   /// - [device]: The device that recorded the data.
-  const Metadata({
-    required this.dataOrigin,
+  const Metadata._({
     required this.recordingMethod,
+    this.dataOrigin,
     this.lastModifiedTime,
     this.clientRecordId,
     this.clientRecordVersion,
     this.device,
   });
+
+  /// Factory constructor for platform implementations.
+  ///
+  /// **⚠️ Internal Use Only**: This factory is intended for use by the SDK to
+  /// construct metadata instances populated with values from the underlying
+  /// native platform.
+  ///
+  /// ## Parameters
+  ///
+  /// - [dataOrigin]: The application that wrote this health record.
+  /// - [recordingMethod]: The method used to record this data.
+  /// - [lastModifiedTime]: The timestamp when this record was last modified.
+  /// - [clientRecordId]: A custom identifier assigned by your application.
+  /// - [clientRecordVersion]: A version number assigned by your application.
+  /// - [device]: The device that recorded the data.
+  @internalUse
+  factory Metadata.internal({
+    required RecordingMethod recordingMethod,
+    DataOrigin? dataOrigin,
+    DateTime? lastModifiedTime,
+    String? clientRecordId,
+    int? clientRecordVersion,
+    Device? device,
+  }) {
+    return Metadata._(
+      recordingMethod: recordingMethod,
+      dataOrigin: dataOrigin,
+      lastModifiedTime: lastModifiedTime,
+      clientRecordId: clientRecordId,
+      clientRecordVersion: clientRecordVersion,
+      device: device,
+    );
+  }
 
   /// Creates metadata for manually entered data.
   ///
@@ -41,16 +74,13 @@ final class Metadata {
   ///
   /// ## Parameters
   ///
-  /// - [dataOrigin]: The application that wrote this health record.
   /// - [clientRecordId]: A custom identifier assigned by your application.
   /// - [clientRecordVersion]: A version number assigned by your application.
   factory Metadata.manualEntry({
-    required DataOrigin dataOrigin,
     String? clientRecordId,
     int? clientRecordVersion,
   }) {
-    return Metadata(
-      dataOrigin: dataOrigin,
+    return Metadata._(
       recordingMethod: RecordingMethod.manualEntry,
       clientRecordId: clientRecordId,
       clientRecordVersion: clientRecordVersion,
@@ -64,18 +94,15 @@ final class Metadata {
   ///
   /// ## Parameters
   ///
-  /// - [dataOrigin]: The application that wrote this health record.
   /// - [device]: The device that recorded the data.
   /// - [clientRecordId]: A custom identifier assigned by your application.
   /// - [clientRecordVersion]: A version number assigned by your application.
   factory Metadata.automaticallyRecorded({
-    required DataOrigin dataOrigin,
     required Device device,
     String? clientRecordId,
     int? clientRecordVersion,
   }) {
-    return Metadata(
-      dataOrigin: dataOrigin,
+    return Metadata._(
       recordingMethod: RecordingMethod.automaticallyRecorded,
       device: device,
       clientRecordId: clientRecordId,
@@ -91,18 +118,15 @@ final class Metadata {
   ///
   /// ## Parameters
   ///
-  /// - [dataOrigin]: The application that wrote this health record.
   /// - [device]: The device that recorded the data.
   /// - [clientRecordId]: A custom identifier assigned by your application.
   /// - [clientRecordVersion]: A version number assigned by your application.
   factory Metadata.activelyRecorded({
-    required DataOrigin dataOrigin,
     required Device device,
     String? clientRecordId,
     int? clientRecordVersion,
   }) {
-    return Metadata(
-      dataOrigin: dataOrigin,
+    return Metadata._(
       recordingMethod: RecordingMethod.activelyRecorded,
       device: device,
       clientRecordId: clientRecordId,
@@ -117,18 +141,15 @@ final class Metadata {
   ///
   /// ## Parameters
   ///
-  /// - [dataOrigin]: The application that wrote this health record.
   /// - [device]: The device that recorded the data.
   /// - [clientRecordId]: A custom identifier assigned by your application.
   /// - [clientRecordVersion]: A version number assigned by your application.
   factory Metadata.unknownRecordingMethod({
-    required DataOrigin dataOrigin,
     Device? device,
     String? clientRecordId,
     int? clientRecordVersion,
   }) {
-    return Metadata(
-      dataOrigin: dataOrigin,
+    return Metadata._(
       recordingMethod: RecordingMethod.unknown,
       device: device,
       clientRecordId: clientRecordId,
@@ -136,11 +157,14 @@ final class Metadata {
     );
   }
 
-  /// The application that wrote this health record.
+  /// The data origin (app package name) that wrote this record.
   ///
-  /// Identifies the source application using its package name
-  /// (Android Health Connect) or bundle identifier (iOS HealthKit).
-  final DataOrigin dataOrigin;
+  /// This field is automatically populated by the platform when writing records
+  /// and is only available on records retrieved via read operations.
+  ///
+  /// **Important**: You cannot specify the data origin when creating records.
+  /// The platform automatically assigns your app's package name/bundle ID.
+  final DataOrigin? dataOrigin;
 
   /// The timestamp when this record was last modified on the platform.
   ///
@@ -190,15 +214,14 @@ final class Metadata {
   /// This is useful for creating variations of metadata or updating specific
   /// fields while preserving others.
   Metadata copyWith({
-    DataOrigin? dataOrigin,
     DateTime? lastModifiedTime,
     String? clientRecordId,
     int? clientRecordVersion,
     Device? device,
     RecordingMethod? recordingMethod,
   }) {
-    return Metadata(
-      dataOrigin: dataOrigin ?? this.dataOrigin,
+    return Metadata._(
+      dataOrigin: dataOrigin,
       lastModifiedTime: lastModifiedTime ?? this.lastModifiedTime,
       clientRecordId: clientRecordId ?? this.clientRecordId,
       clientRecordVersion: clientRecordVersion ?? this.clientRecordVersion,

--- a/packages/health_connector_core/test/src/models/metadata/metadata_test.dart
+++ b/packages/health_connector_core/test/src/models/metadata/metadata_test.dart
@@ -1,0 +1,176 @@
+import 'package:health_connector_core/health_connector_core.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('Metadata', () {
+    const testDataOrigin = DataOrigin('com.example.app');
+    const testDevice = Device.fromType(DeviceType.phone);
+    final testTime = DateTime(2026);
+    const testClientId = 'client_123';
+    const testClientVersion = 1;
+
+    group('internal', () {
+      test('creates metadata with all fields', () {
+        final metadata = Metadata.internal(
+          dataOrigin: testDataOrigin,
+          recordingMethod: RecordingMethod.manualEntry,
+          lastModifiedTime: testTime,
+          clientRecordId: testClientId,
+          clientRecordVersion: testClientVersion,
+          device: testDevice,
+        );
+
+        expect(metadata.dataOrigin, equals(testDataOrigin));
+        expect(metadata.recordingMethod, equals(RecordingMethod.manualEntry));
+        expect(metadata.lastModifiedTime, equals(testTime));
+        expect(metadata.clientRecordId, equals(testClientId));
+        expect(metadata.clientRecordVersion, equals(testClientVersion));
+        expect(metadata.device, equals(testDevice));
+      });
+
+      test('creates metadata with nullable fields as null', () {
+        final metadata = Metadata.internal(
+          recordingMethod: RecordingMethod.unknown,
+        );
+
+        expect(metadata.dataOrigin, isNull);
+        expect(metadata.recordingMethod, equals(RecordingMethod.unknown));
+        expect(metadata.lastModifiedTime, isNull);
+        expect(metadata.clientRecordId, isNull);
+        expect(metadata.clientRecordVersion, isNull);
+        expect(metadata.device, isNull);
+      });
+    });
+
+    group('manualEntry', () {
+      test('creates metadata with correct recording method', () {
+        final metadata = Metadata.manualEntry(
+          clientRecordId: testClientId,
+          clientRecordVersion: testClientVersion,
+        );
+
+        expect(metadata.recordingMethod, equals(RecordingMethod.manualEntry));
+        expect(metadata.clientRecordId, equals(testClientId));
+        expect(metadata.clientRecordVersion, equals(testClientVersion));
+        expect(metadata.device, isNull);
+        expect(metadata.dataOrigin, isNull);
+      });
+    });
+
+    group('automaticallyRecorded', () {
+      test('creates metadata with correct recording method', () {
+        final metadata = Metadata.automaticallyRecorded(
+          device: testDevice,
+          clientRecordId: testClientId,
+          clientRecordVersion: testClientVersion,
+        );
+
+        expect(
+          metadata.recordingMethod,
+          equals(RecordingMethod.automaticallyRecorded),
+        );
+        expect(metadata.device, equals(testDevice));
+        expect(metadata.clientRecordId, equals(testClientId));
+        expect(metadata.clientRecordVersion, equals(testClientVersion));
+        expect(metadata.dataOrigin, isNull);
+      });
+    });
+
+    group('activelyRecorded', () {
+      test('creates metadata with correct recording method', () {
+        final metadata = Metadata.activelyRecorded(
+          device: testDevice,
+          clientRecordId: testClientId,
+          clientRecordVersion: testClientVersion,
+        );
+
+        expect(
+          metadata.recordingMethod,
+          equals(RecordingMethod.activelyRecorded),
+        );
+        expect(metadata.device, equals(testDevice));
+        expect(metadata.clientRecordId, equals(testClientId));
+        expect(metadata.clientRecordVersion, equals(testClientVersion));
+        expect(metadata.dataOrigin, isNull);
+      });
+    });
+
+    group('unknownRecordingMethod', () {
+      test('creates metadata with correct recording method', () {
+        final metadata = Metadata.unknownRecordingMethod(
+          device: testDevice,
+          clientRecordId: testClientId,
+          clientRecordVersion: testClientVersion,
+        );
+
+        expect(metadata.recordingMethod, equals(RecordingMethod.unknown));
+        expect(metadata.device, equals(testDevice));
+        expect(metadata.clientRecordId, equals(testClientId));
+        expect(metadata.clientRecordVersion, equals(testClientVersion));
+        expect(metadata.dataOrigin, isNull);
+      });
+    });
+
+    group('copyWith', () {
+      final baseMetadata = Metadata.internal(
+        dataOrigin: testDataOrigin,
+        recordingMethod: RecordingMethod.manualEntry,
+        lastModifiedTime: testTime,
+        clientRecordId: testClientId,
+        clientRecordVersion: testClientVersion,
+        device: testDevice,
+      );
+
+      test('returns same object if no arguments provided', () {
+        final copiedMetadata = baseMetadata.copyWith();
+        expect(copiedMetadata, equals(baseMetadata));
+      });
+
+      test('updates provided fields', () {
+        final newTime = DateTime(2023, 2, 2);
+        const newDevice = Device.fromType(DeviceType.watch);
+        const newClientId = 'new_client_id';
+        const newVersion = 2;
+        const newMethod = RecordingMethod.automaticallyRecorded;
+
+        final copiedMetadata = baseMetadata.copyWith(
+          lastModifiedTime: newTime,
+          clientRecordId: newClientId,
+          clientRecordVersion: newVersion,
+          device: newDevice,
+          recordingMethod: newMethod,
+        );
+
+        expect(
+          copiedMetadata.dataOrigin,
+          equals(testDataOrigin),
+        ); // Should not change
+        expect(copiedMetadata.lastModifiedTime, equals(newTime));
+        expect(copiedMetadata.clientRecordId, equals(newClientId));
+        expect(copiedMetadata.clientRecordVersion, equals(newVersion));
+        expect(copiedMetadata.device, equals(newDevice));
+        expect(copiedMetadata.recordingMethod, equals(newMethod));
+      });
+    });
+
+    group('Equality and HashCode', () {
+      test('identical instances are equal', () {
+        final metadata = Metadata.manualEntry();
+        expect(metadata, equals(metadata));
+      });
+
+      test('equal instances are equal', () {
+        final metadataA = Metadata.manualEntry(clientRecordId: 'id');
+        final metadataB = Metadata.manualEntry(clientRecordId: 'id');
+        expect(metadataA, equals(metadataB));
+        expect(metadataA.hashCode, equals(metadataB.hashCode));
+      });
+
+      test('different instances are not equal', () {
+        final metadataA = Metadata.manualEntry(clientRecordId: 'id1');
+        final metadataB = Metadata.manualEntry(clientRecordId: 'id2');
+        expect(metadataA, isNot(equals(metadataB)));
+      });
+    });
+  });
+}

--- a/packages/health_connector_core/test/utils/health_record_data_type_extension_test.dart
+++ b/packages/health_connector_core/test/utils/health_record_data_type_extension_test.dart
@@ -12,9 +12,7 @@ void main() {
         () {
           // Helper function to create metadata for test records
           Metadata createTestMetadata() {
-            return Metadata.manualEntry(
-              dataOrigin: const DataOrigin('com.test.app'),
-            );
+            return Metadata.manualEntry();
           }
 
           // Helper function to create test time

--- a/packages/health_connector_hc_android/example/lib/main.dart
+++ b/packages/health_connector_hc_android/example/lib/main.dart
@@ -386,7 +386,6 @@ class _ExampleAppHomePageState extends State<ExampleAppHomePage> {
         endTime: now,
         count: const Number(1000),
         metadata: Metadata.automaticallyRecorded(
-          dataOrigin: const DataOrigin('com.example.health_connector'),
           device: const Device.fromType(DeviceType.phone),
         ),
       );
@@ -430,7 +429,6 @@ class _ExampleAppHomePageState extends State<ExampleAppHomePage> {
           endTime: now.subtract(const Duration(hours: 2)),
           count: const Number(1500),
           metadata: Metadata.automaticallyRecorded(
-            dataOrigin: const DataOrigin('com.example.health_connector'),
             device: const Device.fromType(DeviceType.watch),
           ),
         ),
@@ -439,7 +437,6 @@ class _ExampleAppHomePageState extends State<ExampleAppHomePage> {
           endTime: now.subtract(const Duration(hours: 1)),
           count: const Number(2000),
           metadata: Metadata.automaticallyRecorded(
-            dataOrigin: const DataOrigin('com.example.health_connector'),
             device: const Device.fromType(DeviceType.watch),
           ),
         ),
@@ -448,7 +445,6 @@ class _ExampleAppHomePageState extends State<ExampleAppHomePage> {
           endTime: now,
           count: const Number(1800),
           metadata: Metadata.automaticallyRecorded(
-            dataOrigin: const DataOrigin('com.example.health_connector'),
             device: const Device.fromType(DeviceType.phone),
           ),
         ),

--- a/packages/health_connector_hc_android/lib/src/mappers/metadata_mappers/metadata_mapper.dart
+++ b/packages/health_connector_hc_android/lib/src/mappers/metadata_mappers/metadata_mapper.dart
@@ -12,7 +12,7 @@ import 'package:meta/meta.dart' show internal;
 extension MetadataDtoMapper on Metadata {
   MetadataDto toDto() {
     return MetadataDto(
-      dataOrigin: dataOrigin.packageName,
+      dataOrigin: dataOrigin?.packageName ?? '',
       recordingMethod: recordingMethod.toDto(),
       lastModifiedTime: lastModifiedTime?.millisecondsSinceEpoch,
       clientRecordId: clientRecordId,
@@ -29,7 +29,7 @@ extension MetadataDtoMapper on Metadata {
 @internal
 extension MetadataDtoToDomain on MetadataDto {
   Metadata toDomain() {
-    return Metadata(
+    return Metadata.internal(
       dataOrigin: DataOrigin(dataOrigin),
       recordingMethod: recordingMethod.toDomain(),
       lastModifiedTime: lastModifiedTime != null

--- a/packages/health_connector_hc_android/test/unit_tests/src/health_connector_hc_client_test.dart
+++ b/packages/health_connector_hc_android/test/unit_tests/src/health_connector_hc_client_test.dart
@@ -653,9 +653,7 @@ void main() {
                       count: const Number(100),
                       startTime: now.subtract(const Duration(hours: 1)),
                       endTime: now,
-                      metadata: Metadata.manualEntry(
-                        dataOrigin: const DataOrigin('com.example.app'),
-                      ),
+                      metadata: Metadata.manualEntry(),
                     ),
                   );
 
@@ -677,9 +675,7 @@ void main() {
                         count: const Number(100),
                         startTime: now.subtract(const Duration(hours: 1)),
                         endTime: now,
-                        metadata: Metadata.manualEntry(
-                          dataOrigin: const DataOrigin('com.example.app'),
-                        ),
+                        metadata: Metadata.manualEntry(),
                       ),
                     ),
                     throwsA(isA<HealthConnectorException>()),
@@ -715,17 +711,13 @@ void main() {
                       count: const Number(100),
                       startTime: now.subtract(const Duration(hours: 2)),
                       endTime: now.subtract(const Duration(hours: 1)),
-                      metadata: Metadata.manualEntry(
-                        dataOrigin: const DataOrigin('com.example.app'),
-                      ),
+                      metadata: Metadata.manualEntry(),
                     ),
                     StepsRecord(
                       count: const Number(200),
                       startTime: now.subtract(const Duration(hours: 1)),
                       endTime: now,
-                      metadata: Metadata.manualEntry(
-                        dataOrigin: const DataOrigin('com.example.app'),
-                      ),
+                      metadata: Metadata.manualEntry(),
                     ),
                   ]);
 
@@ -749,9 +741,7 @@ void main() {
                         count: const Number(100),
                         startTime: now.subtract(const Duration(hours: 1)),
                         endTime: now,
-                        metadata: Metadata.manualEntry(
-                          dataOrigin: const DataOrigin('com.example.app'),
-                        ),
+                        metadata: Metadata.manualEntry(),
                       ),
                     ]),
                     throwsA(isA<HealthConnectorException>()),
@@ -779,9 +769,7 @@ void main() {
                         startTime: now.subtract(const Duration(hours: 1)),
                         endTime: now,
                         id: HealthRecordId('existing-id'),
-                        metadata: Metadata.manualEntry(
-                          dataOrigin: const DataOrigin('com.example.app'),
-                        ),
+                        metadata: Metadata.manualEntry(),
                       ),
                     ),
                     completes,
@@ -805,9 +793,7 @@ void main() {
                         startTime: now.subtract(const Duration(hours: 1)),
                         endTime: now,
                         id: HealthRecordId('existing-id'),
-                        metadata: Metadata.manualEntry(
-                          dataOrigin: const DataOrigin('com.example.app'),
-                        ),
+                        metadata: Metadata.manualEntry(),
                       ),
                     ),
                     throwsA(isA<HealthConnectorException>()),

--- a/packages/health_connector_hc_android/test/unit_tests/src/mappers/health_record_mappers/blood_glucose/blood_glucose_record_mapper_test.dart
+++ b/packages/health_connector_hc_android/test/unit_tests/src/mappers/health_record_mappers/blood_glucose/blood_glucose_record_mapper_test.dart
@@ -20,11 +20,11 @@ void main() {
                 id: HealthRecordId(FakeData.fakeId),
                 time: FakeData.fakeTime,
                 zoneOffsetSeconds: FakeData.fakeTime.timeZoneOffset.inSeconds,
-                metadata: const Metadata(
-                  dataOrigin: DataOrigin(FakeData.fakeDataOrigin),
+                metadata: Metadata.internal(
+                  dataOrigin: const DataOrigin(FakeData.fakeDataOrigin),
                   recordingMethod: RecordingMethod.activelyRecorded,
                   clientRecordVersion: 1,
-                  device: Device(type: DeviceType.phone),
+                  device: const Device(type: DeviceType.phone),
                 ),
                 bloodGlucose: const BloodGlucose.millimolesPerLiter(5.5),
                 relationToMeal: BloodGlucoseRelationToMeal.fasting,
@@ -92,7 +92,7 @@ void main() {
                 FakeData.fakeTime.timeZoneOffset.inSeconds,
               );
               expect(
-                record.metadata.dataOrigin.packageName,
+                record.metadata.dataOrigin?.packageName,
                 FakeData.fakeDataOrigin,
               );
               expect(record.bloodGlucose.inMillimolesPerLiter, 6.0);

--- a/packages/health_connector_hc_android/test/unit_tests/src/mappers/health_record_mappers/blood_pressure/blood_pressure_record_mapper_test.dart
+++ b/packages/health_connector_hc_android/test/unit_tests/src/mappers/health_record_mappers/blood_pressure/blood_pressure_record_mapper_test.dart
@@ -20,11 +20,11 @@ void main() {
                 id: HealthRecordId(FakeData.fakeId),
                 time: FakeData.fakeTime,
                 zoneOffsetSeconds: FakeData.fakeTime.timeZoneOffset.inSeconds,
-                metadata: const Metadata(
-                  dataOrigin: DataOrigin(FakeData.fakeDataOrigin),
+                metadata: Metadata.internal(
+                  dataOrigin: const DataOrigin(FakeData.fakeDataOrigin),
                   recordingMethod: RecordingMethod.activelyRecorded,
                   clientRecordVersion: 1,
-                  device: Device(type: DeviceType.phone),
+                  device: const Device(type: DeviceType.phone),
                 ),
                 systolic: const Pressure.millimetersOfMercury(120),
                 diastolic: const Pressure.millimetersOfMercury(80),
@@ -90,7 +90,7 @@ void main() {
                 FakeData.fakeTime.timeZoneOffset.inSeconds,
               );
               expect(
-                record.metadata.dataOrigin.packageName,
+                record.metadata.dataOrigin?.packageName,
                 FakeData.fakeDataOrigin,
               );
               expect(record.systolic.inMillimetersOfMercury, 130);

--- a/packages/health_connector_hc_android/test/unit_tests/src/mappers/health_record_mappers/body_fat_percentage_record_mapper_test.dart
+++ b/packages/health_connector_hc_android/test/unit_tests/src/mappers/health_record_mappers/body_fat_percentage_record_mapper_test.dart
@@ -19,11 +19,11 @@ void main() {
                 id: HealthRecordId(FakeData.fakeId),
                 time: FakeData.fakeTime,
                 zoneOffsetSeconds: FakeData.fakeTime.timeZoneOffset.inSeconds,
-                metadata: const Metadata(
-                  dataOrigin: DataOrigin(FakeData.fakeDataOrigin),
+                metadata: Metadata.internal(
+                  dataOrigin: const DataOrigin(FakeData.fakeDataOrigin),
                   recordingMethod: RecordingMethod.activelyRecorded,
                   clientRecordVersion: 1,
-                  device: Device(type: DeviceType.phone),
+                  device: const Device(type: DeviceType.phone),
                 ),
                 percentage: const Percentage.fromWhole(22.5),
               );
@@ -71,7 +71,7 @@ void main() {
                 FakeData.fakeTime.timeZoneOffset.inSeconds,
               );
               expect(
-                record.metadata.dataOrigin.packageName,
+                record.metadata.dataOrigin?.packageName,
                 FakeData.fakeDataOrigin,
               );
               expect(record.percentage.asDecimal, 0.18);

--- a/packages/health_connector_hc_android/test/unit_tests/src/mappers/health_record_mappers/body_water_mass_record_mapper_test.dart
+++ b/packages/health_connector_hc_android/test/unit_tests/src/mappers/health_record_mappers/body_water_mass_record_mapper_test.dart
@@ -19,11 +19,11 @@ void main() {
                 id: HealthRecordId(FakeData.fakeId),
                 time: FakeData.fakeTime,
                 zoneOffsetSeconds: FakeData.fakeTime.timeZoneOffset.inSeconds,
-                metadata: const Metadata(
-                  dataOrigin: DataOrigin(FakeData.fakeDataOrigin),
+                metadata: Metadata.internal(
+                  dataOrigin: const DataOrigin(FakeData.fakeDataOrigin),
                   recordingMethod: RecordingMethod.activelyRecorded,
                   clientRecordVersion: 1,
-                  device: Device(type: DeviceType.phone),
+                  device: const Device(type: DeviceType.phone),
                 ),
                 mass: const Mass.kilograms(45.5),
               );
@@ -71,7 +71,7 @@ void main() {
                 FakeData.fakeTime.timeZoneOffset.inSeconds,
               );
               expect(
-                record.metadata.dataOrigin.packageName,
+                record.metadata.dataOrigin?.packageName,
                 FakeData.fakeDataOrigin,
               );
               expect(record.mass.inKilograms, 50.0);

--- a/packages/health_connector_hc_android/test/unit_tests/src/mappers/health_record_mappers/bone_mass_record_mapper_test.dart
+++ b/packages/health_connector_hc_android/test/unit_tests/src/mappers/health_record_mappers/bone_mass_record_mapper_test.dart
@@ -19,11 +19,11 @@ void main() {
                 id: HealthRecordId(FakeData.fakeId),
                 time: FakeData.fakeTime,
                 zoneOffsetSeconds: FakeData.fakeTime.timeZoneOffset.inSeconds,
-                metadata: const Metadata(
-                  dataOrigin: DataOrigin(FakeData.fakeDataOrigin),
+                metadata: Metadata.internal(
+                  dataOrigin: const DataOrigin(FakeData.fakeDataOrigin),
                   recordingMethod: RecordingMethod.activelyRecorded,
                   clientRecordVersion: 1,
-                  device: Device(type: DeviceType.phone),
+                  device: const Device(type: DeviceType.phone),
                 ),
                 mass: const Mass.kilograms(3.2),
               );
@@ -72,7 +72,7 @@ void main() {
                 FakeData.fakeTime.timeZoneOffset.inSeconds,
               );
               expect(
-                record.metadata.dataOrigin.packageName,
+                record.metadata.dataOrigin?.packageName,
                 FakeData.fakeDataOrigin,
               );
               expect(record.mass.inKilograms, 3.5);

--- a/packages/health_connector_hc_android/test/unit_tests/src/mappers/health_record_mappers/cycling_pedaling_cadence/cycling_pedaling_cadence_series_record_mapper_test.dart
+++ b/packages/health_connector_hc_android/test/unit_tests/src/mappers/health_record_mappers/cycling_pedaling_cadence/cycling_pedaling_cadence_series_record_mapper_test.dart
@@ -27,8 +27,8 @@ void main() {
                     FakeData.fakeStartTime.timeZoneOffset.inSeconds,
                 endZoneOffsetSeconds:
                     FakeData.fakeEndTime.timeZoneOffset.inSeconds,
-                metadata: const Metadata(
-                  dataOrigin: DataOrigin(FakeData.fakeDataOrigin),
+                metadata: Metadata.internal(
+                  dataOrigin: const DataOrigin(FakeData.fakeDataOrigin),
                   recordingMethod: RecordingMethod.activelyRecorded,
                   clientRecordVersion: 1,
                   device: Device(type: DeviceType.watch),
@@ -91,7 +91,7 @@ void main() {
               expect(record.startTime, FakeData.fakeStartTime);
               expect(record.endTime, FakeData.fakeEndTime);
               expect(
-                record.metadata.dataOrigin.packageName,
+                record.metadata.dataOrigin?.packageName,
                 FakeData.fakeDataOrigin,
               );
               expect(record.samples, hasLength(1));

--- a/packages/health_connector_hc_android/test/unit_tests/src/mappers/health_record_mappers/distance_record_mapper_test.dart
+++ b/packages/health_connector_hc_android/test/unit_tests/src/mappers/health_record_mappers/distance_record_mapper_test.dart
@@ -23,8 +23,8 @@ void main() {
                     FakeData.fakeStartTime.timeZoneOffset.inSeconds,
                 endZoneOffsetSeconds:
                     FakeData.fakeEndTime.timeZoneOffset.inSeconds,
-                metadata: const Metadata(
-                  dataOrigin: DataOrigin(FakeData.fakeDataOrigin),
+                metadata: Metadata.internal(
+                  dataOrigin: const DataOrigin(FakeData.fakeDataOrigin),
                   recordingMethod: RecordingMethod.activelyRecorded,
                   clientRecordVersion: 1,
                   device: Device(type: DeviceType.watch),

--- a/packages/health_connector_hc_android/test/unit_tests/src/mappers/health_record_mappers/energy_burned/active_calories_burned_record_mapper_test.dart
+++ b/packages/health_connector_hc_android/test/unit_tests/src/mappers/health_record_mappers/energy_burned/active_calories_burned_record_mapper_test.dart
@@ -25,11 +25,11 @@ void main() {
                     FakeData.fakeStartTime.timeZoneOffset.inSeconds,
                 endZoneOffsetSeconds:
                     FakeData.fakeEndTime.timeZoneOffset.inSeconds,
-                metadata: const Metadata(
-                  dataOrigin: DataOrigin(FakeData.fakeDataOrigin),
+                metadata: Metadata.internal(
+                  dataOrigin: const DataOrigin(FakeData.fakeDataOrigin),
                   recordingMethod: RecordingMethod.activelyRecorded,
                   clientRecordVersion: 1,
-                  device: Device(type: DeviceType.phone),
+                  device: const Device(type: DeviceType.phone),
                 ),
                 energy: const Energy.kilocalories(250.5),
               );
@@ -104,7 +104,7 @@ void main() {
                 FakeData.fakeEndTime.timeZoneOffset.inSeconds,
               );
               expect(
-                record.metadata.dataOrigin.packageName,
+                record.metadata.dataOrigin?.packageName,
                 FakeData.fakeDataOrigin,
               );
               expect(

--- a/packages/health_connector_hc_android/test/unit_tests/src/mappers/health_record_mappers/energy_burned/total_calories_burned_record_mapper_test.dart
+++ b/packages/health_connector_hc_android/test/unit_tests/src/mappers/health_record_mappers/energy_burned/total_calories_burned_record_mapper_test.dart
@@ -24,8 +24,8 @@ void main() {
                     FakeData.fakeStartTime.timeZoneOffset.inSeconds,
                 endZoneOffsetSeconds:
                     FakeData.fakeEndTime.timeZoneOffset.inSeconds,
-                metadata: const Metadata(
-                  dataOrigin: DataOrigin(FakeData.fakeDataOrigin),
+                metadata: Metadata.internal(
+                  dataOrigin: const DataOrigin(FakeData.fakeDataOrigin),
                   recordingMethod: RecordingMethod.activelyRecorded,
                   clientRecordVersion: 1,
                   device: Device(type: DeviceType.watch),

--- a/packages/health_connector_hc_android/test/unit_tests/src/mappers/health_record_mappers/exercise/exercise_session_record_mapper_test.dart
+++ b/packages/health_connector_hc_android/test/unit_tests/src/mappers/health_record_mappers/exercise/exercise_session_record_mapper_test.dart
@@ -22,8 +22,8 @@ void main() {
                 id: HealthRecordId(FakeData.fakeId),
                 startTime: FakeData.fakeStartTime,
                 endTime: FakeData.fakeEndTime,
-                metadata: const Metadata(
-                  dataOrigin: DataOrigin(FakeData.fakeDataOrigin),
+                metadata: Metadata.internal(
+                  dataOrigin: const DataOrigin(FakeData.fakeDataOrigin),
                   recordingMethod: RecordingMethod.activelyRecorded,
                   clientRecordVersion: 1,
                   device: Device(type: DeviceType.watch),

--- a/packages/health_connector_hc_android/test/unit_tests/src/mappers/health_record_mappers/floors_climbed_record_mapper_test.dart
+++ b/packages/health_connector_hc_android/test/unit_tests/src/mappers/health_record_mappers/floors_climbed_record_mapper_test.dart
@@ -23,11 +23,11 @@ void main() {
                     FakeData.fakeStartTime.timeZoneOffset.inSeconds,
                 endZoneOffsetSeconds:
                     FakeData.fakeEndTime.timeZoneOffset.inSeconds,
-                metadata: const Metadata(
-                  dataOrigin: DataOrigin(FakeData.fakeDataOrigin),
+                metadata: Metadata.internal(
+                  dataOrigin: const DataOrigin(FakeData.fakeDataOrigin),
                   recordingMethod: RecordingMethod.activelyRecorded,
                   clientRecordVersion: 1,
-                  device: Device(type: DeviceType.phone),
+                  device: const Device(type: DeviceType.phone),
                 ),
                 floors: const Number(15),
               );
@@ -92,7 +92,7 @@ void main() {
                 FakeData.fakeEndTime.timeZoneOffset.inSeconds,
               );
               expect(
-                record.metadata.dataOrigin.packageName,
+                record.metadata.dataOrigin?.packageName,
                 FakeData.fakeDataOrigin,
               );
               expect(record.floors.value, 20);

--- a/packages/health_connector_hc_android/test/unit_tests/src/mappers/health_record_mappers/health_record_mapper_test.dart
+++ b/packages/health_connector_hc_android/test/unit_tests/src/mappers/health_record_mappers/health_record_mapper_test.dart
@@ -12,9 +12,7 @@ void main() {
           startTime: DateTime(2025),
           endTime: DateTime(2025).add(const Duration(hours: 1)),
           energy: const Energy.calories(100),
-          metadata: Metadata.manualEntry(
-            dataOrigin: const DataOrigin('com.example'),
-          ),
+          metadata: Metadata.manualEntry(),
         );
         expect(caloriesRecord.toDto(), isA<ActiveCaloriesBurnedRecordDto>());
 
@@ -23,9 +21,7 @@ void main() {
           startTime: DateTime(2023, 1, 1, 10),
           endTime: DateTime(2023, 1, 1, 11),
           count: const Number(1000),
-          metadata: Metadata.manualEntry(
-            dataOrigin: const DataOrigin('com.example'),
-          ),
+          metadata: Metadata.manualEntry(),
         );
         expect(stepsRecord.toDto(), isA<StepsRecordDto>());
       });
@@ -36,9 +32,7 @@ void main() {
             startTime: DateTime.now(),
             endTime: DateTime.now().add(const Duration(minutes: 10)),
             distance: const Length.meters(100),
-            metadata: Metadata.manualEntry(
-              dataOrigin: const DataOrigin('com.example'),
-            ),
+            metadata: Metadata.manualEntry(),
           ).toDto(),
           throwsUnsupportedError,
         );
@@ -49,9 +43,7 @@ void main() {
             startTime: DateTime.now(),
             endTime: DateTime.now().add(const Duration(minutes: 10)),
             energy: const Energy.calories(100),
-            metadata: Metadata.manualEntry(
-              dataOrigin: const DataOrigin('com.example'),
-            ),
+            metadata: Metadata.manualEntry(),
           ).toDto(),
           throwsUnsupportedError,
         );
@@ -60,9 +52,7 @@ void main() {
           () => VitaminANutrientRecord(
             time: DateTime.now(),
             value: const Mass.grams(1),
-            metadata: Metadata.manualEntry(
-              dataOrigin: const DataOrigin('com.example'),
-            ),
+            metadata: Metadata.manualEntry(),
           ).toDto(),
           throwsUnsupportedError,
         );

--- a/packages/health_connector_hc_android/test/unit_tests/src/mappers/health_record_mappers/heart_rate/heart_rate_series_record_mapper_test.dart
+++ b/packages/health_connector_hc_android/test/unit_tests/src/mappers/health_record_mappers/heart_rate/heart_rate_series_record_mapper_test.dart
@@ -27,8 +27,8 @@ void main() {
                     FakeData.fakeStartTime.timeZoneOffset.inSeconds,
                 endZoneOffsetSeconds:
                     FakeData.fakeEndTime.timeZoneOffset.inSeconds,
-                metadata: const Metadata(
-                  dataOrigin: DataOrigin(FakeData.fakeDataOrigin),
+                metadata: Metadata.internal(
+                  dataOrigin: const DataOrigin(FakeData.fakeDataOrigin),
                   recordingMethod: RecordingMethod.activelyRecorded,
                   clientRecordVersion: 1,
                   device: Device(type: DeviceType.watch),

--- a/packages/health_connector_hc_android/test/unit_tests/src/mappers/health_record_mappers/heart_rate/heart_rate_variability_rmssd_record_mapper_test.dart
+++ b/packages/health_connector_hc_android/test/unit_tests/src/mappers/health_record_mappers/heart_rate/heart_rate_variability_rmssd_record_mapper_test.dart
@@ -20,8 +20,8 @@ void main() {
                 id: HealthRecordId(FakeData.fakeId),
                 time: FakeData.fakeTime,
                 zoneOffsetSeconds: FakeData.fakeTime.timeZoneOffset.inSeconds,
-                metadata: const Metadata(
-                  dataOrigin: DataOrigin(FakeData.fakeDataOrigin),
+                metadata: Metadata.internal(
+                  dataOrigin: const DataOrigin(FakeData.fakeDataOrigin),
                   recordingMethod: RecordingMethod.activelyRecorded,
                   clientRecordVersion: 1,
                   device: Device(type: DeviceType.watch),
@@ -73,7 +73,7 @@ void main() {
                 FakeData.fakeTime.timeZoneOffset.inSeconds,
               );
               expect(
-                record.metadata.dataOrigin.packageName,
+                record.metadata.dataOrigin?.packageName,
                 FakeData.fakeDataOrigin,
               );
               expect(record.heartRateVariabilityMillis, const Number(50.0));

--- a/packages/health_connector_hc_android/test/unit_tests/src/mappers/health_record_mappers/heart_rate/resting_heart_rate_record_mapper_test.dart
+++ b/packages/health_connector_hc_android/test/unit_tests/src/mappers/health_record_mappers/heart_rate/resting_heart_rate_record_mapper_test.dart
@@ -19,8 +19,8 @@ void main() {
                 id: HealthRecordId(FakeData.fakeId),
                 time: FakeData.fakeTime,
                 zoneOffsetSeconds: FakeData.fakeTime.timeZoneOffset.inSeconds,
-                metadata: const Metadata(
-                  dataOrigin: DataOrigin(FakeData.fakeDataOrigin),
+                metadata: Metadata.internal(
+                  dataOrigin: const DataOrigin(FakeData.fakeDataOrigin),
                   recordingMethod: RecordingMethod.activelyRecorded,
                   clientRecordVersion: 1,
                   device: Device(type: DeviceType.watch),
@@ -71,7 +71,7 @@ void main() {
                 FakeData.fakeTime.timeZoneOffset.inSeconds,
               );
               expect(
-                record.metadata.dataOrigin.packageName,
+                record.metadata.dataOrigin?.packageName,
                 FakeData.fakeDataOrigin,
               );
               expect(record.beatsPerMinute.inPerMinute, 65);

--- a/packages/health_connector_hc_android/test/unit_tests/src/mappers/health_record_mappers/height_record_mapper_test.dart
+++ b/packages/health_connector_hc_android/test/unit_tests/src/mappers/health_record_mappers/height_record_mapper_test.dart
@@ -19,11 +19,11 @@ void main() {
                 id: HealthRecordId(FakeData.fakeId),
                 time: FakeData.fakeTime,
                 zoneOffsetSeconds: FakeData.fakeTime.timeZoneOffset.inSeconds,
-                metadata: const Metadata(
-                  dataOrigin: DataOrigin(FakeData.fakeDataOrigin),
+                metadata: Metadata.internal(
+                  dataOrigin: const DataOrigin(FakeData.fakeDataOrigin),
                   recordingMethod: RecordingMethod.manualEntry,
                   clientRecordVersion: 1,
-                  device: Device(type: DeviceType.phone),
+                  device: const Device(type: DeviceType.phone),
                 ),
                 height: const Length.meters(1.75),
               );

--- a/packages/health_connector_hc_android/test/unit_tests/src/mappers/health_record_mappers/hydration_record_mapper_test.dart
+++ b/packages/health_connector_hc_android/test/unit_tests/src/mappers/health_record_mappers/hydration_record_mapper_test.dart
@@ -23,11 +23,11 @@ void main() {
                     FakeData.fakeStartTime.timeZoneOffset.inSeconds,
                 endZoneOffsetSeconds:
                     FakeData.fakeEndTime.timeZoneOffset.inSeconds,
-                metadata: const Metadata(
-                  dataOrigin: DataOrigin(FakeData.fakeDataOrigin),
+                metadata: Metadata.internal(
+                  dataOrigin: const DataOrigin(FakeData.fakeDataOrigin),
                   recordingMethod: RecordingMethod.manualEntry,
                   clientRecordVersion: 1,
-                  device: Device(type: DeviceType.phone),
+                  device: const Device(type: DeviceType.phone),
                 ),
                 volume: const Volume.liters(0.5),
               );

--- a/packages/health_connector_hc_android/test/unit_tests/src/mappers/health_record_mappers/lean_body_mass_record_mapper_test.dart
+++ b/packages/health_connector_hc_android/test/unit_tests/src/mappers/health_record_mappers/lean_body_mass_record_mapper_test.dart
@@ -19,11 +19,11 @@ void main() {
                 id: HealthRecordId(FakeData.fakeId),
                 time: FakeData.fakeTime,
                 zoneOffsetSeconds: FakeData.fakeTime.timeZoneOffset.inSeconds,
-                metadata: const Metadata(
-                  dataOrigin: DataOrigin(FakeData.fakeDataOrigin),
+                metadata: Metadata.internal(
+                  dataOrigin: const DataOrigin(FakeData.fakeDataOrigin),
                   recordingMethod: RecordingMethod.activelyRecorded,
                   clientRecordVersion: 1,
-                  device: Device(type: DeviceType.phone),
+                  device: const Device(type: DeviceType.phone),
                 ),
                 mass: const Mass.kilograms(60.5),
               );
@@ -72,7 +72,7 @@ void main() {
                 FakeData.fakeTime.timeZoneOffset.inSeconds,
               );
               expect(
-                record.metadata.dataOrigin.packageName,
+                record.metadata.dataOrigin?.packageName,
                 FakeData.fakeDataOrigin,
               );
               expect(record.mass.inKilograms, 65.0);

--- a/packages/health_connector_hc_android/test/unit_tests/src/mappers/health_record_mappers/menstruation/cervical_mucus_record_mapper_test.dart
+++ b/packages/health_connector_hc_android/test/unit_tests/src/mappers/health_record_mappers/menstruation/cervical_mucus_record_mapper_test.dart
@@ -19,11 +19,11 @@ void main() {
                 id: HealthRecordId(FakeData.fakeId),
                 time: FakeData.fakeTime,
                 zoneOffsetSeconds: FakeData.fakeTime.timeZoneOffset.inSeconds,
-                metadata: const Metadata(
-                  dataOrigin: DataOrigin(FakeData.fakeDataOrigin),
+                metadata: Metadata.internal(
+                  dataOrigin: const DataOrigin(FakeData.fakeDataOrigin),
                   recordingMethod: RecordingMethod.activelyRecorded,
                   clientRecordVersion: 1,
-                  device: Device(type: DeviceType.phone),
+                  device: const Device(type: DeviceType.phone),
                 ),
                 appearance: CervicalMucusAppearanceType.eggWhite,
                 sensation: CervicalMucusSensationType.medium,
@@ -74,7 +74,7 @@ void main() {
                 FakeData.fakeTime.timeZoneOffset.inSeconds,
               );
               expect(
-                record.metadata.dataOrigin.packageName,
+                record.metadata.dataOrigin?.packageName,
                 FakeData.fakeDataOrigin,
               );
               expect(record.appearance, CervicalMucusAppearanceType.watery);

--- a/packages/health_connector_hc_android/test/unit_tests/src/mappers/health_record_mappers/menstruation/intermenstrual_bleeding_record_mapper_test.dart
+++ b/packages/health_connector_hc_android/test/unit_tests/src/mappers/health_record_mappers/menstruation/intermenstrual_bleeding_record_mapper_test.dart
@@ -20,11 +20,11 @@ void main() {
                 id: HealthRecordId(FakeData.fakeId),
                 time: FakeData.fakeTime,
                 zoneOffsetSeconds: FakeData.fakeTime.timeZoneOffset.inSeconds,
-                metadata: const Metadata(
-                  dataOrigin: DataOrigin(FakeData.fakeDataOrigin),
+                metadata: Metadata.internal(
+                  dataOrigin: const DataOrigin(FakeData.fakeDataOrigin),
                   recordingMethod: RecordingMethod.manualEntry,
                   clientRecordVersion: 1,
-                  device: Device(type: DeviceType.phone),
+                  device: const Device(type: DeviceType.phone),
                 ),
               );
 

--- a/packages/health_connector_hc_android/test/unit_tests/src/mappers/health_record_mappers/menstruation/menstrual_flow_instant_record_mapper_test.dart
+++ b/packages/health_connector_hc_android/test/unit_tests/src/mappers/health_record_mappers/menstruation/menstrual_flow_instant_record_mapper_test.dart
@@ -20,11 +20,11 @@ void main() {
                 id: HealthRecordId(FakeData.fakeId),
                 time: FakeData.fakeTime,
                 zoneOffsetSeconds: FakeData.fakeTime.timeZoneOffset.inSeconds,
-                metadata: const Metadata(
-                  dataOrigin: DataOrigin(FakeData.fakeDataOrigin),
+                metadata: Metadata.internal(
+                  dataOrigin: const DataOrigin(FakeData.fakeDataOrigin),
                   recordingMethod: RecordingMethod.manualEntry,
                   clientRecordVersion: 1,
-                  device: Device(type: DeviceType.phone),
+                  device: const Device(type: DeviceType.phone),
                 ),
                 flow: MenstrualFlowType.medium,
               );

--- a/packages/health_connector_hc_android/test/unit_tests/src/mappers/health_record_mappers/menstruation/ovulation_test_record_mapper_test.dart
+++ b/packages/health_connector_hc_android/test/unit_tests/src/mappers/health_record_mappers/menstruation/ovulation_test_record_mapper_test.dart
@@ -19,11 +19,11 @@ void main() {
                 id: HealthRecordId(FakeData.fakeId),
                 time: FakeData.fakeTime,
                 zoneOffsetSeconds: FakeData.fakeTime.timeZoneOffset.inSeconds,
-                metadata: const Metadata(
-                  dataOrigin: DataOrigin(FakeData.fakeDataOrigin),
+                metadata: Metadata.internal(
+                  dataOrigin: const DataOrigin(FakeData.fakeDataOrigin),
                   recordingMethod: RecordingMethod.manualEntry,
                   clientRecordVersion: 1,
-                  device: Device(type: DeviceType.phone),
+                  device: const Device(type: DeviceType.phone),
                 ),
                 result: OvulationTestResultType.positive,
               );

--- a/packages/health_connector_hc_android/test/unit_tests/src/mappers/health_record_mappers/mindfulness/mindfulness_session_record_mapper_test.dart
+++ b/packages/health_connector_hc_android/test/unit_tests/src/mappers/health_record_mappers/mindfulness/mindfulness_session_record_mapper_test.dart
@@ -26,11 +26,11 @@ void main() {
                 endTime: endTime,
                 startZoneOffsetSeconds: 3_600,
                 endZoneOffsetSeconds: 3_600,
-                metadata: const Metadata(
-                  dataOrigin: DataOrigin(FakeData.fakeDataOrigin),
+                metadata: Metadata.internal(
+                  dataOrigin: const DataOrigin(FakeData.fakeDataOrigin),
                   recordingMethod: RecordingMethod.activelyRecorded,
                   clientRecordVersion: 1,
-                  device: Device(type: DeviceType.phone),
+                  device: const Device(type: DeviceType.phone),
                 ),
                 sessionType: MindfulnessSessionType.meditation,
                 title: title,
@@ -85,7 +85,7 @@ void main() {
               expect(record.startTime, startTime);
               expect(record.endTime, endTime);
               expect(
-                record.metadata.dataOrigin.packageName,
+                record.metadata.dataOrigin?.packageName,
                 FakeData.fakeDataOrigin,
               );
               expect(record.sessionType, MindfulnessSessionType.breathing);

--- a/packages/health_connector_hc_android/test/unit_tests/src/mappers/health_record_mappers/nutrition/nutrition_record_mapper_test.dart
+++ b/packages/health_connector_hc_android/test/unit_tests/src/mappers/health_record_mappers/nutrition/nutrition_record_mapper_test.dart
@@ -25,11 +25,11 @@ void main() {
                     FakeData.fakeStartTime.timeZoneOffset.inSeconds,
                 endZoneOffsetSeconds:
                     FakeData.fakeEndTime.timeZoneOffset.inSeconds,
-                metadata: const Metadata(
-                  dataOrigin: DataOrigin(FakeData.fakeDataOrigin),
+                metadata: Metadata.internal(
+                  dataOrigin: const DataOrigin(FakeData.fakeDataOrigin),
                   recordingMethod: RecordingMethod.manualEntry,
                   clientRecordVersion: 1,
-                  device: Device(type: DeviceType.phone),
+                  device: const Device(type: DeviceType.phone),
                 ),
                 foodName: foodName,
                 mealType: MealType.lunch,
@@ -91,7 +91,7 @@ void main() {
               expect(record.startTime, FakeData.fakeStartTime);
               expect(record.endTime, FakeData.fakeEndTime);
               expect(
-                record.metadata.dataOrigin.packageName,
+                record.metadata.dataOrigin?.packageName,
                 FakeData.fakeDataOrigin,
               );
               expect(record.foodName, 'Salmon Dinner');

--- a/packages/health_connector_hc_android/test/unit_tests/src/mappers/health_record_mappers/oxygen_saturation_record_mapper_test.dart
+++ b/packages/health_connector_hc_android/test/unit_tests/src/mappers/health_record_mappers/oxygen_saturation_record_mapper_test.dart
@@ -19,8 +19,8 @@ void main() {
                 id: HealthRecordId(FakeData.fakeId),
                 time: FakeData.fakeTime,
                 zoneOffsetSeconds: FakeData.fakeTime.timeZoneOffset.inSeconds,
-                metadata: const Metadata(
-                  dataOrigin: DataOrigin(FakeData.fakeDataOrigin),
+                metadata: Metadata.internal(
+                  dataOrigin: const DataOrigin(FakeData.fakeDataOrigin),
                   recordingMethod: RecordingMethod.activelyRecorded,
                   clientRecordVersion: 1,
                   device: Device(type: DeviceType.watch),
@@ -71,7 +71,7 @@ void main() {
                 FakeData.fakeTime.timeZoneOffset.inSeconds,
               );
               expect(
-                record.metadata.dataOrigin.packageName,
+                record.metadata.dataOrigin?.packageName,
                 FakeData.fakeDataOrigin,
               );
               expect(record.percentage.asWhole, 95);

--- a/packages/health_connector_hc_android/test/unit_tests/src/mappers/health_record_mappers/power/power_record_mapper_test.dart
+++ b/packages/health_connector_hc_android/test/unit_tests/src/mappers/health_record_mappers/power/power_record_mapper_test.dart
@@ -26,8 +26,8 @@ void main() {
                     FakeData.fakeStartTime.timeZoneOffset.inSeconds,
                 endZoneOffsetSeconds:
                     FakeData.fakeEndTime.timeZoneOffset.inSeconds,
-                metadata: const Metadata(
-                  dataOrigin: DataOrigin(FakeData.fakeDataOrigin),
+                metadata: Metadata.internal(
+                  dataOrigin: const DataOrigin(FakeData.fakeDataOrigin),
                   recordingMethod: RecordingMethod.activelyRecorded,
                   clientRecordVersion: 1,
                   device: Device(type: DeviceType.watch),
@@ -110,7 +110,7 @@ void main() {
                 FakeData.fakeEndTime.timeZoneOffset.inSeconds,
               );
               expect(
-                record.metadata.dataOrigin.packageName,
+                record.metadata.dataOrigin?.packageName,
                 FakeData.fakeDataOrigin,
               );
               expect(record.samples, hasLength(1));

--- a/packages/health_connector_hc_android/test/unit_tests/src/mappers/health_record_mappers/respiratory_rate_record_mapper_test.dart
+++ b/packages/health_connector_hc_android/test/unit_tests/src/mappers/health_record_mappers/respiratory_rate_record_mapper_test.dart
@@ -19,8 +19,8 @@ void main() {
                 id: HealthRecordId(FakeData.fakeId),
                 time: FakeData.fakeTime,
                 zoneOffsetSeconds: FakeData.fakeTime.timeZoneOffset.inSeconds,
-                metadata: const Metadata(
-                  dataOrigin: DataOrigin(FakeData.fakeDataOrigin),
+                metadata: Metadata.internal(
+                  dataOrigin: const DataOrigin(FakeData.fakeDataOrigin),
                   recordingMethod: RecordingMethod.activelyRecorded,
                   clientRecordVersion: 1,
                   device: Device(type: DeviceType.watch),
@@ -71,7 +71,7 @@ void main() {
                 FakeData.fakeTime.timeZoneOffset.inSeconds,
               );
               expect(
-                record.metadata.dataOrigin.packageName,
+                record.metadata.dataOrigin?.packageName,
                 FakeData.fakeDataOrigin,
               );
               expect(record.breathsPerMin.inPerMinute, 18);

--- a/packages/health_connector_hc_android/test/unit_tests/src/mappers/health_record_mappers/sexual_activity/sexual_activity_record_mapper_test.dart
+++ b/packages/health_connector_hc_android/test/unit_tests/src/mappers/health_record_mappers/sexual_activity/sexual_activity_record_mapper_test.dart
@@ -19,11 +19,11 @@ void main() {
                 id: HealthRecordId(FakeData.fakeId),
                 time: FakeData.fakeTime,
                 zoneOffsetSeconds: FakeData.fakeTime.timeZoneOffset.inSeconds,
-                metadata: const Metadata(
-                  dataOrigin: DataOrigin(FakeData.fakeDataOrigin),
+                metadata: Metadata.internal(
+                  dataOrigin: const DataOrigin(FakeData.fakeDataOrigin),
                   recordingMethod: RecordingMethod.manualEntry,
                   clientRecordVersion: 1,
-                  device: Device(type: DeviceType.phone),
+                  device: const Device(type: DeviceType.phone),
                 ),
                 protectionUsed: SexualActivityProtectionUsedType.protected,
               );
@@ -74,7 +74,7 @@ void main() {
                 FakeData.fakeTime.timeZoneOffset.inSeconds,
               );
               expect(
-                record.metadata.dataOrigin.packageName,
+                record.metadata.dataOrigin?.packageName,
                 FakeData.fakeDataOrigin,
               );
               expect(

--- a/packages/health_connector_hc_android/test/unit_tests/src/mappers/health_record_mappers/sleep/sleep_session_record_mapper_test.dart
+++ b/packages/health_connector_hc_android/test/unit_tests/src/mappers/health_record_mappers/sleep/sleep_session_record_mapper_test.dart
@@ -33,8 +33,8 @@ void main() {
                     FakeData.fakeStartTime.timeZoneOffset.inSeconds,
                 endZoneOffsetSeconds:
                     FakeData.fakeEndTime.timeZoneOffset.inSeconds,
-                metadata: const Metadata(
-                  dataOrigin: DataOrigin(FakeData.fakeDataOrigin),
+                metadata: Metadata.internal(
+                  dataOrigin: const DataOrigin(FakeData.fakeDataOrigin),
                   recordingMethod: RecordingMethod.activelyRecorded,
                   clientRecordVersion: 1,
                   device: Device(type: DeviceType.watch),
@@ -106,7 +106,7 @@ void main() {
               expect(record.startTime, FakeData.fakeStartTime);
               expect(record.endTime, FakeData.fakeEndTime);
               expect(
-                record.metadata.dataOrigin.packageName,
+                record.metadata.dataOrigin?.packageName,
                 FakeData.fakeDataOrigin,
               );
               expect(record.samples, hasLength(1));

--- a/packages/health_connector_hc_android/test/unit_tests/src/mappers/health_record_mappers/speed/speed_record_mapper_test.dart
+++ b/packages/health_connector_hc_android/test/unit_tests/src/mappers/health_record_mappers/speed/speed_record_mapper_test.dart
@@ -29,8 +29,8 @@ void main() {
                     FakeData.fakeStartTime.timeZoneOffset.inSeconds,
                 endZoneOffsetSeconds:
                     FakeData.fakeEndTime.timeZoneOffset.inSeconds,
-                metadata: const Metadata(
-                  dataOrigin: DataOrigin(FakeData.fakeDataOrigin),
+                metadata: Metadata.internal(
+                  dataOrigin: const DataOrigin(FakeData.fakeDataOrigin),
                   recordingMethod: RecordingMethod.activelyRecorded,
                   clientRecordVersion: 1,
                   device: Device(type: DeviceType.watch),
@@ -111,7 +111,7 @@ void main() {
                 FakeData.fakeEndTime.timeZoneOffset.inSeconds,
               );
               expect(
-                record.metadata.dataOrigin.packageName,
+                record.metadata.dataOrigin?.packageName,
                 FakeData.fakeDataOrigin,
               );
               expect(record.samples, hasLength(1));

--- a/packages/health_connector_hc_android/test/unit_tests/src/mappers/health_record_mappers/steps_record_mapper_test.dart
+++ b/packages/health_connector_hc_android/test/unit_tests/src/mappers/health_record_mappers/steps_record_mapper_test.dart
@@ -23,8 +23,8 @@ void main() {
                     FakeData.fakeStartTime.timeZoneOffset.inSeconds,
                 endZoneOffsetSeconds:
                     FakeData.fakeEndTime.timeZoneOffset.inSeconds,
-                metadata: const Metadata(
-                  dataOrigin: DataOrigin(FakeData.fakeDataOrigin),
+                metadata: Metadata.internal(
+                  dataOrigin: const DataOrigin(FakeData.fakeDataOrigin),
                   recordingMethod: RecordingMethod.activelyRecorded,
                   clientRecordVersion: 1,
                   device: Device(type: DeviceType.watch),

--- a/packages/health_connector_hc_android/test/unit_tests/src/mappers/health_record_mappers/temperature/basal_body_temperature_record_mapper_test.dart
+++ b/packages/health_connector_hc_android/test/unit_tests/src/mappers/health_record_mappers/temperature/basal_body_temperature_record_mapper_test.dart
@@ -20,11 +20,11 @@ void main() {
                 id: HealthRecordId(FakeData.fakeId),
                 time: FakeData.fakeTime,
                 zoneOffsetSeconds: FakeData.fakeTime.timeZoneOffset.inSeconds,
-                metadata: const Metadata(
-                  dataOrigin: DataOrigin(FakeData.fakeDataOrigin),
+                metadata: Metadata.internal(
+                  dataOrigin: const DataOrigin(FakeData.fakeDataOrigin),
                   recordingMethod: RecordingMethod.activelyRecorded,
                   clientRecordVersion: 1,
-                  device: Device(type: DeviceType.phone),
+                  device: const Device(type: DeviceType.phone),
                 ),
                 temperature: const Temperature.celsius(36.5),
               );

--- a/packages/health_connector_hc_android/test/unit_tests/src/mappers/health_record_mappers/temperature/body_temperature_record_mapper_test.dart
+++ b/packages/health_connector_hc_android/test/unit_tests/src/mappers/health_record_mappers/temperature/body_temperature_record_mapper_test.dart
@@ -19,11 +19,11 @@ void main() {
                 id: HealthRecordId(FakeData.fakeId),
                 time: FakeData.fakeTime,
                 zoneOffsetSeconds: FakeData.fakeTime.timeZoneOffset.inSeconds,
-                metadata: const Metadata(
-                  dataOrigin: DataOrigin(FakeData.fakeDataOrigin),
+                metadata: Metadata.internal(
+                  dataOrigin: const DataOrigin(FakeData.fakeDataOrigin),
                   recordingMethod: RecordingMethod.activelyRecorded,
                   clientRecordVersion: 1,
-                  device: Device(type: DeviceType.phone),
+                  device: const Device(type: DeviceType.phone),
                 ),
                 temperature: const Temperature.celsius(37.2),
               );
@@ -72,7 +72,7 @@ void main() {
                 FakeData.fakeTime.timeZoneOffset.inSeconds,
               );
               expect(
-                record.metadata.dataOrigin.packageName,
+                record.metadata.dataOrigin?.packageName,
                 FakeData.fakeDataOrigin,
               );
               expect(record.temperature.inFahrenheit, 98.6);

--- a/packages/health_connector_hc_android/test/unit_tests/src/mappers/health_record_mappers/vo2_max_record_mapper_test.dart
+++ b/packages/health_connector_hc_android/test/unit_tests/src/mappers/health_record_mappers/vo2_max_record_mapper_test.dart
@@ -19,9 +19,7 @@ void main() {
               final record = Vo2MaxRecord(
                 time: FakeData.fakeTime,
                 zoneOffsetSeconds: FakeData.fakeTime.timeZoneOffset.inSeconds,
-                metadata: Metadata.manualEntry(
-                  dataOrigin: const DataOrigin(FakeData.fakeDataOrigin),
-                ),
+                metadata: Metadata.manualEntry(),
                 mLPerKgPerMin: const Number(45.5),
                 testType: Vo2MaxTestType.rockportFitnessTest,
               );
@@ -34,7 +32,7 @@ void main() {
                 dto.zoneOffsetSeconds,
                 FakeData.fakeTime.timeZoneOffset.inSeconds,
               );
-              expect(dto.metadata.dataOrigin, FakeData.fakeDataOrigin);
+              expect(dto.metadata.dataOrigin, isEmpty);
               expect(dto.mLPerKgPerMin.value, 45.5);
               expect(
                 dto.measurementMethod,
@@ -69,7 +67,7 @@ void main() {
               expect(record.id, HealthRecordId.none);
               expect(record.time, FakeData.fakeTime);
               expect(
-                record.metadata.dataOrigin.packageName,
+                record.metadata.dataOrigin?.packageName,
                 FakeData.fakeDataOrigin,
               );
               expect(record.mLPerKgPerMin.value, 50.0);
@@ -154,9 +152,7 @@ void main() {
               final domainRecord = Vo2MaxRecord(
                 time: FakeData.fakeTime,
                 zoneOffsetSeconds: 0,
-                metadata: Metadata.manualEntry(
-                  dataOrigin: const DataOrigin('com.example.app'),
-                ),
+                metadata: Metadata.manualEntry(),
                 mLPerKgPerMin: const Number(45.0),
                 testType: domainVal,
               );

--- a/packages/health_connector_hc_android/test/unit_tests/src/mappers/health_record_mappers/weight_record_mapper_test.dart
+++ b/packages/health_connector_hc_android/test/unit_tests/src/mappers/health_record_mappers/weight_record_mapper_test.dart
@@ -19,11 +19,11 @@ void main() {
                 id: HealthRecordId(FakeData.fakeId),
                 time: FakeData.fakeTime,
                 zoneOffsetSeconds: FakeData.fakeTime.timeZoneOffset.inSeconds,
-                metadata: const Metadata(
-                  dataOrigin: DataOrigin(FakeData.fakeDataOrigin),
+                metadata: Metadata.internal(
+                  dataOrigin: const DataOrigin(FakeData.fakeDataOrigin),
                   recordingMethod: RecordingMethod.manualEntry,
                   clientRecordVersion: 1,
-                  device: Device(type: DeviceType.phone),
+                  device: const Device(type: DeviceType.phone),
                 ),
                 weight: const Mass.kilograms(70.5),
               );

--- a/packages/health_connector_hc_android/test/unit_tests/src/mappers/health_record_mappers/wheelchair_pushes_record_mapper_test.dart
+++ b/packages/health_connector_hc_android/test/unit_tests/src/mappers/health_record_mappers/wheelchair_pushes_record_mapper_test.dart
@@ -23,8 +23,8 @@ void main() {
                     FakeData.fakeStartTime.timeZoneOffset.inSeconds,
                 endZoneOffsetSeconds:
                     FakeData.fakeEndTime.timeZoneOffset.inSeconds,
-                metadata: const Metadata(
-                  dataOrigin: DataOrigin(FakeData.fakeDataOrigin),
+                metadata: Metadata.internal(
+                  dataOrigin: const DataOrigin(FakeData.fakeDataOrigin),
                   recordingMethod: RecordingMethod.activelyRecorded,
                   clientRecordVersion: 1,
                   device: Device(type: DeviceType.watch),
@@ -76,7 +76,7 @@ void main() {
               expect(record.startTime, FakeData.fakeStartTime);
               expect(record.endTime, FakeData.fakeEndTime);
               expect(
-                record.metadata.dataOrigin.packageName,
+                record.metadata.dataOrigin?.packageName,
                 FakeData.fakeDataOrigin,
               );
               expect(record.pushes.value, 200);

--- a/packages/health_connector_hc_android/test/unit_tests/src/mappers/metadata_mappers/metadata_mapper_test.dart
+++ b/packages/health_connector_hc_android/test/unit_tests/src/mappers/metadata_mappers/metadata_mapper_test.dart
@@ -23,7 +23,7 @@ void main() {
           test(
             'maps Metadata to MetadataDto with all fields populated',
             () {
-              final metadata = Metadata(
+              final metadata = Metadata.internal(
                 dataOrigin: const DataOrigin(dataOriginName),
                 recordingMethod: RecordingMethod.manualEntry,
                 lastModifiedTime: lastModifiedTime,
@@ -52,7 +52,7 @@ void main() {
           test(
             'maps Metadata to MetadataDto with nullable fields',
             () {
-              const metadata = Metadata(
+              final metadata = Metadata.internal(
                 dataOrigin: DataOrigin(dataOriginName),
                 recordingMethod: RecordingMethod.unknown,
                 clientRecordVersion: 0,
@@ -92,7 +92,7 @@ void main() {
 
               final metadata = dto.toDomain();
 
-              expect(metadata.dataOrigin.packageName, dataOriginName);
+              expect(metadata.dataOrigin?.packageName, dataOriginName);
               expect(
                 metadata.recordingMethod,
                 RecordingMethod.activelyRecorded,
@@ -118,7 +118,7 @@ void main() {
 
               final metadata = dto.toDomain();
 
-              expect(metadata.dataOrigin.packageName, dataOriginName);
+              expect(metadata.dataOrigin?.packageName, dataOriginName);
               expect(metadata.recordingMethod, RecordingMethod.unknown);
               expect(metadata.lastModifiedTime, null);
               expect(metadata.clientRecordId, null);

--- a/packages/health_connector_hk_ios/example/lib/main.dart
+++ b/packages/health_connector_hk_ios/example/lib/main.dart
@@ -280,7 +280,6 @@ class _ExampleAppHomePageState extends State<ExampleAppHomePage> {
         endTime: now,
         count: const Number(1000),
         metadata: Metadata.automaticallyRecorded(
-          dataOrigin: const DataOrigin('com.example.health_connector'),
           device: const Device.fromType(DeviceType.phone),
         ),
       );
@@ -324,7 +323,6 @@ class _ExampleAppHomePageState extends State<ExampleAppHomePage> {
           endTime: now.subtract(const Duration(hours: 2)),
           count: const Number(1500),
           metadata: Metadata.automaticallyRecorded(
-            dataOrigin: const DataOrigin('com.example.health_connector'),
             device: const Device.fromType(DeviceType.watch),
           ),
         ),
@@ -333,7 +331,6 @@ class _ExampleAppHomePageState extends State<ExampleAppHomePage> {
           endTime: now.subtract(const Duration(hours: 1)),
           count: const Number(2000),
           metadata: Metadata.automaticallyRecorded(
-            dataOrigin: const DataOrigin('com.example.health_connector'),
             device: const Device.fromType(DeviceType.watch),
           ),
         ),
@@ -342,7 +339,6 @@ class _ExampleAppHomePageState extends State<ExampleAppHomePage> {
           endTime: now,
           count: const Number(1800),
           metadata: Metadata.automaticallyRecorded(
-            dataOrigin: const DataOrigin('com.example.health_connector'),
             device: const Device.fromType(DeviceType.phone),
           ),
         ),

--- a/packages/health_connector_hk_ios/lib/src/mappers/metadata_mappers/metadata_mapper.dart
+++ b/packages/health_connector_hk_ios/lib/src/mappers/metadata_mappers/metadata_mapper.dart
@@ -12,7 +12,7 @@ import 'package:meta/meta.dart' show internal;
 extension MetadataDtoMapper on Metadata {
   MetadataDto toDto() {
     return MetadataDto(
-      dataOrigin: dataOrigin.packageName,
+      dataOrigin: dataOrigin?.packageName ?? '',
       recordingMethod: recordingMethod.toDto(),
       deviceType: device?.type.toDto() ?? DeviceType.unknown.toDto(),
       clientRecordId: clientRecordId,
@@ -34,7 +34,7 @@ extension MetadataDtoMapper on Metadata {
 @internal
 extension MetadataDtoToDomain on MetadataDto {
   Metadata toDomain() {
-    return Metadata(
+    return Metadata.internal(
       dataOrigin: DataOrigin(dataOrigin),
       recordingMethod: recordingMethod.toDomain(),
       clientRecordId: clientRecordId,

--- a/packages/health_connector_hk_ios/test/unit_tests/src/health_connector_hk_client_test.dart
+++ b/packages/health_connector_hk_ios/test/unit_tests/src/health_connector_hk_client_test.dart
@@ -544,9 +544,7 @@ void main() {
                       count: const Number(100),
                       startTime: now.subtract(const Duration(hours: 1)),
                       endTime: now,
-                      metadata: Metadata.manualEntry(
-                        dataOrigin: const DataOrigin('com.example.app'),
-                      ),
+                      metadata: Metadata.manualEntry(),
                     ),
                   );
 
@@ -568,9 +566,7 @@ void main() {
                         count: const Number(100),
                         startTime: now.subtract(const Duration(hours: 1)),
                         endTime: now,
-                        metadata: Metadata.manualEntry(
-                          dataOrigin: const DataOrigin('com.example.app'),
-                        ),
+                        metadata: Metadata.manualEntry(),
                       ),
                     ),
                     throwsA(isA<HealthConnectorException>()),
@@ -606,17 +602,13 @@ void main() {
                       count: const Number(100),
                       startTime: now.subtract(const Duration(hours: 2)),
                       endTime: now.subtract(const Duration(hours: 1)),
-                      metadata: Metadata.manualEntry(
-                        dataOrigin: const DataOrigin('com.example.app'),
-                      ),
+                      metadata: Metadata.manualEntry(),
                     ),
                     StepsRecord(
                       count: const Number(200),
                       startTime: now.subtract(const Duration(hours: 1)),
                       endTime: now,
-                      metadata: Metadata.manualEntry(
-                        dataOrigin: const DataOrigin('com.example.app'),
-                      ),
+                      metadata: Metadata.manualEntry(),
                     ),
                   ]);
 
@@ -640,9 +632,7 @@ void main() {
                         count: const Number(100),
                         startTime: now.subtract(const Duration(hours: 1)),
                         endTime: now,
-                        metadata: Metadata.manualEntry(
-                          dataOrigin: const DataOrigin('com.example.app'),
-                        ),
+                        metadata: Metadata.manualEntry(),
                       ),
                     ]),
                     throwsA(isA<HealthConnectorException>()),
@@ -666,9 +656,7 @@ void main() {
                         startTime: now.subtract(const Duration(hours: 1)),
                         endTime: now,
                         id: HealthRecordId('existing-id'),
-                        metadata: Metadata.manualEntry(
-                          dataOrigin: const DataOrigin('com.example.app'),
-                        ),
+                        metadata: Metadata.manualEntry(),
                       ),
                     ),
                     throwsA(isA<UnsupportedOperationException>()),
@@ -692,9 +680,7 @@ void main() {
                         startTime: now.subtract(const Duration(hours: 1)),
                         endTime: now,
                         id: HealthRecordId('existing-id'),
-                        metadata: Metadata.manualEntry(
-                          dataOrigin: const DataOrigin('com.example.app'),
-                        ),
+                        metadata: Metadata.manualEntry(),
                       ),
                     ]),
                     throwsA(isA<UnsupportedOperationException>()),

--- a/packages/health_connector_hk_ios/test/unit_tests/src/mappers/health_record_mappers/blood_glucose_record_mapper_test.dart
+++ b/packages/health_connector_hk_ios/test/unit_tests/src/mappers/health_record_mappers/blood_glucose_record_mapper_test.dart
@@ -21,11 +21,11 @@ void main() {
                 id: HealthRecordId(FakeData.fakeId),
                 time: time,
                 zoneOffsetSeconds: FakeData.fakeTime.timeZoneOffset.inSeconds,
-                metadata: const Metadata(
-                  dataOrigin: DataOrigin(FakeData.fakeDataOrigin),
+                metadata: Metadata.internal(
+                  dataOrigin: const DataOrigin(FakeData.fakeDataOrigin),
                   recordingMethod: RecordingMethod.manualEntry,
                   clientRecordVersion: 1,
-                  device: Device(type: DeviceType.phone),
+                  device: const Device(type: DeviceType.phone),
                 ),
                 bloodGlucose: const BloodGlucose.millimolesPerLiter(5.5),
                 specimenSource: BloodGlucoseSpecimenSource.capillaryBlood,
@@ -74,7 +74,7 @@ void main() {
               expect(record.time, time);
               expect(record.bloodGlucose.inMillimolesPerLiter, 6.1);
               expect(
-                record.metadata.dataOrigin.packageName,
+                record.metadata.dataOrigin?.packageName,
                 FakeData.fakeDataOrigin,
               );
             },

--- a/packages/health_connector_hk_ios/test/unit_tests/src/mappers/health_record_mappers/blood_pressure/blood_pressure_record_mapper_test.dart
+++ b/packages/health_connector_hk_ios/test/unit_tests/src/mappers/health_record_mappers/blood_pressure/blood_pressure_record_mapper_test.dart
@@ -21,11 +21,11 @@ void main() {
                 id: HealthRecordId(FakeData.fakeId),
                 time: time,
                 zoneOffsetSeconds: FakeData.fakeTime.timeZoneOffset.inSeconds,
-                metadata: const Metadata(
-                  dataOrigin: DataOrigin(FakeData.fakeDataOrigin),
+                metadata: Metadata.internal(
+                  dataOrigin: const DataOrigin(FakeData.fakeDataOrigin),
                   recordingMethod: RecordingMethod.manualEntry,
                   clientRecordVersion: 1,
-                  device: Device(type: DeviceType.phone),
+                  device: const Device(type: DeviceType.phone),
                 ),
                 systolic: const Pressure.millimetersOfMercury(120.0),
                 diastolic: const Pressure.millimetersOfMercury(80.0),
@@ -78,7 +78,7 @@ void main() {
               expect(record.systolic.inMillimetersOfMercury, 125.0);
               expect(record.diastolic.inMillimetersOfMercury, 85.0);
               expect(
-                record.metadata.dataOrigin.packageName,
+                record.metadata.dataOrigin?.packageName,
                 FakeData.fakeDataOrigin,
               );
             },

--- a/packages/health_connector_hk_ios/test/unit_tests/src/mappers/health_record_mappers/blood_pressure/diastolic_blood_pressure_record_mapper_test.dart
+++ b/packages/health_connector_hk_ios/test/unit_tests/src/mappers/health_record_mappers/blood_pressure/diastolic_blood_pressure_record_mapper_test.dart
@@ -22,11 +22,11 @@ void main() {
                 id: HealthRecordId(FakeData.fakeId),
                 time: time,
                 zoneOffsetSeconds: FakeData.fakeTime.timeZoneOffset.inSeconds,
-                metadata: const Metadata(
-                  dataOrigin: DataOrigin(FakeData.fakeDataOrigin),
+                metadata: Metadata.internal(
+                  dataOrigin: const DataOrigin(FakeData.fakeDataOrigin),
                   recordingMethod: RecordingMethod.manualEntry,
                   clientRecordVersion: 1,
-                  device: Device(type: DeviceType.phone),
+                  device: const Device(type: DeviceType.phone),
                 ),
                 pressure: const Pressure.millimetersOfMercury(80.0),
                 bodyPosition: BloodPressureBodyPosition.sittingDown,
@@ -78,7 +78,7 @@ void main() {
               expect(record.time, time);
               expect(record.pressure.inMillimetersOfMercury, 75.0);
               expect(
-                record.metadata.dataOrigin.packageName,
+                record.metadata.dataOrigin?.packageName,
                 FakeData.fakeDataOrigin,
               );
             },

--- a/packages/health_connector_hk_ios/test/unit_tests/src/mappers/health_record_mappers/blood_pressure/systolic_blood_pressure_record_mapper_test.dart
+++ b/packages/health_connector_hk_ios/test/unit_tests/src/mappers/health_record_mappers/blood_pressure/systolic_blood_pressure_record_mapper_test.dart
@@ -22,11 +22,11 @@ void main() {
                 id: HealthRecordId(FakeData.fakeId),
                 time: time,
                 zoneOffsetSeconds: FakeData.fakeTime.timeZoneOffset.inSeconds,
-                metadata: const Metadata(
-                  dataOrigin: DataOrigin(FakeData.fakeDataOrigin),
+                metadata: Metadata.internal(
+                  dataOrigin: const DataOrigin(FakeData.fakeDataOrigin),
                   recordingMethod: RecordingMethod.manualEntry,
                   clientRecordVersion: 1,
-                  device: Device(type: DeviceType.phone),
+                  device: const Device(type: DeviceType.phone),
                 ),
                 pressure: const Pressure.millimetersOfMercury(120.0),
                 bodyPosition: BloodPressureBodyPosition.sittingDown,
@@ -78,7 +78,7 @@ void main() {
               expect(record.time, time);
               expect(record.pressure.inMillimetersOfMercury, 115.0);
               expect(
-                record.metadata.dataOrigin.packageName,
+                record.metadata.dataOrigin?.packageName,
                 FakeData.fakeDataOrigin,
               );
             },

--- a/packages/health_connector_hk_ios/test/unit_tests/src/mappers/health_record_mappers/body_fat_percentage_record_mapper_test.dart
+++ b/packages/health_connector_hk_ios/test/unit_tests/src/mappers/health_record_mappers/body_fat_percentage_record_mapper_test.dart
@@ -21,11 +21,11 @@ void main() {
                 id: HealthRecordId(FakeData.fakeId),
                 time: time,
                 zoneOffsetSeconds: FakeData.fakeTime.timeZoneOffset.inSeconds,
-                metadata: const Metadata(
-                  dataOrigin: DataOrigin(FakeData.fakeDataOrigin),
+                metadata: Metadata.internal(
+                  dataOrigin: const DataOrigin(FakeData.fakeDataOrigin),
                   recordingMethod: RecordingMethod.manualEntry,
                   clientRecordVersion: 1,
-                  device: Device(type: DeviceType.phone),
+                  device: const Device(type: DeviceType.phone),
                 ),
                 percentage: const Percentage.fromWhole(18.5),
               );
@@ -72,7 +72,7 @@ void main() {
               expect(record.time, time);
               expect(record.percentage.asDecimal, 20.2);
               expect(
-                record.metadata.dataOrigin.packageName,
+                record.metadata.dataOrigin?.packageName,
                 FakeData.fakeDataOrigin,
               );
             },

--- a/packages/health_connector_hk_ios/test/unit_tests/src/mappers/health_record_mappers/body_mass_index_record_mapper_test.dart
+++ b/packages/health_connector_hk_ios/test/unit_tests/src/mappers/health_record_mappers/body_mass_index_record_mapper_test.dart
@@ -21,11 +21,11 @@ void main() {
                 id: HealthRecordId(FakeData.fakeId),
                 time: time,
                 zoneOffsetSeconds: FakeData.fakeTime.timeZoneOffset.inSeconds,
-                metadata: const Metadata(
-                  dataOrigin: DataOrigin(FakeData.fakeDataOrigin),
+                metadata: Metadata.internal(
+                  dataOrigin: const DataOrigin(FakeData.fakeDataOrigin),
                   recordingMethod: RecordingMethod.manualEntry,
                   clientRecordVersion: 1,
-                  device: Device(type: DeviceType.phone),
+                  device: const Device(type: DeviceType.phone),
                 ),
                 bodyMassIndex: const Number(22.5),
               );
@@ -72,7 +72,7 @@ void main() {
               expect(record.time, time);
               expect(record.bodyMassIndex.value, 23.8);
               expect(
-                record.metadata.dataOrigin.packageName,
+                record.metadata.dataOrigin?.packageName,
                 FakeData.fakeDataOrigin,
               );
             },

--- a/packages/health_connector_hk_ios/test/unit_tests/src/mappers/health_record_mappers/cycling_pedaling_cadence/cycling_pedaling_cadence_measurement_record_mapper_test.dart
+++ b/packages/health_connector_hk_ios/test/unit_tests/src/mappers/health_record_mappers/cycling_pedaling_cadence/cycling_pedaling_cadence_measurement_record_mapper_test.dart
@@ -20,11 +20,11 @@ void main() {
 
               final record = CyclingPedalingCadenceMeasurementRecord(
                 id: HealthRecordId(FakeData.fakeId),
-                metadata: const Metadata(
-                  dataOrigin: DataOrigin(FakeData.fakeDataOrigin),
+                metadata: Metadata.internal(
+                  dataOrigin: const DataOrigin(FakeData.fakeDataOrigin),
                   recordingMethod: RecordingMethod.manualEntry,
                   clientRecordVersion: 1,
-                  device: Device(type: DeviceType.phone),
+                  device: const Device(type: DeviceType.phone),
                 ),
                 measurement: CyclingPedalingCadenceMeasurement(
                   time: time,
@@ -72,7 +72,7 @@ void main() {
               expect(record.id.value, FakeData.fakeId);
               expect(record.measurement.revolutionsPerMinute.value, 85.0);
               expect(
-                record.metadata.dataOrigin.packageName,
+                record.metadata.dataOrigin?.packageName,
                 FakeData.fakeDataOrigin,
               );
             },

--- a/packages/health_connector_hk_ios/test/unit_tests/src/mappers/health_record_mappers/distance/cross_country_skiing_distance_record_mapper_test.dart
+++ b/packages/health_connector_hk_ios/test/unit_tests/src/mappers/health_record_mappers/distance/cross_country_skiing_distance_record_mapper_test.dart
@@ -25,8 +25,8 @@ void main() {
                     FakeData.fakeStartTime.timeZoneOffset.inSeconds,
                 endZoneOffsetSeconds:
                     FakeData.fakeEndTime.timeZoneOffset.inSeconds,
-                metadata: const Metadata(
-                  dataOrigin: DataOrigin(FakeData.fakeDataOrigin),
+                metadata: Metadata.internal(
+                  dataOrigin: const DataOrigin(FakeData.fakeDataOrigin),
                   recordingMethod: RecordingMethod.activelyRecorded,
                   clientRecordVersion: 1,
                   device: Device(type: DeviceType.watch),
@@ -77,11 +77,11 @@ void main() {
                     FakeData.fakeStartTime.timeZoneOffset.inSeconds,
                 endZoneOffsetSeconds:
                     FakeData.fakeEndTime.timeZoneOffset.inSeconds,
-                metadata: const Metadata(
-                  dataOrigin: DataOrigin(FakeData.fakeDataOrigin),
+                metadata: Metadata.internal(
+                  dataOrigin: const DataOrigin(FakeData.fakeDataOrigin),
                   recordingMethod: RecordingMethod.manualEntry,
                   clientRecordVersion: 2,
-                  device: Device(type: DeviceType.phone),
+                  device: const Device(type: DeviceType.phone),
                 ),
                 distance: const Length.meters(12000.0),
               );
@@ -136,7 +136,7 @@ void main() {
               expect(record.endTime, FakeData.fakeEndTime);
               expect(record.distance.inMeters, 7500.0);
               expect(
-                record.metadata.dataOrigin.packageName,
+                record.metadata.dataOrigin?.packageName,
                 FakeData.fakeDataOrigin,
               );
             },

--- a/packages/health_connector_hk_ios/test/unit_tests/src/mappers/health_record_mappers/distance/cycling_distance_record_mapper_test.dart
+++ b/packages/health_connector_hk_ios/test/unit_tests/src/mappers/health_record_mappers/distance/cycling_distance_record_mapper_test.dart
@@ -24,11 +24,11 @@ void main() {
                     FakeData.fakeStartTime.timeZoneOffset.inSeconds,
                 endZoneOffsetSeconds:
                     FakeData.fakeEndTime.timeZoneOffset.inSeconds,
-                metadata: const Metadata(
-                  dataOrigin: DataOrigin(FakeData.fakeDataOrigin),
+                metadata: Metadata.internal(
+                  dataOrigin: const DataOrigin(FakeData.fakeDataOrigin),
                   recordingMethod: RecordingMethod.manualEntry,
                   clientRecordVersion: 1,
-                  device: Device(type: DeviceType.phone),
+                  device: const Device(type: DeviceType.phone),
                 ),
                 distance: const Length.meters(5000.0),
               );
@@ -78,8 +78,8 @@ void main() {
                     FakeData.fakeStartTime.timeZoneOffset.inSeconds,
                 endZoneOffsetSeconds:
                     FakeData.fakeEndTime.timeZoneOffset.inSeconds,
-                metadata: const Metadata(
-                  dataOrigin: DataOrigin(FakeData.fakeDataOrigin),
+                metadata: Metadata.internal(
+                  dataOrigin: const DataOrigin(FakeData.fakeDataOrigin),
                   recordingMethod: RecordingMethod.activelyRecorded,
                   clientRecordVersion: 2,
                   device: Device(type: DeviceType.watch),
@@ -146,7 +146,7 @@ void main() {
               );
               expect(record.distance.inMeters, 4500.0);
               expect(
-                record.metadata.dataOrigin.packageName,
+                record.metadata.dataOrigin?.packageName,
                 FakeData.fakeDataOrigin,
               );
               expect(

--- a/packages/health_connector_hk_ios/test/unit_tests/src/mappers/health_record_mappers/distance/distance_activity_record_mapper_test.dart
+++ b/packages/health_connector_hk_ios/test/unit_tests/src/mappers/health_record_mappers/distance/distance_activity_record_mapper_test.dart
@@ -24,11 +24,11 @@ void main() {
                     FakeData.fakeStartTime.timeZoneOffset.inSeconds,
                 endZoneOffsetSeconds:
                     FakeData.fakeEndTime.timeZoneOffset.inSeconds,
-                metadata: const Metadata(
-                  dataOrigin: DataOrigin(FakeData.fakeDataOrigin),
+                metadata: Metadata.internal(
+                  dataOrigin: const DataOrigin(FakeData.fakeDataOrigin),
                   recordingMethod: RecordingMethod.manualEntry,
                   clientRecordVersion: 1,
-                  device: Device(type: DeviceType.phone),
+                  device: const Device(type: DeviceType.phone),
                 ),
                 distance: const Length.meters(5000.0),
               );
@@ -54,8 +54,8 @@ void main() {
                     FakeData.fakeStartTime.timeZoneOffset.inSeconds,
                 endZoneOffsetSeconds:
                     FakeData.fakeEndTime.timeZoneOffset.inSeconds,
-                metadata: const Metadata(
-                  dataOrigin: DataOrigin(FakeData.fakeDataOrigin),
+                metadata: Metadata.internal(
+                  dataOrigin: const DataOrigin(FakeData.fakeDataOrigin),
                   recordingMethod: RecordingMethod.activelyRecorded,
                   clientRecordVersion: 1,
                   device: Device(type: DeviceType.watch),
@@ -84,8 +84,8 @@ void main() {
                     FakeData.fakeStartTime.timeZoneOffset.inSeconds,
                 endZoneOffsetSeconds:
                     FakeData.fakeEndTime.timeZoneOffset.inSeconds,
-                metadata: const Metadata(
-                  dataOrigin: DataOrigin(FakeData.fakeDataOrigin),
+                metadata: Metadata.internal(
+                  dataOrigin: const DataOrigin(FakeData.fakeDataOrigin),
                   recordingMethod: RecordingMethod.activelyRecorded,
                   clientRecordVersion: 1,
                   device: Device(type: DeviceType.watch),
@@ -114,8 +114,8 @@ void main() {
                     FakeData.fakeStartTime.timeZoneOffset.inSeconds,
                 endZoneOffsetSeconds:
                     FakeData.fakeEndTime.timeZoneOffset.inSeconds,
-                metadata: const Metadata(
-                  dataOrigin: DataOrigin(FakeData.fakeDataOrigin),
+                metadata: Metadata.internal(
+                  dataOrigin: const DataOrigin(FakeData.fakeDataOrigin),
                   recordingMethod: RecordingMethod.activelyRecorded,
                   clientRecordVersion: 1,
                   device: Device(type: DeviceType.watch),
@@ -147,8 +147,8 @@ void main() {
                     FakeData.fakeStartTime.timeZoneOffset.inSeconds,
                 endZoneOffsetSeconds:
                     FakeData.fakeEndTime.timeZoneOffset.inSeconds,
-                metadata: const Metadata(
-                  dataOrigin: DataOrigin(FakeData.fakeDataOrigin),
+                metadata: Metadata.internal(
+                  dataOrigin: const DataOrigin(FakeData.fakeDataOrigin),
                   recordingMethod: RecordingMethod.activelyRecorded,
                   clientRecordVersion: 1,
                   device: Device(type: DeviceType.watch),
@@ -177,8 +177,8 @@ void main() {
                     FakeData.fakeStartTime.timeZoneOffset.inSeconds,
                 endZoneOffsetSeconds:
                     FakeData.fakeEndTime.timeZoneOffset.inSeconds,
-                metadata: const Metadata(
-                  dataOrigin: DataOrigin(FakeData.fakeDataOrigin),
+                metadata: Metadata.internal(
+                  dataOrigin: const DataOrigin(FakeData.fakeDataOrigin),
                   recordingMethod: RecordingMethod.activelyRecorded,
                   clientRecordVersion: 1,
                   device: Device(type: DeviceType.watch),
@@ -207,8 +207,8 @@ void main() {
                     FakeData.fakeStartTime.timeZoneOffset.inSeconds,
                 endZoneOffsetSeconds:
                     FakeData.fakeEndTime.timeZoneOffset.inSeconds,
-                metadata: const Metadata(
-                  dataOrigin: DataOrigin(FakeData.fakeDataOrigin),
+                metadata: Metadata.internal(
+                  dataOrigin: const DataOrigin(FakeData.fakeDataOrigin),
                   recordingMethod: RecordingMethod.activelyRecorded,
                   clientRecordVersion: 1,
                   device: Device(type: DeviceType.watch),
@@ -240,8 +240,8 @@ void main() {
                     FakeData.fakeStartTime.timeZoneOffset.inSeconds,
                 endZoneOffsetSeconds:
                     FakeData.fakeEndTime.timeZoneOffset.inSeconds,
-                metadata: const Metadata(
-                  dataOrigin: DataOrigin(FakeData.fakeDataOrigin),
+                metadata: Metadata.internal(
+                  dataOrigin: const DataOrigin(FakeData.fakeDataOrigin),
                   recordingMethod: RecordingMethod.activelyRecorded,
                   clientRecordVersion: 1,
                   device: Device(type: DeviceType.watch),
@@ -270,8 +270,8 @@ void main() {
                     FakeData.fakeStartTime.timeZoneOffset.inSeconds,
                 endZoneOffsetSeconds:
                     FakeData.fakeEndTime.timeZoneOffset.inSeconds,
-                metadata: const Metadata(
-                  dataOrigin: DataOrigin(FakeData.fakeDataOrigin),
+                metadata: Metadata.internal(
+                  dataOrigin: const DataOrigin(FakeData.fakeDataOrigin),
                   recordingMethod: RecordingMethod.activelyRecorded,
                   clientRecordVersion: 1,
                   device: Device(type: DeviceType.watch),
@@ -303,8 +303,8 @@ void main() {
                     FakeData.fakeStartTime.timeZoneOffset.inSeconds,
                 endZoneOffsetSeconds:
                     FakeData.fakeEndTime.timeZoneOffset.inSeconds,
-                metadata: const Metadata(
-                  dataOrigin: DataOrigin(FakeData.fakeDataOrigin),
+                metadata: Metadata.internal(
+                  dataOrigin: const DataOrigin(FakeData.fakeDataOrigin),
                   recordingMethod: RecordingMethod.activelyRecorded,
                   clientRecordVersion: 1,
                   device: Device(type: DeviceType.watch),

--- a/packages/health_connector_hk_ios/test/unit_tests/src/mappers/health_record_mappers/distance/downhill_snow_sports_distance_record_mapper_test.dart
+++ b/packages/health_connector_hk_ios/test/unit_tests/src/mappers/health_record_mappers/distance/downhill_snow_sports_distance_record_mapper_test.dart
@@ -25,8 +25,8 @@ void main() {
                     FakeData.fakeStartTime.timeZoneOffset.inSeconds,
                 endZoneOffsetSeconds:
                     FakeData.fakeEndTime.timeZoneOffset.inSeconds,
-                metadata: const Metadata(
-                  dataOrigin: DataOrigin(FakeData.fakeDataOrigin),
+                metadata: Metadata.internal(
+                  dataOrigin: const DataOrigin(FakeData.fakeDataOrigin),
                   recordingMethod: RecordingMethod.activelyRecorded,
                   clientRecordVersion: 1,
                   device: Device(type: DeviceType.watch),
@@ -77,11 +77,11 @@ void main() {
                     FakeData.fakeStartTime.timeZoneOffset.inSeconds,
                 endZoneOffsetSeconds:
                     FakeData.fakeEndTime.timeZoneOffset.inSeconds,
-                metadata: const Metadata(
-                  dataOrigin: DataOrigin(FakeData.fakeDataOrigin),
+                metadata: Metadata.internal(
+                  dataOrigin: const DataOrigin(FakeData.fakeDataOrigin),
                   recordingMethod: RecordingMethod.manualEntry,
                   clientRecordVersion: 2,
-                  device: Device(type: DeviceType.phone),
+                  device: const Device(type: DeviceType.phone),
                 ),
                 distance: const Length.meters(5000.0),
               );
@@ -136,7 +136,7 @@ void main() {
               expect(record.endTime, FakeData.fakeEndTime);
               expect(record.distance.inMeters, 2500.0);
               expect(
-                record.metadata.dataOrigin.packageName,
+                record.metadata.dataOrigin?.packageName,
                 FakeData.fakeDataOrigin,
               );
             },

--- a/packages/health_connector_hk_ios/test/unit_tests/src/mappers/health_record_mappers/distance/paddle_sports_distance_record_mapper_test.dart
+++ b/packages/health_connector_hk_ios/test/unit_tests/src/mappers/health_record_mappers/distance/paddle_sports_distance_record_mapper_test.dart
@@ -25,8 +25,8 @@ void main() {
                     FakeData.fakeStartTime.timeZoneOffset.inSeconds,
                 endZoneOffsetSeconds:
                     FakeData.fakeEndTime.timeZoneOffset.inSeconds,
-                metadata: const Metadata(
-                  dataOrigin: DataOrigin(FakeData.fakeDataOrigin),
+                metadata: Metadata.internal(
+                  dataOrigin: const DataOrigin(FakeData.fakeDataOrigin),
                   recordingMethod: RecordingMethod.activelyRecorded,
                   clientRecordVersion: 1,
                   device: Device(type: DeviceType.watch),
@@ -73,11 +73,11 @@ void main() {
                     FakeData.fakeStartTime.timeZoneOffset.inSeconds,
                 endZoneOffsetSeconds:
                     FakeData.fakeEndTime.timeZoneOffset.inSeconds,
-                metadata: const Metadata(
-                  dataOrigin: DataOrigin(FakeData.fakeDataOrigin),
+                metadata: Metadata.internal(
+                  dataOrigin: const DataOrigin(FakeData.fakeDataOrigin),
                   recordingMethod: RecordingMethod.manualEntry,
                   clientRecordVersion: 2,
-                  device: Device(type: DeviceType.phone),
+                  device: const Device(type: DeviceType.phone),
                 ),
                 distance: const Length.meters(7000.0),
               );
@@ -129,7 +129,7 @@ void main() {
               expect(record.endTime, FakeData.fakeEndTime);
               expect(record.distance.inMeters, 2800.0);
               expect(
-                record.metadata.dataOrigin.packageName,
+                record.metadata.dataOrigin?.packageName,
                 FakeData.fakeDataOrigin,
               );
             },

--- a/packages/health_connector_hk_ios/test/unit_tests/src/mappers/health_record_mappers/distance/rowing_distance_record_mapper_test.dart
+++ b/packages/health_connector_hk_ios/test/unit_tests/src/mappers/health_record_mappers/distance/rowing_distance_record_mapper_test.dart
@@ -24,8 +24,8 @@ void main() {
                     FakeData.fakeStartTime.timeZoneOffset.inSeconds,
                 endZoneOffsetSeconds:
                     FakeData.fakeEndTime.timeZoneOffset.inSeconds,
-                metadata: const Metadata(
-                  dataOrigin: DataOrigin(FakeData.fakeDataOrigin),
+                metadata: Metadata.internal(
+                  dataOrigin: const DataOrigin(FakeData.fakeDataOrigin),
                   recordingMethod: RecordingMethod.activelyRecorded,
                   clientRecordVersion: 1,
                   device: Device(type: DeviceType.watch),
@@ -72,11 +72,11 @@ void main() {
                     FakeData.fakeStartTime.timeZoneOffset.inSeconds,
                 endZoneOffsetSeconds:
                     FakeData.fakeEndTime.timeZoneOffset.inSeconds,
-                metadata: const Metadata(
-                  dataOrigin: DataOrigin(FakeData.fakeDataOrigin),
+                metadata: Metadata.internal(
+                  dataOrigin: const DataOrigin(FakeData.fakeDataOrigin),
                   recordingMethod: RecordingMethod.manualEntry,
                   clientRecordVersion: 2,
-                  device: Device(type: DeviceType.phone),
+                  device: const Device(type: DeviceType.phone),
                 ),
                 distance: const Length.meters(6000.0),
               );
@@ -127,7 +127,7 @@ void main() {
               expect(record.endTime, FakeData.fakeEndTime);
               expect(record.distance.inMeters, 3500.0);
               expect(
-                record.metadata.dataOrigin.packageName,
+                record.metadata.dataOrigin?.packageName,
                 FakeData.fakeDataOrigin,
               );
             },

--- a/packages/health_connector_hk_ios/test/unit_tests/src/mappers/health_record_mappers/distance/six_minute_walk_test_distance_record_mapper_test.dart
+++ b/packages/health_connector_hk_ios/test/unit_tests/src/mappers/health_record_mappers/distance/six_minute_walk_test_distance_record_mapper_test.dart
@@ -25,8 +25,8 @@ void main() {
                     FakeData.fakeStartTime.timeZoneOffset.inSeconds,
                 endZoneOffsetSeconds:
                     FakeData.fakeEndTime.timeZoneOffset.inSeconds,
-                metadata: const Metadata(
-                  dataOrigin: DataOrigin(FakeData.fakeDataOrigin),
+                metadata: Metadata.internal(
+                  dataOrigin: const DataOrigin(FakeData.fakeDataOrigin),
                   recordingMethod: RecordingMethod.activelyRecorded,
                   clientRecordVersion: 1,
                   device: Device(type: DeviceType.watch),
@@ -77,11 +77,11 @@ void main() {
                     FakeData.fakeStartTime.timeZoneOffset.inSeconds,
                 endZoneOffsetSeconds:
                     FakeData.fakeEndTime.timeZoneOffset.inSeconds,
-                metadata: const Metadata(
-                  dataOrigin: DataOrigin(FakeData.fakeDataOrigin),
+                metadata: Metadata.internal(
+                  dataOrigin: const DataOrigin(FakeData.fakeDataOrigin),
                   recordingMethod: RecordingMethod.manualEntry,
                   clientRecordVersion: 2,
-                  device: Device(type: DeviceType.phone),
+                  device: const Device(type: DeviceType.phone),
                 ),
                 distance: const Length.meters(600.0),
               );
@@ -136,7 +136,7 @@ void main() {
               expect(record.endTime, FakeData.fakeEndTime);
               expect(record.distance.inMeters, 450.0);
               expect(
-                record.metadata.dataOrigin.packageName,
+                record.metadata.dataOrigin?.packageName,
                 FakeData.fakeDataOrigin,
               );
             },

--- a/packages/health_connector_hk_ios/test/unit_tests/src/mappers/health_record_mappers/distance/skating_sports_distance_record_mapper_test.dart
+++ b/packages/health_connector_hk_ios/test/unit_tests/src/mappers/health_record_mappers/distance/skating_sports_distance_record_mapper_test.dart
@@ -25,8 +25,8 @@ void main() {
                     FakeData.fakeStartTime.timeZoneOffset.inSeconds,
                 endZoneOffsetSeconds:
                     FakeData.fakeEndTime.timeZoneOffset.inSeconds,
-                metadata: const Metadata(
-                  dataOrigin: DataOrigin(FakeData.fakeDataOrigin),
+                metadata: Metadata.internal(
+                  dataOrigin: const DataOrigin(FakeData.fakeDataOrigin),
                   recordingMethod: RecordingMethod.activelyRecorded,
                   clientRecordVersion: 1,
                   device: Device(type: DeviceType.watch),
@@ -77,11 +77,11 @@ void main() {
                     FakeData.fakeStartTime.timeZoneOffset.inSeconds,
                 endZoneOffsetSeconds:
                     FakeData.fakeEndTime.timeZoneOffset.inSeconds,
-                metadata: const Metadata(
-                  dataOrigin: DataOrigin(FakeData.fakeDataOrigin),
+                metadata: Metadata.internal(
+                  dataOrigin: const DataOrigin(FakeData.fakeDataOrigin),
                   recordingMethod: RecordingMethod.manualEntry,
                   clientRecordVersion: 2,
-                  device: Device(type: DeviceType.phone),
+                  device: const Device(type: DeviceType.phone),
                 ),
                 distance: const Length.meters(9000.0),
               );
@@ -136,7 +136,7 @@ void main() {
               expect(record.endTime, FakeData.fakeEndTime);
               expect(record.distance.inMeters, 5500.0);
               expect(
-                record.metadata.dataOrigin.packageName,
+                record.metadata.dataOrigin?.packageName,
                 FakeData.fakeDataOrigin,
               );
             },

--- a/packages/health_connector_hk_ios/test/unit_tests/src/mappers/health_record_mappers/distance/swimming_distance_record_mapper_test.dart
+++ b/packages/health_connector_hk_ios/test/unit_tests/src/mappers/health_record_mappers/distance/swimming_distance_record_mapper_test.dart
@@ -24,8 +24,8 @@ void main() {
                     FakeData.fakeStartTime.timeZoneOffset.inSeconds,
                 endZoneOffsetSeconds:
                     FakeData.fakeEndTime.timeZoneOffset.inSeconds,
-                metadata: const Metadata(
-                  dataOrigin: DataOrigin(FakeData.fakeDataOrigin),
+                metadata: Metadata.internal(
+                  dataOrigin: const DataOrigin(FakeData.fakeDataOrigin),
                   recordingMethod: RecordingMethod.activelyRecorded,
                   clientRecordVersion: 1,
                   device: Device(type: DeviceType.watch),
@@ -78,11 +78,11 @@ void main() {
                     FakeData.fakeStartTime.timeZoneOffset.inSeconds,
                 endZoneOffsetSeconds:
                     FakeData.fakeEndTime.timeZoneOffset.inSeconds,
-                metadata: const Metadata(
-                  dataOrigin: DataOrigin(FakeData.fakeDataOrigin),
+                metadata: Metadata.internal(
+                  dataOrigin: const DataOrigin(FakeData.fakeDataOrigin),
                   recordingMethod: RecordingMethod.manualEntry,
                   clientRecordVersion: 2,
-                  device: Device(type: DeviceType.phone),
+                  device: const Device(type: DeviceType.phone),
                 ),
                 distance: const Length.meters(500.0),
               );
@@ -146,7 +146,7 @@ void main() {
               );
               expect(record.distance.inMeters, 800.0);
               expect(
-                record.metadata.dataOrigin.packageName,
+                record.metadata.dataOrigin?.packageName,
                 FakeData.fakeDataOrigin,
               );
               expect(

--- a/packages/health_connector_hk_ios/test/unit_tests/src/mappers/health_record_mappers/distance/walking_running_distance_record_mapper_test.dart
+++ b/packages/health_connector_hk_ios/test/unit_tests/src/mappers/health_record_mappers/distance/walking_running_distance_record_mapper_test.dart
@@ -25,8 +25,8 @@ void main() {
                     FakeData.fakeStartTime.timeZoneOffset.inSeconds,
                 endZoneOffsetSeconds:
                     FakeData.fakeEndTime.timeZoneOffset.inSeconds,
-                metadata: const Metadata(
-                  dataOrigin: DataOrigin(FakeData.fakeDataOrigin),
+                metadata: Metadata.internal(
+                  dataOrigin: const DataOrigin(FakeData.fakeDataOrigin),
                   recordingMethod: RecordingMethod.activelyRecorded,
                   clientRecordVersion: 1,
                   device: Device(type: DeviceType.watch),
@@ -77,11 +77,11 @@ void main() {
                     FakeData.fakeStartTime.timeZoneOffset.inSeconds,
                 endZoneOffsetSeconds:
                     FakeData.fakeEndTime.timeZoneOffset.inSeconds,
-                metadata: const Metadata(
-                  dataOrigin: DataOrigin(FakeData.fakeDataOrigin),
+                metadata: Metadata.internal(
+                  dataOrigin: const DataOrigin(FakeData.fakeDataOrigin),
                   recordingMethod: RecordingMethod.manualEntry,
                   clientRecordVersion: 2,
-                  device: Device(type: DeviceType.phone),
+                  device: const Device(type: DeviceType.phone),
                 ),
                 distance: const Length.meters(12000.0),
               );
@@ -136,7 +136,7 @@ void main() {
               expect(record.endTime, FakeData.fakeEndTime);
               expect(record.distance.inMeters, 7000.0);
               expect(
-                record.metadata.dataOrigin.packageName,
+                record.metadata.dataOrigin?.packageName,
                 FakeData.fakeDataOrigin,
               );
             },

--- a/packages/health_connector_hk_ios/test/unit_tests/src/mappers/health_record_mappers/distance/wheelchair_distance_record_mapper_test.dart
+++ b/packages/health_connector_hk_ios/test/unit_tests/src/mappers/health_record_mappers/distance/wheelchair_distance_record_mapper_test.dart
@@ -24,8 +24,8 @@ void main() {
                     FakeData.fakeStartTime.timeZoneOffset.inSeconds,
                 endZoneOffsetSeconds:
                     FakeData.fakeEndTime.timeZoneOffset.inSeconds,
-                metadata: const Metadata(
-                  dataOrigin: DataOrigin(FakeData.fakeDataOrigin),
+                metadata: Metadata.internal(
+                  dataOrigin: const DataOrigin(FakeData.fakeDataOrigin),
                   recordingMethod: RecordingMethod.activelyRecorded,
                   clientRecordVersion: 1,
                   device: Device(type: DeviceType.watch),
@@ -72,11 +72,11 @@ void main() {
                     FakeData.fakeStartTime.timeZoneOffset.inSeconds,
                 endZoneOffsetSeconds:
                     FakeData.fakeEndTime.timeZoneOffset.inSeconds,
-                metadata: const Metadata(
-                  dataOrigin: DataOrigin(FakeData.fakeDataOrigin),
+                metadata: Metadata.internal(
+                  dataOrigin: const DataOrigin(FakeData.fakeDataOrigin),
                   recordingMethod: RecordingMethod.manualEntry,
                   clientRecordVersion: 2,
-                  device: Device(type: DeviceType.phone),
+                  device: const Device(type: DeviceType.phone),
                 ),
                 distance: const Length.meters(1500.0),
               );
@@ -127,7 +127,7 @@ void main() {
               expect(record.endTime, FakeData.fakeEndTime);
               expect(record.distance.inMeters, 1800.0);
               expect(
-                record.metadata.dataOrigin.packageName,
+                record.metadata.dataOrigin?.packageName,
                 FakeData.fakeDataOrigin,
               );
             },

--- a/packages/health_connector_hk_ios/test/unit_tests/src/mappers/health_record_mappers/energy_burned/active_calories_burned_record_mapper_test.dart
+++ b/packages/health_connector_hk_ios/test/unit_tests/src/mappers/health_record_mappers/energy_burned/active_calories_burned_record_mapper_test.dart
@@ -24,11 +24,11 @@ void main() {
                     FakeData.fakeStartTime.timeZoneOffset.inSeconds,
                 endZoneOffsetSeconds:
                     FakeData.fakeEndTime.timeZoneOffset.inSeconds,
-                metadata: const Metadata(
-                  dataOrigin: DataOrigin(FakeData.fakeDataOrigin),
+                metadata: Metadata.internal(
+                  dataOrigin: const DataOrigin(FakeData.fakeDataOrigin),
                   recordingMethod: RecordingMethod.activelyRecorded,
                   clientRecordVersion: 1,
-                  device: Device(type: DeviceType.watch),
+                  device: const Device(type: DeviceType.watch),
                 ),
                 energy: const Energy.kilocalories(350.0),
               );
@@ -85,7 +85,7 @@ void main() {
               expect(record.endTime, FakeData.fakeEndTime);
               expect(record.energy.inKilocalories, 275.0);
               expect(
-                record.metadata.dataOrigin.packageName,
+                record.metadata.dataOrigin?.packageName,
                 FakeData.fakeDataOrigin,
               );
             },

--- a/packages/health_connector_hk_ios/test/unit_tests/src/mappers/health_record_mappers/energy_burned/basal_energy_burned_record_mapper_test.dart
+++ b/packages/health_connector_hk_ios/test/unit_tests/src/mappers/health_record_mappers/energy_burned/basal_energy_burned_record_mapper_test.dart
@@ -23,11 +23,11 @@ void main() {
                     FakeData.fakeStartTime.timeZoneOffset.inSeconds,
                 endZoneOffsetSeconds:
                     FakeData.fakeEndTime.timeZoneOffset.inSeconds,
-                metadata: const Metadata(
-                  dataOrigin: DataOrigin(FakeData.fakeDataOrigin),
+                metadata: Metadata.internal(
+                  dataOrigin: const DataOrigin(FakeData.fakeDataOrigin),
                   recordingMethod: RecordingMethod.activelyRecorded,
                   clientRecordVersion: 1,
-                  device: Device(type: DeviceType.watch),
+                  device: const Device(type: DeviceType.watch),
                 ),
                 energy: const Energy.kilocalories(250.0),
               );
@@ -79,7 +79,7 @@ void main() {
               expect(record.endTime, FakeData.fakeEndTime);
               expect(record.energy.inKilocalories, 220.0);
               expect(
-                record.metadata.dataOrigin.packageName,
+                record.metadata.dataOrigin?.packageName,
                 FakeData.fakeDataOrigin,
               );
             },

--- a/packages/health_connector_hk_ios/test/unit_tests/src/mappers/health_record_mappers/exercise/exercise_session_record_mapper_test.dart
+++ b/packages/health_connector_hk_ios/test/unit_tests/src/mappers/health_record_mappers/exercise/exercise_session_record_mapper_test.dart
@@ -23,11 +23,11 @@ void main() {
                     FakeData.fakeStartTime.timeZoneOffset.inSeconds,
                 endZoneOffsetSeconds:
                     FakeData.fakeEndTime.timeZoneOffset.inSeconds,
-                metadata: const Metadata(
-                  dataOrigin: DataOrigin(FakeData.fakeDataOrigin),
+                metadata: Metadata.internal(
+                  dataOrigin: const DataOrigin(FakeData.fakeDataOrigin),
                   recordingMethod: RecordingMethod.manualEntry,
                   clientRecordVersion: 1,
-                  device: Device(type: DeviceType.phone),
+                  device: const Device(type: DeviceType.phone),
                 ),
                 exerciseType: ExerciseType.running,
                 title: 'Morning Run',
@@ -85,7 +85,7 @@ void main() {
               expect(record.title, 'Evening Yoga');
               expect(record.notes, 'Relaxing');
               expect(
-                record.metadata.dataOrigin.packageName,
+                record.metadata.dataOrigin?.packageName,
                 FakeData.fakeDataOrigin,
               );
             },

--- a/packages/health_connector_hk_ios/test/unit_tests/src/mappers/health_record_mappers/floors_climbed_record_mapper_test.dart
+++ b/packages/health_connector_hk_ios/test/unit_tests/src/mappers/health_record_mappers/floors_climbed_record_mapper_test.dart
@@ -23,11 +23,11 @@ void main() {
                     FakeData.fakeStartTime.timeZoneOffset.inSeconds,
                 endZoneOffsetSeconds:
                     FakeData.fakeEndTime.timeZoneOffset.inSeconds,
-                metadata: const Metadata(
-                  dataOrigin: DataOrigin(FakeData.fakeDataOrigin),
+                metadata: Metadata.internal(
+                  dataOrigin: const DataOrigin(FakeData.fakeDataOrigin),
                   recordingMethod: RecordingMethod.activelyRecorded,
                   clientRecordVersion: 1,
-                  device: Device(type: DeviceType.phone),
+                  device: const Device(type: DeviceType.phone),
                 ),
                 floors: const Number(15.0),
               );
@@ -83,7 +83,7 @@ void main() {
               expect(record.endTime, FakeData.fakeEndTime);
               expect(record.floors.value, 12.0);
               expect(
-                record.metadata.dataOrigin.packageName,
+                record.metadata.dataOrigin?.packageName,
                 FakeData.fakeDataOrigin,
               );
             },

--- a/packages/health_connector_hk_ios/test/unit_tests/src/mappers/health_record_mappers/health_record_mapper_test.dart
+++ b/packages/health_connector_hk_ios/test/unit_tests/src/mappers/health_record_mappers/health_record_mapper_test.dart
@@ -25,8 +25,8 @@ void main() {
                     FakeData.fakeStartTime.timeZoneOffset.inSeconds,
                 endZoneOffsetSeconds:
                     FakeData.fakeEndTime.timeZoneOffset.inSeconds,
-                metadata: const Metadata(
-                  dataOrigin: DataOrigin(FakeData.fakeDataOrigin),
+                metadata: Metadata.internal(
+                  dataOrigin: const DataOrigin(FakeData.fakeDataOrigin),
                   recordingMethod: RecordingMethod.activelyRecorded,
                   clientRecordVersion: 1,
                   device: Device(type: DeviceType.watch),
@@ -57,11 +57,11 @@ void main() {
                     FakeData.fakeStartTime.timeZoneOffset.inSeconds,
                 endZoneOffsetSeconds:
                     FakeData.fakeEndTime.timeZoneOffset.inSeconds,
-                metadata: const Metadata(
-                  dataOrigin: DataOrigin(FakeData.fakeDataOrigin),
+                metadata: Metadata.internal(
+                  dataOrigin: const DataOrigin(FakeData.fakeDataOrigin),
                   recordingMethod: RecordingMethod.activelyRecorded,
                   clientRecordVersion: 1,
-                  device: Device(type: DeviceType.phone),
+                  device: const Device(type: DeviceType.phone),
                 ),
                 count: const Number(5000),
               );
@@ -87,11 +87,11 @@ void main() {
                 id: HealthRecordId(FakeData.fakeId),
                 time: time,
                 zoneOffsetSeconds: FakeData.fakeTime.timeZoneOffset.inSeconds,
-                metadata: const Metadata(
-                  dataOrigin: DataOrigin(FakeData.fakeDataOrigin),
+                metadata: Metadata.internal(
+                  dataOrigin: const DataOrigin(FakeData.fakeDataOrigin),
                   recordingMethod: RecordingMethod.manualEntry,
                   clientRecordVersion: 1,
-                  device: Device(type: DeviceType.phone),
+                  device: const Device(type: DeviceType.phone),
                 ),
                 weight: const Mass.kilograms(70.5),
               );
@@ -117,11 +117,11 @@ void main() {
                 id: HealthRecordId(FakeData.fakeId),
                 time: time,
                 zoneOffsetSeconds: FakeData.fakeTime.timeZoneOffset.inSeconds,
-                metadata: const Metadata(
-                  dataOrigin: DataOrigin(FakeData.fakeDataOrigin),
+                metadata: Metadata.internal(
+                  dataOrigin: const DataOrigin(FakeData.fakeDataOrigin),
                   recordingMethod: RecordingMethod.manualEntry,
                   clientRecordVersion: 1,
-                  device: Device(type: DeviceType.phone),
+                  device: const Device(type: DeviceType.phone),
                 ),
                 systolic: const Pressure.millimetersOfMercury(120.0),
                 diastolic: const Pressure.millimetersOfMercury(80.0),
@@ -151,8 +151,8 @@ void main() {
                     FakeData.fakeStartTime.timeZoneOffset.inSeconds,
                 endZoneOffsetSeconds:
                     FakeData.fakeEndTime.timeZoneOffset.inSeconds,
-                metadata: const Metadata(
-                  dataOrigin: DataOrigin(FakeData.fakeDataOrigin),
+                metadata: Metadata.internal(
+                  dataOrigin: const DataOrigin(FakeData.fakeDataOrigin),
                   recordingMethod: RecordingMethod.activelyRecorded,
                   clientRecordVersion: 1,
                   device: Device(type: DeviceType.watch),
@@ -186,8 +186,8 @@ void main() {
                     FakeData.fakeStartTime.timeZoneOffset.inSeconds,
                 endZoneOffsetSeconds:
                     FakeData.fakeEndTime.timeZoneOffset.inSeconds,
-                metadata: const Metadata(
-                  dataOrigin: DataOrigin(FakeData.fakeDataOrigin),
+                metadata: Metadata.internal(
+                  dataOrigin: const DataOrigin(FakeData.fakeDataOrigin),
                   recordingMethod: RecordingMethod.activelyRecorded,
                   clientRecordVersion: 1,
                   device: Device(type: DeviceType.watch),
@@ -221,8 +221,8 @@ void main() {
                     FakeData.fakeStartTime.timeZoneOffset.inSeconds,
                 endZoneOffsetSeconds:
                     FakeData.fakeEndTime.timeZoneOffset.inSeconds,
-                metadata: const Metadata(
-                  dataOrigin: DataOrigin(FakeData.fakeDataOrigin),
+                metadata: Metadata.internal(
+                  dataOrigin: const DataOrigin(FakeData.fakeDataOrigin),
                   recordingMethod: RecordingMethod.activelyRecorded,
                   clientRecordVersion: 1,
                   device: Device(type: DeviceType.watch),

--- a/packages/health_connector_hk_ios/test/unit_tests/src/mappers/health_record_mappers/heart_rate/heart_rate_measurement_record_mapper_test.dart
+++ b/packages/health_connector_hk_ios/test/unit_tests/src/mappers/health_record_mappers/heart_rate/heart_rate_measurement_record_mapper_test.dart
@@ -20,8 +20,8 @@ void main() {
 
               final record = HeartRateMeasurementRecord(
                 id: HealthRecordId(FakeData.fakeId),
-                metadata: const Metadata(
-                  dataOrigin: DataOrigin(FakeData.fakeDataOrigin),
+                metadata: Metadata.internal(
+                  dataOrigin: const DataOrigin(FakeData.fakeDataOrigin),
                   recordingMethod: RecordingMethod.activelyRecorded,
                   clientRecordVersion: 1,
                   device: Device(type: DeviceType.watch),
@@ -67,7 +67,7 @@ void main() {
               expect(record.time, time);
               expect(record.beatsPerMinute.inPerMinute, 68.0);
               expect(
-                record.metadata.dataOrigin.packageName,
+                record.metadata.dataOrigin?.packageName,
                 FakeData.fakeDataOrigin,
               );
             },

--- a/packages/health_connector_hk_ios/test/unit_tests/src/mappers/health_record_mappers/heart_rate/heart_rate_variability_sdnn_record_mapper_test.dart
+++ b/packages/health_connector_hk_ios/test/unit_tests/src/mappers/health_record_mappers/heart_rate/heart_rate_variability_sdnn_record_mapper_test.dart
@@ -22,8 +22,8 @@ void main() {
                 id: HealthRecordId(FakeData.fakeId),
                 time: time,
                 zoneOffsetSeconds: FakeData.fakeTime.timeZoneOffset.inSeconds,
-                metadata: const Metadata(
-                  dataOrigin: DataOrigin(FakeData.fakeDataOrigin),
+                metadata: Metadata.internal(
+                  dataOrigin: const DataOrigin(FakeData.fakeDataOrigin),
                   recordingMethod: RecordingMethod.activelyRecorded,
                   clientRecordVersion: 1,
                   device: Device(type: DeviceType.watch),
@@ -76,7 +76,7 @@ void main() {
               expect(record.time, time);
               expect(record.heartRateVariabilitySDNN.value, 52.0);
               expect(
-                record.metadata.dataOrigin.packageName,
+                record.metadata.dataOrigin?.packageName,
                 FakeData.fakeDataOrigin,
               );
             },

--- a/packages/health_connector_hk_ios/test/unit_tests/src/mappers/health_record_mappers/heart_rate/resting_heart_rate_record_mapper_test.dart
+++ b/packages/health_connector_hk_ios/test/unit_tests/src/mappers/health_record_mappers/heart_rate/resting_heart_rate_record_mapper_test.dart
@@ -21,8 +21,8 @@ void main() {
                 id: HealthRecordId(FakeData.fakeId),
                 time: time,
                 zoneOffsetSeconds: FakeData.fakeTime.timeZoneOffset.inSeconds,
-                metadata: const Metadata(
-                  dataOrigin: DataOrigin(FakeData.fakeDataOrigin),
+                metadata: Metadata.internal(
+                  dataOrigin: const DataOrigin(FakeData.fakeDataOrigin),
                   recordingMethod: RecordingMethod.activelyRecorded,
                   clientRecordVersion: 1,
                   device: Device(type: DeviceType.watch),
@@ -72,7 +72,7 @@ void main() {
               expect(record.time, time);
               expect(record.beatsPerMinute.inPerMinute, 62.0);
               expect(
-                record.metadata.dataOrigin.packageName,
+                record.metadata.dataOrigin?.packageName,
                 FakeData.fakeDataOrigin,
               );
             },

--- a/packages/health_connector_hk_ios/test/unit_tests/src/mappers/health_record_mappers/height_record_mapper_test.dart
+++ b/packages/health_connector_hk_ios/test/unit_tests/src/mappers/health_record_mappers/height_record_mapper_test.dart
@@ -21,11 +21,11 @@ void main() {
                 id: HealthRecordId(FakeData.fakeId),
                 time: time,
                 zoneOffsetSeconds: FakeData.fakeTime.timeZoneOffset.inSeconds,
-                metadata: const Metadata(
-                  dataOrigin: DataOrigin(FakeData.fakeDataOrigin),
+                metadata: Metadata.internal(
+                  dataOrigin: const DataOrigin(FakeData.fakeDataOrigin),
                   recordingMethod: RecordingMethod.manualEntry,
                   clientRecordVersion: 1,
-                  device: Device(type: DeviceType.phone),
+                  device: const Device(type: DeviceType.phone),
                 ),
                 height: const Length.meters(1.75),
               );
@@ -72,7 +72,7 @@ void main() {
               expect(record.time, time);
               expect(record.height.inMeters, 1.82);
               expect(
-                record.metadata.dataOrigin.packageName,
+                record.metadata.dataOrigin?.packageName,
                 FakeData.fakeDataOrigin,
               );
             },

--- a/packages/health_connector_hk_ios/test/unit_tests/src/mappers/health_record_mappers/hydration_record_mapper_test.dart
+++ b/packages/health_connector_hk_ios/test/unit_tests/src/mappers/health_record_mappers/hydration_record_mapper_test.dart
@@ -23,11 +23,11 @@ void main() {
                     FakeData.fakeStartTime.timeZoneOffset.inSeconds,
                 endZoneOffsetSeconds:
                     FakeData.fakeEndTime.timeZoneOffset.inSeconds,
-                metadata: const Metadata(
-                  dataOrigin: DataOrigin(FakeData.fakeDataOrigin),
+                metadata: Metadata.internal(
+                  dataOrigin: const DataOrigin(FakeData.fakeDataOrigin),
                   recordingMethod: RecordingMethod.manualEntry,
                   clientRecordVersion: 1,
-                  device: Device(type: DeviceType.phone),
+                  device: const Device(type: DeviceType.phone),
                 ),
                 volume: const Volume.liters(2.5),
               );
@@ -83,7 +83,7 @@ void main() {
               expect(record.endTime, FakeData.fakeEndTime);
               expect(record.volume.inLiters, 1.5);
               expect(
-                record.metadata.dataOrigin.packageName,
+                record.metadata.dataOrigin?.packageName,
                 FakeData.fakeDataOrigin,
               );
             },

--- a/packages/health_connector_hk_ios/test/unit_tests/src/mappers/health_record_mappers/lean_body_mass_record_mapper_test.dart
+++ b/packages/health_connector_hk_ios/test/unit_tests/src/mappers/health_record_mappers/lean_body_mass_record_mapper_test.dart
@@ -21,11 +21,11 @@ void main() {
                 id: HealthRecordId(FakeData.fakeId),
                 time: time,
                 zoneOffsetSeconds: FakeData.fakeTime.timeZoneOffset.inSeconds,
-                metadata: const Metadata(
-                  dataOrigin: DataOrigin(FakeData.fakeDataOrigin),
+                metadata: Metadata.internal(
+                  dataOrigin: const DataOrigin(FakeData.fakeDataOrigin),
                   recordingMethod: RecordingMethod.manualEntry,
                   clientRecordVersion: 1,
-                  device: Device(type: DeviceType.phone),
+                  device: const Device(type: DeviceType.phone),
                 ),
                 mass: const Mass.kilograms(55.0),
               );
@@ -72,7 +72,7 @@ void main() {
               expect(record.time, time);
               expect(record.mass.inKilograms, 58.0);
               expect(
-                record.metadata.dataOrigin.packageName,
+                record.metadata.dataOrigin?.packageName,
                 FakeData.fakeDataOrigin,
               );
             },

--- a/packages/health_connector_hk_ios/test/unit_tests/src/mappers/health_record_mappers/menstruation/cervical_mucus_record_mapper_test.dart
+++ b/packages/health_connector_hk_ios/test/unit_tests/src/mappers/health_record_mappers/menstruation/cervical_mucus_record_mapper_test.dart
@@ -21,11 +21,11 @@ void main() {
                 id: HealthRecordId(FakeData.fakeId),
                 time: time,
                 zoneOffsetSeconds: FakeData.fakeTime.timeZoneOffset.inSeconds,
-                metadata: const Metadata(
-                  dataOrigin: DataOrigin(FakeData.fakeDataOrigin),
+                metadata: Metadata.internal(
+                  dataOrigin: const DataOrigin(FakeData.fakeDataOrigin),
                   recordingMethod: RecordingMethod.manualEntry,
                   clientRecordVersion: 1,
-                  device: Device(type: DeviceType.phone),
+                  device: const Device(type: DeviceType.phone),
                 ),
                 appearance: CervicalMucusAppearanceType.watery,
                 sensation: CervicalMucusSensationType.heavy,
@@ -79,7 +79,7 @@ void main() {
               expect(record.appearance, CervicalMucusAppearanceType.creamy);
               expect(record.sensation, CervicalMucusSensationType.medium);
               expect(
-                record.metadata.dataOrigin.packageName,
+                record.metadata.dataOrigin?.packageName,
                 FakeData.fakeDataOrigin,
               );
             },

--- a/packages/health_connector_hk_ios/test/unit_tests/src/mappers/health_record_mappers/menstruation/intermenstrual_bleeding_record_mapper_test.dart
+++ b/packages/health_connector_hk_ios/test/unit_tests/src/mappers/health_record_mappers/menstruation/intermenstrual_bleeding_record_mapper_test.dart
@@ -22,11 +22,11 @@ void main() {
                 id: HealthRecordId(FakeData.fakeId),
                 time: time,
                 zoneOffsetSeconds: FakeData.fakeTime.timeZoneOffset.inSeconds,
-                metadata: const Metadata(
-                  dataOrigin: DataOrigin(FakeData.fakeDataOrigin),
+                metadata: Metadata.internal(
+                  dataOrigin: const DataOrigin(FakeData.fakeDataOrigin),
                   recordingMethod: RecordingMethod.manualEntry,
                   clientRecordVersion: 1,
-                  device: Device(type: DeviceType.phone),
+                  device: const Device(type: DeviceType.phone),
                 ),
               );
 
@@ -70,7 +70,7 @@ void main() {
               expect(record.id.value, FakeData.fakeId);
               expect(record.time, time);
               expect(
-                record.metadata.dataOrigin.packageName,
+                record.metadata.dataOrigin?.packageName,
                 FakeData.fakeDataOrigin,
               );
             },

--- a/packages/health_connector_hk_ios/test/unit_tests/src/mappers/health_record_mappers/menstruation/menstrual_flow_record_mapper_test.dart
+++ b/packages/health_connector_hk_ios/test/unit_tests/src/mappers/health_record_mappers/menstruation/menstrual_flow_record_mapper_test.dart
@@ -23,11 +23,11 @@ void main() {
                     FakeData.fakeStartTime.timeZoneOffset.inSeconds,
                 endZoneOffsetSeconds:
                     FakeData.fakeEndTime.timeZoneOffset.inSeconds,
-                metadata: const Metadata(
-                  dataOrigin: DataOrigin(FakeData.fakeDataOrigin),
+                metadata: Metadata.internal(
+                  dataOrigin: const DataOrigin(FakeData.fakeDataOrigin),
                   recordingMethod: RecordingMethod.manualEntry,
                   clientRecordVersion: 1,
-                  device: Device(type: DeviceType.phone),
+                  device: const Device(type: DeviceType.phone),
                 ),
                 flow: MenstrualFlowType.medium,
                 isCycleStart: true,
@@ -81,7 +81,7 @@ void main() {
               expect(record.flow, MenstrualFlowType.heavy);
               expect(record.isCycleStart, false);
               expect(
-                record.metadata.dataOrigin.packageName,
+                record.metadata.dataOrigin?.packageName,
                 FakeData.fakeDataOrigin,
               );
             },

--- a/packages/health_connector_hk_ios/test/unit_tests/src/mappers/health_record_mappers/menstruation/ovulation_test_record_mapper_test.dart
+++ b/packages/health_connector_hk_ios/test/unit_tests/src/mappers/health_record_mappers/menstruation/ovulation_test_record_mapper_test.dart
@@ -21,11 +21,11 @@ void main() {
                 id: HealthRecordId(FakeData.fakeId),
                 time: time,
                 zoneOffsetSeconds: FakeData.fakeTime.timeZoneOffset.inSeconds,
-                metadata: const Metadata(
-                  dataOrigin: DataOrigin(FakeData.fakeDataOrigin),
+                metadata: Metadata.internal(
+                  dataOrigin: const DataOrigin(FakeData.fakeDataOrigin),
                   recordingMethod: RecordingMethod.manualEntry,
                   clientRecordVersion: 1,
-                  device: Device(type: DeviceType.phone),
+                  device: const Device(type: DeviceType.phone),
                 ),
                 result: OvulationTestResultType.positive,
               );
@@ -72,7 +72,7 @@ void main() {
               expect(record.time, time);
               expect(record.result, OvulationTestResultType.negative);
               expect(
-                record.metadata.dataOrigin.packageName,
+                record.metadata.dataOrigin?.packageName,
                 FakeData.fakeDataOrigin,
               );
             },

--- a/packages/health_connector_hk_ios/test/unit_tests/src/mappers/health_record_mappers/mindfulness/mindfulness_session_record_mapper_test.dart
+++ b/packages/health_connector_hk_ios/test/unit_tests/src/mappers/health_record_mappers/mindfulness/mindfulness_session_record_mapper_test.dart
@@ -23,11 +23,11 @@ void main() {
                     FakeData.fakeStartTime.timeZoneOffset.inSeconds,
                 endZoneOffsetSeconds:
                     FakeData.fakeEndTime.timeZoneOffset.inSeconds,
-                metadata: const Metadata(
-                  dataOrigin: DataOrigin(FakeData.fakeDataOrigin),
+                metadata: Metadata.internal(
+                  dataOrigin: const DataOrigin(FakeData.fakeDataOrigin),
                   recordingMethod: RecordingMethod.manualEntry,
                   clientRecordVersion: 1,
-                  device: Device(type: DeviceType.phone),
+                  device: const Device(type: DeviceType.phone),
                 ),
                 sessionType: MindfulnessSessionType.meditation,
                 title: 'Morning Meditation',
@@ -85,7 +85,7 @@ void main() {
               expect(record.title, 'Breathing Exercise');
               expect(record.notes, 'Calm');
               expect(
-                record.metadata.dataOrigin.packageName,
+                record.metadata.dataOrigin?.packageName,
                 FakeData.fakeDataOrigin,
               );
             },

--- a/packages/health_connector_hk_ios/test/unit_tests/src/mappers/health_record_mappers/nutrition/biotin_nutrient_record_mapper_test.dart
+++ b/packages/health_connector_hk_ios/test/unit_tests/src/mappers/health_record_mappers/nutrition/biotin_nutrient_record_mapper_test.dart
@@ -11,11 +11,11 @@ void main() {
       final record = BiotinNutrientRecord(
         time: FakeData.fakeTime,
         zoneOffsetSeconds: FakeData.fakeTime.timeZoneOffset.inSeconds,
-        metadata: const Metadata(
-          dataOrigin: DataOrigin(FakeData.fakeDataOrigin),
+        metadata: Metadata.internal(
+          dataOrigin: const DataOrigin(FakeData.fakeDataOrigin),
           recordingMethod: RecordingMethod.manualEntry,
           clientRecordVersion: 1,
-          device: Device(type: DeviceType.phone),
+          device: const Device(type: DeviceType.phone),
         ),
         value: const Mass.grams(10),
         foodName: 'Test Food',
@@ -55,7 +55,10 @@ void main() {
           record.zoneOffsetSeconds,
           FakeData.fakeTime.timeZoneOffset.inSeconds,
         );
-        expect(record.metadata.dataOrigin.packageName, FakeData.fakeDataOrigin);
+        expect(
+          record.metadata.dataOrigin?.packageName,
+          FakeData.fakeDataOrigin,
+        );
         expect(record.value.inKilograms, closeTo(10.0, 0.0001));
         expect(record.foodName, 'Test Food');
         expect(record.mealType, MealType.breakfast);

--- a/packages/health_connector_hk_ios/test/unit_tests/src/mappers/health_record_mappers/nutrition/caffeine_nutrient_record_mapper_test.dart
+++ b/packages/health_connector_hk_ios/test/unit_tests/src/mappers/health_record_mappers/nutrition/caffeine_nutrient_record_mapper_test.dart
@@ -13,11 +13,11 @@ void main() {
         final record = CaffeineNutrientRecord(
           time: FakeData.fakeTime,
           zoneOffsetSeconds: FakeData.fakeTime.timeZoneOffset.inSeconds,
-          metadata: const Metadata(
-            dataOrigin: DataOrigin(FakeData.fakeDataOrigin),
+          metadata: Metadata.internal(
+            dataOrigin: const DataOrigin(FakeData.fakeDataOrigin),
             recordingMethod: RecordingMethod.manualEntry,
             clientRecordVersion: 1,
-            device: Device(type: DeviceType.phone),
+            device: const Device(type: DeviceType.phone),
           ),
           value: const Mass.grams(10),
           foodName: 'Test Food',
@@ -63,7 +63,10 @@ void main() {
           record.zoneOffsetSeconds,
           FakeData.fakeTime.timeZoneOffset.inSeconds,
         );
-        expect(record.metadata.dataOrigin.packageName, FakeData.fakeDataOrigin);
+        expect(
+          record.metadata.dataOrigin?.packageName,
+          FakeData.fakeDataOrigin,
+        );
         expect(record.value.inKilograms, closeTo(10.0, 0.0001));
         expect(record.foodName, 'Test Food');
         expect(record.mealType, MealType.breakfast);

--- a/packages/health_connector_hk_ios/test/unit_tests/src/mappers/health_record_mappers/nutrition/calcium_nutrient_record_mapper_test.dart
+++ b/packages/health_connector_hk_ios/test/unit_tests/src/mappers/health_record_mappers/nutrition/calcium_nutrient_record_mapper_test.dart
@@ -13,11 +13,11 @@ void main() {
         final record = CalciumNutrientRecord(
           time: FakeData.fakeTime,
           zoneOffsetSeconds: FakeData.fakeTime.timeZoneOffset.inSeconds,
-          metadata: const Metadata(
-            dataOrigin: DataOrigin(FakeData.fakeDataOrigin),
+          metadata: Metadata.internal(
+            dataOrigin: const DataOrigin(FakeData.fakeDataOrigin),
             recordingMethod: RecordingMethod.manualEntry,
             clientRecordVersion: 1,
-            device: Device(type: DeviceType.phone),
+            device: const Device(type: DeviceType.phone),
           ),
           value: const Mass.grams(10),
           foodName: 'Test Food',
@@ -63,7 +63,10 @@ void main() {
           record.zoneOffsetSeconds,
           FakeData.fakeTime.timeZoneOffset.inSeconds,
         );
-        expect(record.metadata.dataOrigin.packageName, FakeData.fakeDataOrigin);
+        expect(
+          record.metadata.dataOrigin?.packageName,
+          FakeData.fakeDataOrigin,
+        );
         expect(record.value.inKilograms, closeTo(10.0, 0.0001));
         expect(record.foodName, 'Test Food');
         expect(record.mealType, MealType.breakfast);

--- a/packages/health_connector_hk_ios/test/unit_tests/src/mappers/health_record_mappers/nutrition/cholesterol_nutrient_record_mapper_test.dart
+++ b/packages/health_connector_hk_ios/test/unit_tests/src/mappers/health_record_mappers/nutrition/cholesterol_nutrient_record_mapper_test.dart
@@ -14,11 +14,11 @@ void main() {
         final record = CholesterolNutrientRecord(
           time: FakeData.fakeTime,
           zoneOffsetSeconds: FakeData.fakeTime.timeZoneOffset.inSeconds,
-          metadata: const Metadata(
-            dataOrigin: DataOrigin(FakeData.fakeDataOrigin),
+          metadata: Metadata.internal(
+            dataOrigin: const DataOrigin(FakeData.fakeDataOrigin),
             recordingMethod: RecordingMethod.manualEntry,
             clientRecordVersion: 1,
-            device: Device(type: DeviceType.phone),
+            device: const Device(type: DeviceType.phone),
           ),
           value: const Mass.grams(10),
           foodName: 'Test Food',
@@ -65,7 +65,10 @@ void main() {
           record.zoneOffsetSeconds,
           FakeData.fakeTime.timeZoneOffset.inSeconds,
         );
-        expect(record.metadata.dataOrigin.packageName, FakeData.fakeDataOrigin);
+        expect(
+          record.metadata.dataOrigin?.packageName,
+          FakeData.fakeDataOrigin,
+        );
         expect(record.value.inKilograms, closeTo(10.0, 0.0001));
         expect(record.foodName, 'Test Food');
         expect(record.mealType, MealType.breakfast);

--- a/packages/health_connector_hk_ios/test/unit_tests/src/mappers/health_record_mappers/nutrition/dietary_fiber_nutrient_record_mapper_test.dart
+++ b/packages/health_connector_hk_ios/test/unit_tests/src/mappers/health_record_mappers/nutrition/dietary_fiber_nutrient_record_mapper_test.dart
@@ -14,11 +14,11 @@ void main() {
         final record = DietaryFiberNutrientRecord(
           time: FakeData.fakeTime,
           zoneOffsetSeconds: FakeData.fakeTime.timeZoneOffset.inSeconds,
-          metadata: const Metadata(
-            dataOrigin: DataOrigin(FakeData.fakeDataOrigin),
+          metadata: Metadata.internal(
+            dataOrigin: const DataOrigin(FakeData.fakeDataOrigin),
             recordingMethod: RecordingMethod.manualEntry,
             clientRecordVersion: 1,
-            device: Device(type: DeviceType.phone),
+            device: const Device(type: DeviceType.phone),
           ),
           value: const Mass.grams(10),
           foodName: 'Test Food',
@@ -65,7 +65,10 @@ void main() {
           record.zoneOffsetSeconds,
           FakeData.fakeTime.timeZoneOffset.inSeconds,
         );
-        expect(record.metadata.dataOrigin.packageName, FakeData.fakeDataOrigin);
+        expect(
+          record.metadata.dataOrigin?.packageName,
+          FakeData.fakeDataOrigin,
+        );
         expect(record.value.inKilograms, closeTo(10.0, 0.0001));
         expect(record.foodName, 'Test Food');
         expect(record.mealType, MealType.breakfast);

--- a/packages/health_connector_hk_ios/test/unit_tests/src/mappers/health_record_mappers/nutrition/energy_nutrient_record_mapper_test.dart
+++ b/packages/health_connector_hk_ios/test/unit_tests/src/mappers/health_record_mappers/nutrition/energy_nutrient_record_mapper_test.dart
@@ -11,11 +11,11 @@ void main() {
       final record = EnergyNutrientRecord(
         time: FakeData.fakeTime,
         zoneOffsetSeconds: FakeData.fakeTime.timeZoneOffset.inSeconds,
-        metadata: const Metadata(
-          dataOrigin: DataOrigin(FakeData.fakeDataOrigin),
+        metadata: Metadata.internal(
+          dataOrigin: const DataOrigin(FakeData.fakeDataOrigin),
           recordingMethod: RecordingMethod.manualEntry,
           clientRecordVersion: 1,
-          device: Device(type: DeviceType.phone),
+          device: const Device(type: DeviceType.phone),
         ),
         value: const Energy.calories(500),
         foodName: 'Test Food',
@@ -55,7 +55,10 @@ void main() {
           record.zoneOffsetSeconds,
           FakeData.fakeTime.timeZoneOffset.inSeconds,
         );
-        expect(record.metadata.dataOrigin.packageName, FakeData.fakeDataOrigin);
+        expect(
+          record.metadata.dataOrigin?.packageName,
+          FakeData.fakeDataOrigin,
+        );
         expect(record.value.inKilocalories, closeTo(500.0, 0.0001));
         expect(record.foodName, 'Test Food');
         expect(record.mealType, MealType.breakfast);

--- a/packages/health_connector_hk_ios/test/unit_tests/src/mappers/health_record_mappers/nutrition/folate_nutrient_record_mapper_test.dart
+++ b/packages/health_connector_hk_ios/test/unit_tests/src/mappers/health_record_mappers/nutrition/folate_nutrient_record_mapper_test.dart
@@ -11,11 +11,11 @@ void main() {
       final record = FolateNutrientRecord(
         time: FakeData.fakeTime,
         zoneOffsetSeconds: FakeData.fakeTime.timeZoneOffset.inSeconds,
-        metadata: const Metadata(
-          dataOrigin: DataOrigin(FakeData.fakeDataOrigin),
+        metadata: Metadata.internal(
+          dataOrigin: const DataOrigin(FakeData.fakeDataOrigin),
           recordingMethod: RecordingMethod.manualEntry,
           clientRecordVersion: 1,
-          device: Device(type: DeviceType.phone),
+          device: const Device(type: DeviceType.phone),
         ),
         value: const Mass.grams(10),
         foodName: 'Test Food',
@@ -56,7 +56,10 @@ void main() {
           record.zoneOffsetSeconds,
           FakeData.fakeTime.timeZoneOffset.inSeconds,
         );
-        expect(record.metadata.dataOrigin.packageName, FakeData.fakeDataOrigin);
+        expect(
+          record.metadata.dataOrigin?.packageName,
+          FakeData.fakeDataOrigin,
+        );
         expect(record.value.inKilograms, closeTo(10.0, 0.0001));
         expect(record.foodName, 'Test Food');
         expect(record.mealType, MealType.breakfast);

--- a/packages/health_connector_hk_ios/test/unit_tests/src/mappers/health_record_mappers/nutrition/iron_nutrient_record_mapper_test.dart
+++ b/packages/health_connector_hk_ios/test/unit_tests/src/mappers/health_record_mappers/nutrition/iron_nutrient_record_mapper_test.dart
@@ -11,11 +11,11 @@ void main() {
       final record = IronNutrientRecord(
         time: FakeData.fakeTime,
         zoneOffsetSeconds: FakeData.fakeTime.timeZoneOffset.inSeconds,
-        metadata: const Metadata(
-          dataOrigin: DataOrigin(FakeData.fakeDataOrigin),
+        metadata: Metadata.internal(
+          dataOrigin: const DataOrigin(FakeData.fakeDataOrigin),
           recordingMethod: RecordingMethod.manualEntry,
           clientRecordVersion: 1,
-          device: Device(type: DeviceType.phone),
+          device: const Device(type: DeviceType.phone),
         ),
         value: const Mass.grams(10),
         foodName: 'Test Food',
@@ -53,7 +53,7 @@ void main() {
         record.zoneOffsetSeconds,
         FakeData.fakeTime.timeZoneOffset.inSeconds,
       );
-      expect(record.metadata.dataOrigin.packageName, FakeData.fakeDataOrigin);
+      expect(record.metadata.dataOrigin?.packageName, FakeData.fakeDataOrigin);
       expect(record.value.inKilograms, closeTo(10.0, 0.0001));
       expect(record.foodName, 'Test Food');
       expect(record.mealType, MealType.breakfast);

--- a/packages/health_connector_hk_ios/test/unit_tests/src/mappers/health_record_mappers/nutrition/magnesium_nutrient_record_mapper_test.dart
+++ b/packages/health_connector_hk_ios/test/unit_tests/src/mappers/health_record_mappers/nutrition/magnesium_nutrient_record_mapper_test.dart
@@ -13,11 +13,11 @@ void main() {
         final record = MagnesiumNutrientRecord(
           time: FakeData.fakeTime,
           zoneOffsetSeconds: FakeData.fakeTime.timeZoneOffset.inSeconds,
-          metadata: const Metadata(
-            dataOrigin: DataOrigin(FakeData.fakeDataOrigin),
+          metadata: Metadata.internal(
+            dataOrigin: const DataOrigin(FakeData.fakeDataOrigin),
             recordingMethod: RecordingMethod.manualEntry,
             clientRecordVersion: 1,
-            device: Device(type: DeviceType.phone),
+            device: const Device(type: DeviceType.phone),
           ),
           value: const Mass.grams(10),
           foodName: 'Test Food',
@@ -63,7 +63,10 @@ void main() {
           record.zoneOffsetSeconds,
           FakeData.fakeTime.timeZoneOffset.inSeconds,
         );
-        expect(record.metadata.dataOrigin.packageName, FakeData.fakeDataOrigin);
+        expect(
+          record.metadata.dataOrigin?.packageName,
+          FakeData.fakeDataOrigin,
+        );
         expect(record.value.inKilograms, closeTo(10.0, 0.0001));
         expect(record.foodName, 'Test Food');
         expect(record.mealType, MealType.breakfast);

--- a/packages/health_connector_hk_ios/test/unit_tests/src/mappers/health_record_mappers/nutrition/manganese_nutrient_record_mapper_test.dart
+++ b/packages/health_connector_hk_ios/test/unit_tests/src/mappers/health_record_mappers/nutrition/manganese_nutrient_record_mapper_test.dart
@@ -13,11 +13,11 @@ void main() {
         final record = ManganeseNutrientRecord(
           time: FakeData.fakeTime,
           zoneOffsetSeconds: FakeData.fakeTime.timeZoneOffset.inSeconds,
-          metadata: const Metadata(
-            dataOrigin: DataOrigin(FakeData.fakeDataOrigin),
+          metadata: Metadata.internal(
+            dataOrigin: const DataOrigin(FakeData.fakeDataOrigin),
             recordingMethod: RecordingMethod.manualEntry,
             clientRecordVersion: 1,
-            device: Device(type: DeviceType.phone),
+            device: const Device(type: DeviceType.phone),
           ),
           value: const Mass.grams(10),
           foodName: 'Test Food',
@@ -63,7 +63,10 @@ void main() {
           record.zoneOffsetSeconds,
           FakeData.fakeTime.timeZoneOffset.inSeconds,
         );
-        expect(record.metadata.dataOrigin.packageName, FakeData.fakeDataOrigin);
+        expect(
+          record.metadata.dataOrigin?.packageName,
+          FakeData.fakeDataOrigin,
+        );
         expect(record.value.inKilograms, closeTo(10.0, 0.0001));
         expect(record.foodName, 'Test Food');
         expect(record.mealType, MealType.breakfast);

--- a/packages/health_connector_hk_ios/test/unit_tests/src/mappers/health_record_mappers/nutrition/monounsaturated_fat_nutrient_record_mapper_test.dart
+++ b/packages/health_connector_hk_ios/test/unit_tests/src/mappers/health_record_mappers/nutrition/monounsaturated_fat_nutrient_record_mapper_test.dart
@@ -14,11 +14,11 @@ void main() {
         final record = MonounsaturatedFatNutrientRecord(
           time: FakeData.fakeTime,
           zoneOffsetSeconds: FakeData.fakeTime.timeZoneOffset.inSeconds,
-          metadata: const Metadata(
-            dataOrigin: DataOrigin(FakeData.fakeDataOrigin),
+          metadata: Metadata.internal(
+            dataOrigin: const DataOrigin(FakeData.fakeDataOrigin),
             recordingMethod: RecordingMethod.manualEntry,
             clientRecordVersion: 1,
-            device: Device(type: DeviceType.phone),
+            device: const Device(type: DeviceType.phone),
           ),
           value: const Mass.grams(10),
           foodName: 'Test Food',
@@ -65,7 +65,10 @@ void main() {
           record.zoneOffsetSeconds,
           FakeData.fakeTime.timeZoneOffset.inSeconds,
         );
-        expect(record.metadata.dataOrigin.packageName, FakeData.fakeDataOrigin);
+        expect(
+          record.metadata.dataOrigin?.packageName,
+          FakeData.fakeDataOrigin,
+        );
         expect(record.value.inKilograms, closeTo(10.0, 0.0001));
         expect(record.foodName, 'Test Food');
         expect(record.mealType, MealType.breakfast);

--- a/packages/health_connector_hk_ios/test/unit_tests/src/mappers/health_record_mappers/nutrition/niacin_nutrient_record_mapper_test.dart
+++ b/packages/health_connector_hk_ios/test/unit_tests/src/mappers/health_record_mappers/nutrition/niacin_nutrient_record_mapper_test.dart
@@ -11,11 +11,11 @@ void main() {
       final record = NiacinNutrientRecord(
         time: FakeData.fakeTime,
         zoneOffsetSeconds: FakeData.fakeTime.timeZoneOffset.inSeconds,
-        metadata: const Metadata(
-          dataOrigin: DataOrigin(FakeData.fakeDataOrigin),
+        metadata: Metadata.internal(
+          dataOrigin: const DataOrigin(FakeData.fakeDataOrigin),
           recordingMethod: RecordingMethod.manualEntry,
           clientRecordVersion: 1,
-          device: Device(type: DeviceType.phone),
+          device: const Device(type: DeviceType.phone),
         ),
         value: const Mass.grams(10),
         foodName: 'Test Food',
@@ -56,7 +56,10 @@ void main() {
           record.zoneOffsetSeconds,
           FakeData.fakeTime.timeZoneOffset.inSeconds,
         );
-        expect(record.metadata.dataOrigin.packageName, FakeData.fakeDataOrigin);
+        expect(
+          record.metadata.dataOrigin?.packageName,
+          FakeData.fakeDataOrigin,
+        );
         expect(record.value.inKilograms, closeTo(10.0, 0.0001));
         expect(record.foodName, 'Test Food');
         expect(record.mealType, MealType.breakfast);

--- a/packages/health_connector_hk_ios/test/unit_tests/src/mappers/health_record_mappers/nutrition/nutrition_record_mapper_test.dart
+++ b/packages/health_connector_hk_ios/test/unit_tests/src/mappers/health_record_mappers/nutrition/nutrition_record_mapper_test.dart
@@ -23,11 +23,11 @@ void main() {
                     FakeData.fakeStartTime.timeZoneOffset.inSeconds,
                 endZoneOffsetSeconds:
                     FakeData.fakeEndTime.timeZoneOffset.inSeconds,
-                metadata: const Metadata(
-                  dataOrigin: DataOrigin(FakeData.fakeDataOrigin),
+                metadata: Metadata.internal(
+                  dataOrigin: const DataOrigin(FakeData.fakeDataOrigin),
                   recordingMethod: RecordingMethod.manualEntry,
                   clientRecordVersion: 1,
-                  device: Device(type: DeviceType.phone),
+                  device: const Device(type: DeviceType.phone),
                 ),
                 mealType: MealType.lunch,
                 foodName: 'Chicken Salad',
@@ -93,7 +93,7 @@ void main() {
               expect(record.energy?.inKilocalories, 600);
               expect(record.protein?.inKilograms, 25);
               expect(
-                record.metadata.dataOrigin.packageName,
+                record.metadata.dataOrigin?.packageName,
                 FakeData.fakeDataOrigin,
               );
             },

--- a/packages/health_connector_hk_ios/test/unit_tests/src/mappers/health_record_mappers/nutrition/pantothenic_acid_nutrient_record_mapper_test.dart
+++ b/packages/health_connector_hk_ios/test/unit_tests/src/mappers/health_record_mappers/nutrition/pantothenic_acid_nutrient_record_mapper_test.dart
@@ -14,11 +14,11 @@ void main() {
         final record = PantothenicAcidNutrientRecord(
           time: FakeData.fakeTime,
           zoneOffsetSeconds: FakeData.fakeTime.timeZoneOffset.inSeconds,
-          metadata: const Metadata(
-            dataOrigin: DataOrigin(FakeData.fakeDataOrigin),
+          metadata: Metadata.internal(
+            dataOrigin: const DataOrigin(FakeData.fakeDataOrigin),
             recordingMethod: RecordingMethod.manualEntry,
             clientRecordVersion: 1,
-            device: Device(type: DeviceType.phone),
+            device: const Device(type: DeviceType.phone),
           ),
           value: const Mass.grams(10),
           foodName: 'Test Food',
@@ -65,7 +65,10 @@ void main() {
           record.zoneOffsetSeconds,
           FakeData.fakeTime.timeZoneOffset.inSeconds,
         );
-        expect(record.metadata.dataOrigin.packageName, FakeData.fakeDataOrigin);
+        expect(
+          record.metadata.dataOrigin?.packageName,
+          FakeData.fakeDataOrigin,
+        );
         expect(record.value.inKilograms, closeTo(10.0, 0.0001));
         expect(record.foodName, 'Test Food');
         expect(record.mealType, MealType.breakfast);

--- a/packages/health_connector_hk_ios/test/unit_tests/src/mappers/health_record_mappers/nutrition/phosphorus_nutrient_record_mapper_test.dart
+++ b/packages/health_connector_hk_ios/test/unit_tests/src/mappers/health_record_mappers/nutrition/phosphorus_nutrient_record_mapper_test.dart
@@ -13,11 +13,11 @@ void main() {
         final record = PhosphorusNutrientRecord(
           time: FakeData.fakeTime,
           zoneOffsetSeconds: FakeData.fakeTime.timeZoneOffset.inSeconds,
-          metadata: const Metadata(
-            dataOrigin: DataOrigin(FakeData.fakeDataOrigin),
+          metadata: Metadata.internal(
+            dataOrigin: const DataOrigin(FakeData.fakeDataOrigin),
             recordingMethod: RecordingMethod.manualEntry,
             clientRecordVersion: 1,
-            device: Device(type: DeviceType.phone),
+            device: const Device(type: DeviceType.phone),
           ),
           value: const Mass.grams(10),
           foodName: 'Test Food',
@@ -64,7 +64,10 @@ void main() {
           record.zoneOffsetSeconds,
           FakeData.fakeTime.timeZoneOffset.inSeconds,
         );
-        expect(record.metadata.dataOrigin.packageName, FakeData.fakeDataOrigin);
+        expect(
+          record.metadata.dataOrigin?.packageName,
+          FakeData.fakeDataOrigin,
+        );
         expect(record.value.inKilograms, closeTo(10.0, 0.0001));
         expect(record.foodName, 'Test Food');
         expect(record.mealType, MealType.breakfast);

--- a/packages/health_connector_hk_ios/test/unit_tests/src/mappers/health_record_mappers/nutrition/polyunsaturated_fat_nutrient_record_mapper_test.dart
+++ b/packages/health_connector_hk_ios/test/unit_tests/src/mappers/health_record_mappers/nutrition/polyunsaturated_fat_nutrient_record_mapper_test.dart
@@ -14,11 +14,11 @@ void main() {
         final record = PolyunsaturatedFatNutrientRecord(
           time: FakeData.fakeTime,
           zoneOffsetSeconds: FakeData.fakeTime.timeZoneOffset.inSeconds,
-          metadata: const Metadata(
-            dataOrigin: DataOrigin(FakeData.fakeDataOrigin),
+          metadata: Metadata.internal(
+            dataOrigin: const DataOrigin(FakeData.fakeDataOrigin),
             recordingMethod: RecordingMethod.manualEntry,
             clientRecordVersion: 1,
-            device: Device(type: DeviceType.phone),
+            device: const Device(type: DeviceType.phone),
           ),
           value: const Mass.grams(10),
           foodName: 'Test Food',
@@ -65,7 +65,10 @@ void main() {
           record.zoneOffsetSeconds,
           FakeData.fakeTime.timeZoneOffset.inSeconds,
         );
-        expect(record.metadata.dataOrigin.packageName, FakeData.fakeDataOrigin);
+        expect(
+          record.metadata.dataOrigin?.packageName,
+          FakeData.fakeDataOrigin,
+        );
         expect(record.value.inKilograms, closeTo(10.0, 0.0001));
         expect(record.foodName, 'Test Food');
         expect(record.mealType, MealType.breakfast);

--- a/packages/health_connector_hk_ios/test/unit_tests/src/mappers/health_record_mappers/nutrition/potassium_nutrient_record_mapper_test.dart
+++ b/packages/health_connector_hk_ios/test/unit_tests/src/mappers/health_record_mappers/nutrition/potassium_nutrient_record_mapper_test.dart
@@ -13,11 +13,11 @@ void main() {
         final record = PotassiumNutrientRecord(
           time: FakeData.fakeTime,
           zoneOffsetSeconds: FakeData.fakeTime.timeZoneOffset.inSeconds,
-          metadata: const Metadata(
-            dataOrigin: DataOrigin(FakeData.fakeDataOrigin),
+          metadata: Metadata.internal(
+            dataOrigin: const DataOrigin(FakeData.fakeDataOrigin),
             recordingMethod: RecordingMethod.manualEntry,
             clientRecordVersion: 1,
-            device: Device(type: DeviceType.phone),
+            device: const Device(type: DeviceType.phone),
           ),
           value: const Mass.grams(10),
           foodName: 'Test Food',
@@ -63,7 +63,10 @@ void main() {
           record.zoneOffsetSeconds,
           FakeData.fakeTime.timeZoneOffset.inSeconds,
         );
-        expect(record.metadata.dataOrigin.packageName, FakeData.fakeDataOrigin);
+        expect(
+          record.metadata.dataOrigin?.packageName,
+          FakeData.fakeDataOrigin,
+        );
         expect(record.value.inKilograms, closeTo(10.0, 0.0001));
         expect(record.foodName, 'Test Food');
         expect(record.mealType, MealType.breakfast);

--- a/packages/health_connector_hk_ios/test/unit_tests/src/mappers/health_record_mappers/nutrition/protein_nutrient_record_mapper_test.dart
+++ b/packages/health_connector_hk_ios/test/unit_tests/src/mappers/health_record_mappers/nutrition/protein_nutrient_record_mapper_test.dart
@@ -13,11 +13,11 @@ void main() {
         final record = ProteinNutrientRecord(
           time: FakeData.fakeTime,
           zoneOffsetSeconds: FakeData.fakeTime.timeZoneOffset.inSeconds,
-          metadata: const Metadata(
-            dataOrigin: DataOrigin(FakeData.fakeDataOrigin),
+          metadata: Metadata.internal(
+            dataOrigin: const DataOrigin(FakeData.fakeDataOrigin),
             recordingMethod: RecordingMethod.manualEntry,
             clientRecordVersion: 1,
-            device: Device(type: DeviceType.phone),
+            device: const Device(type: DeviceType.phone),
           ),
           value: const Mass.grams(10),
           foodName: 'Test Food',
@@ -63,7 +63,10 @@ void main() {
           record.zoneOffsetSeconds,
           FakeData.fakeTime.timeZoneOffset.inSeconds,
         );
-        expect(record.metadata.dataOrigin.packageName, FakeData.fakeDataOrigin);
+        expect(
+          record.metadata.dataOrigin?.packageName,
+          FakeData.fakeDataOrigin,
+        );
         expect(record.value.inKilograms, closeTo(10.0, 0.0001));
         expect(record.foodName, 'Test Food');
         expect(record.mealType, MealType.breakfast);

--- a/packages/health_connector_hk_ios/test/unit_tests/src/mappers/health_record_mappers/nutrition/riboflavin_nutrient_record_mapper_test.dart
+++ b/packages/health_connector_hk_ios/test/unit_tests/src/mappers/health_record_mappers/nutrition/riboflavin_nutrient_record_mapper_test.dart
@@ -13,11 +13,11 @@ void main() {
         final record = RiboflavinNutrientRecord(
           time: FakeData.fakeTime,
           zoneOffsetSeconds: FakeData.fakeTime.timeZoneOffset.inSeconds,
-          metadata: const Metadata(
-            dataOrigin: DataOrigin(FakeData.fakeDataOrigin),
+          metadata: Metadata.internal(
+            dataOrigin: const DataOrigin(FakeData.fakeDataOrigin),
             recordingMethod: RecordingMethod.manualEntry,
             clientRecordVersion: 1,
-            device: Device(type: DeviceType.phone),
+            device: const Device(type: DeviceType.phone),
           ),
           value: const Mass.grams(10),
           foodName: 'Test Food',
@@ -64,7 +64,10 @@ void main() {
           record.zoneOffsetSeconds,
           FakeData.fakeTime.timeZoneOffset.inSeconds,
         );
-        expect(record.metadata.dataOrigin.packageName, FakeData.fakeDataOrigin);
+        expect(
+          record.metadata.dataOrigin?.packageName,
+          FakeData.fakeDataOrigin,
+        );
         expect(record.value.inKilograms, closeTo(10.0, 0.0001));
         expect(record.foodName, 'Test Food');
         expect(record.mealType, MealType.breakfast);

--- a/packages/health_connector_hk_ios/test/unit_tests/src/mappers/health_record_mappers/nutrition/saturated_fat_nutrient_record_mapper_test.dart
+++ b/packages/health_connector_hk_ios/test/unit_tests/src/mappers/health_record_mappers/nutrition/saturated_fat_nutrient_record_mapper_test.dart
@@ -14,11 +14,11 @@ void main() {
         final record = SaturatedFatNutrientRecord(
           time: FakeData.fakeTime,
           zoneOffsetSeconds: FakeData.fakeTime.timeZoneOffset.inSeconds,
-          metadata: const Metadata(
-            dataOrigin: DataOrigin(FakeData.fakeDataOrigin),
+          metadata: Metadata.internal(
+            dataOrigin: const DataOrigin(FakeData.fakeDataOrigin),
             recordingMethod: RecordingMethod.manualEntry,
             clientRecordVersion: 1,
-            device: Device(type: DeviceType.phone),
+            device: const Device(type: DeviceType.phone),
           ),
           value: const Mass.grams(10),
           foodName: 'Test Food',
@@ -65,7 +65,10 @@ void main() {
           record.zoneOffsetSeconds,
           FakeData.fakeTime.timeZoneOffset.inSeconds,
         );
-        expect(record.metadata.dataOrigin.packageName, FakeData.fakeDataOrigin);
+        expect(
+          record.metadata.dataOrigin?.packageName,
+          FakeData.fakeDataOrigin,
+        );
         expect(record.value.inKilograms, closeTo(10.0, 0.0001));
         expect(record.foodName, 'Test Food');
         expect(record.mealType, MealType.breakfast);

--- a/packages/health_connector_hk_ios/test/unit_tests/src/mappers/health_record_mappers/nutrition/selenium_nutrient_record_mapper_test.dart
+++ b/packages/health_connector_hk_ios/test/unit_tests/src/mappers/health_record_mappers/nutrition/selenium_nutrient_record_mapper_test.dart
@@ -13,11 +13,11 @@ void main() {
         final record = SeleniumNutrientRecord(
           time: FakeData.fakeTime,
           zoneOffsetSeconds: FakeData.fakeTime.timeZoneOffset.inSeconds,
-          metadata: const Metadata(
-            dataOrigin: DataOrigin(FakeData.fakeDataOrigin),
+          metadata: Metadata.internal(
+            dataOrigin: const DataOrigin(FakeData.fakeDataOrigin),
             recordingMethod: RecordingMethod.manualEntry,
             clientRecordVersion: 1,
-            device: Device(type: DeviceType.phone),
+            device: const Device(type: DeviceType.phone),
           ),
           value: const Mass.grams(10),
           foodName: 'Test Food',
@@ -63,7 +63,10 @@ void main() {
           record.zoneOffsetSeconds,
           FakeData.fakeTime.timeZoneOffset.inSeconds,
         );
-        expect(record.metadata.dataOrigin.packageName, FakeData.fakeDataOrigin);
+        expect(
+          record.metadata.dataOrigin?.packageName,
+          FakeData.fakeDataOrigin,
+        );
         expect(record.value.inKilograms, closeTo(10.0, 0.0001));
         expect(record.foodName, 'Test Food');
         expect(record.mealType, MealType.breakfast);

--- a/packages/health_connector_hk_ios/test/unit_tests/src/mappers/health_record_mappers/nutrition/sodium_nutrient_record_mapper_test.dart
+++ b/packages/health_connector_hk_ios/test/unit_tests/src/mappers/health_record_mappers/nutrition/sodium_nutrient_record_mapper_test.dart
@@ -11,11 +11,11 @@ void main() {
       final record = SodiumNutrientRecord(
         time: FakeData.fakeTime,
         zoneOffsetSeconds: FakeData.fakeTime.timeZoneOffset.inSeconds,
-        metadata: const Metadata(
-          dataOrigin: DataOrigin(FakeData.fakeDataOrigin),
+        metadata: Metadata.internal(
+          dataOrigin: const DataOrigin(FakeData.fakeDataOrigin),
           recordingMethod: RecordingMethod.manualEntry,
           clientRecordVersion: 1,
-          device: Device(type: DeviceType.phone),
+          device: const Device(type: DeviceType.phone),
         ),
         value: const Mass.grams(10),
         foodName: 'Test Food',
@@ -56,7 +56,10 @@ void main() {
           record.zoneOffsetSeconds,
           FakeData.fakeTime.timeZoneOffset.inSeconds,
         );
-        expect(record.metadata.dataOrigin.packageName, FakeData.fakeDataOrigin);
+        expect(
+          record.metadata.dataOrigin?.packageName,
+          FakeData.fakeDataOrigin,
+        );
         expect(record.value.inKilograms, closeTo(10.0, 0.0001));
         expect(record.foodName, 'Test Food');
         expect(record.mealType, MealType.breakfast);

--- a/packages/health_connector_hk_ios/test/unit_tests/src/mappers/health_record_mappers/nutrition/sugar_nutrient_record_mapper_test.dart
+++ b/packages/health_connector_hk_ios/test/unit_tests/src/mappers/health_record_mappers/nutrition/sugar_nutrient_record_mapper_test.dart
@@ -11,11 +11,11 @@ void main() {
       final record = SugarNutrientRecord(
         time: FakeData.fakeTime,
         zoneOffsetSeconds: FakeData.fakeTime.timeZoneOffset.inSeconds,
-        metadata: const Metadata(
-          dataOrigin: DataOrigin(FakeData.fakeDataOrigin),
+        metadata: Metadata.internal(
+          dataOrigin: const DataOrigin(FakeData.fakeDataOrigin),
           recordingMethod: RecordingMethod.manualEntry,
           clientRecordVersion: 1,
-          device: Device(type: DeviceType.phone),
+          device: const Device(type: DeviceType.phone),
         ),
         value: const Mass.grams(10),
         foodName: 'Test Food',
@@ -53,7 +53,7 @@ void main() {
         record.zoneOffsetSeconds,
         FakeData.fakeTime.timeZoneOffset.inSeconds,
       );
-      expect(record.metadata.dataOrigin.packageName, FakeData.fakeDataOrigin);
+      expect(record.metadata.dataOrigin?.packageName, FakeData.fakeDataOrigin);
       expect(record.value.inKilograms, closeTo(10.0, 0.0001));
       expect(record.foodName, 'Test Food');
       expect(record.mealType, MealType.breakfast);

--- a/packages/health_connector_hk_ios/test/unit_tests/src/mappers/health_record_mappers/nutrition/thiamin_nutrient_record_mapper_test.dart
+++ b/packages/health_connector_hk_ios/test/unit_tests/src/mappers/health_record_mappers/nutrition/thiamin_nutrient_record_mapper_test.dart
@@ -13,11 +13,11 @@ void main() {
         final record = ThiaminNutrientRecord(
           time: FakeData.fakeTime,
           zoneOffsetSeconds: FakeData.fakeTime.timeZoneOffset.inSeconds,
-          metadata: const Metadata(
-            dataOrigin: DataOrigin(FakeData.fakeDataOrigin),
+          metadata: Metadata.internal(
+            dataOrigin: const DataOrigin(FakeData.fakeDataOrigin),
             recordingMethod: RecordingMethod.manualEntry,
             clientRecordVersion: 1,
-            device: Device(type: DeviceType.phone),
+            device: const Device(type: DeviceType.phone),
           ),
           value: const Mass.grams(10),
           foodName: 'Test Food',
@@ -63,7 +63,10 @@ void main() {
           record.zoneOffsetSeconds,
           FakeData.fakeTime.timeZoneOffset.inSeconds,
         );
-        expect(record.metadata.dataOrigin.packageName, FakeData.fakeDataOrigin);
+        expect(
+          record.metadata.dataOrigin?.packageName,
+          FakeData.fakeDataOrigin,
+        );
         expect(record.value.inKilograms, closeTo(10.0, 0.0001));
         expect(record.foodName, 'Test Food');
         expect(record.mealType, MealType.breakfast);

--- a/packages/health_connector_hk_ios/test/unit_tests/src/mappers/health_record_mappers/nutrition/total_carbohydrate_nutrient_record_mapper_test.dart
+++ b/packages/health_connector_hk_ios/test/unit_tests/src/mappers/health_record_mappers/nutrition/total_carbohydrate_nutrient_record_mapper_test.dart
@@ -14,11 +14,11 @@ void main() {
         final record = TotalCarbohydrateNutrientRecord(
           time: FakeData.fakeTime,
           zoneOffsetSeconds: FakeData.fakeTime.timeZoneOffset.inSeconds,
-          metadata: const Metadata(
-            dataOrigin: DataOrigin(FakeData.fakeDataOrigin),
+          metadata: Metadata.internal(
+            dataOrigin: const DataOrigin(FakeData.fakeDataOrigin),
             recordingMethod: RecordingMethod.manualEntry,
             clientRecordVersion: 1,
-            device: Device(type: DeviceType.phone),
+            device: const Device(type: DeviceType.phone),
           ),
           value: const Mass.grams(10),
           foodName: 'Test Food',
@@ -65,7 +65,10 @@ void main() {
           record.zoneOffsetSeconds,
           FakeData.fakeTime.timeZoneOffset.inSeconds,
         );
-        expect(record.metadata.dataOrigin.packageName, FakeData.fakeDataOrigin);
+        expect(
+          record.metadata.dataOrigin?.packageName,
+          FakeData.fakeDataOrigin,
+        );
         expect(record.value.inKilograms, closeTo(10.0, 0.0001));
         expect(record.foodName, 'Test Food');
         expect(record.mealType, MealType.breakfast);

--- a/packages/health_connector_hk_ios/test/unit_tests/src/mappers/health_record_mappers/nutrition/total_fat_nutrient_record_mapper_test.dart
+++ b/packages/health_connector_hk_ios/test/unit_tests/src/mappers/health_record_mappers/nutrition/total_fat_nutrient_record_mapper_test.dart
@@ -13,11 +13,11 @@ void main() {
         final record = TotalFatNutrientRecord(
           time: FakeData.fakeTime,
           zoneOffsetSeconds: FakeData.fakeTime.timeZoneOffset.inSeconds,
-          metadata: const Metadata(
-            dataOrigin: DataOrigin(FakeData.fakeDataOrigin),
+          metadata: Metadata.internal(
+            dataOrigin: const DataOrigin(FakeData.fakeDataOrigin),
             recordingMethod: RecordingMethod.manualEntry,
             clientRecordVersion: 1,
-            device: Device(type: DeviceType.phone),
+            device: const Device(type: DeviceType.phone),
           ),
           value: const Mass.grams(10),
           foodName: 'Test Food',
@@ -63,7 +63,10 @@ void main() {
           record.zoneOffsetSeconds,
           FakeData.fakeTime.timeZoneOffset.inSeconds,
         );
-        expect(record.metadata.dataOrigin.packageName, FakeData.fakeDataOrigin);
+        expect(
+          record.metadata.dataOrigin?.packageName,
+          FakeData.fakeDataOrigin,
+        );
         expect(record.value.inKilograms, closeTo(10.0, 0.0001));
         expect(record.foodName, 'Test Food');
         expect(record.mealType, MealType.breakfast);

--- a/packages/health_connector_hk_ios/test/unit_tests/src/mappers/health_record_mappers/nutrition/vitamin_a_nutrient_record_mapper_test.dart
+++ b/packages/health_connector_hk_ios/test/unit_tests/src/mappers/health_record_mappers/nutrition/vitamin_a_nutrient_record_mapper_test.dart
@@ -13,11 +13,11 @@ void main() {
         final record = VitaminANutrientRecord(
           time: FakeData.fakeTime,
           zoneOffsetSeconds: FakeData.fakeTime.timeZoneOffset.inSeconds,
-          metadata: const Metadata(
-            dataOrigin: DataOrigin(FakeData.fakeDataOrigin),
+          metadata: Metadata.internal(
+            dataOrigin: const DataOrigin(FakeData.fakeDataOrigin),
             recordingMethod: RecordingMethod.manualEntry,
             clientRecordVersion: 1,
-            device: Device(type: DeviceType.phone),
+            device: const Device(type: DeviceType.phone),
           ),
           value: const Mass.grams(10),
           foodName: 'Test Food',
@@ -63,7 +63,10 @@ void main() {
           record.zoneOffsetSeconds,
           FakeData.fakeTime.timeZoneOffset.inSeconds,
         );
-        expect(record.metadata.dataOrigin.packageName, FakeData.fakeDataOrigin);
+        expect(
+          record.metadata.dataOrigin?.packageName,
+          FakeData.fakeDataOrigin,
+        );
         expect(record.value.inKilograms, closeTo(10.0, 0.0001));
         expect(record.foodName, 'Test Food');
         expect(record.mealType, MealType.breakfast);

--- a/packages/health_connector_hk_ios/test/unit_tests/src/mappers/health_record_mappers/nutrition/vitamin_b12_nutrient_record_mapper_test.dart
+++ b/packages/health_connector_hk_ios/test/unit_tests/src/mappers/health_record_mappers/nutrition/vitamin_b12_nutrient_record_mapper_test.dart
@@ -13,11 +13,11 @@ void main() {
         final record = VitaminB12NutrientRecord(
           time: FakeData.fakeTime,
           zoneOffsetSeconds: FakeData.fakeTime.timeZoneOffset.inSeconds,
-          metadata: const Metadata(
-            dataOrigin: DataOrigin(FakeData.fakeDataOrigin),
+          metadata: Metadata.internal(
+            dataOrigin: const DataOrigin(FakeData.fakeDataOrigin),
             recordingMethod: RecordingMethod.manualEntry,
             clientRecordVersion: 1,
-            device: Device(type: DeviceType.phone),
+            device: const Device(type: DeviceType.phone),
           ),
           value: const Mass.grams(10),
           foodName: 'Test Food',
@@ -64,7 +64,10 @@ void main() {
           record.zoneOffsetSeconds,
           FakeData.fakeTime.timeZoneOffset.inSeconds,
         );
-        expect(record.metadata.dataOrigin.packageName, FakeData.fakeDataOrigin);
+        expect(
+          record.metadata.dataOrigin?.packageName,
+          FakeData.fakeDataOrigin,
+        );
         expect(record.value.inKilograms, closeTo(10.0, 0.0001));
         expect(record.foodName, 'Test Food');
         expect(record.mealType, MealType.breakfast);

--- a/packages/health_connector_hk_ios/test/unit_tests/src/mappers/health_record_mappers/nutrition/vitamin_b6_nutrient_record_mapper_test.dart
+++ b/packages/health_connector_hk_ios/test/unit_tests/src/mappers/health_record_mappers/nutrition/vitamin_b6_nutrient_record_mapper_test.dart
@@ -13,11 +13,11 @@ void main() {
         final record = VitaminB6NutrientRecord(
           time: FakeData.fakeTime,
           zoneOffsetSeconds: FakeData.fakeTime.timeZoneOffset.inSeconds,
-          metadata: const Metadata(
-            dataOrigin: DataOrigin(FakeData.fakeDataOrigin),
+          metadata: Metadata.internal(
+            dataOrigin: const DataOrigin(FakeData.fakeDataOrigin),
             recordingMethod: RecordingMethod.manualEntry,
             clientRecordVersion: 1,
-            device: Device(type: DeviceType.phone),
+            device: const Device(type: DeviceType.phone),
           ),
           value: const Mass.grams(10),
           foodName: 'Test Food',
@@ -63,7 +63,10 @@ void main() {
           record.zoneOffsetSeconds,
           FakeData.fakeTime.timeZoneOffset.inSeconds,
         );
-        expect(record.metadata.dataOrigin.packageName, FakeData.fakeDataOrigin);
+        expect(
+          record.metadata.dataOrigin?.packageName,
+          FakeData.fakeDataOrigin,
+        );
         expect(record.value.inKilograms, closeTo(10.0, 0.0001));
         expect(record.foodName, 'Test Food');
         expect(record.mealType, MealType.breakfast);

--- a/packages/health_connector_hk_ios/test/unit_tests/src/mappers/health_record_mappers/nutrition/vitamin_c_nutrient_record_mapper_test.dart
+++ b/packages/health_connector_hk_ios/test/unit_tests/src/mappers/health_record_mappers/nutrition/vitamin_c_nutrient_record_mapper_test.dart
@@ -13,11 +13,11 @@ void main() {
         final record = VitaminCNutrientRecord(
           time: FakeData.fakeTime,
           zoneOffsetSeconds: FakeData.fakeTime.timeZoneOffset.inSeconds,
-          metadata: const Metadata(
-            dataOrigin: DataOrigin(FakeData.fakeDataOrigin),
+          metadata: Metadata.internal(
+            dataOrigin: const DataOrigin(FakeData.fakeDataOrigin),
             recordingMethod: RecordingMethod.manualEntry,
             clientRecordVersion: 1,
-            device: Device(type: DeviceType.phone),
+            device: const Device(type: DeviceType.phone),
           ),
           value: const Mass.grams(10),
           foodName: 'Test Food',
@@ -63,7 +63,10 @@ void main() {
           record.zoneOffsetSeconds,
           FakeData.fakeTime.timeZoneOffset.inSeconds,
         );
-        expect(record.metadata.dataOrigin.packageName, FakeData.fakeDataOrigin);
+        expect(
+          record.metadata.dataOrigin?.packageName,
+          FakeData.fakeDataOrigin,
+        );
         expect(record.value.inKilograms, closeTo(10.0, 0.0001));
         expect(record.foodName, 'Test Food');
         expect(record.mealType, MealType.breakfast);

--- a/packages/health_connector_hk_ios/test/unit_tests/src/mappers/health_record_mappers/nutrition/vitamin_d_nutrient_record_mapper_test.dart
+++ b/packages/health_connector_hk_ios/test/unit_tests/src/mappers/health_record_mappers/nutrition/vitamin_d_nutrient_record_mapper_test.dart
@@ -13,11 +13,11 @@ void main() {
         final record = VitaminDNutrientRecord(
           time: FakeData.fakeTime,
           zoneOffsetSeconds: FakeData.fakeTime.timeZoneOffset.inSeconds,
-          metadata: const Metadata(
-            dataOrigin: DataOrigin(FakeData.fakeDataOrigin),
+          metadata: Metadata.internal(
+            dataOrigin: const DataOrigin(FakeData.fakeDataOrigin),
             recordingMethod: RecordingMethod.manualEntry,
             clientRecordVersion: 1,
-            device: Device(type: DeviceType.phone),
+            device: const Device(type: DeviceType.phone),
           ),
           value: const Mass.grams(10),
           foodName: 'Test Food',
@@ -63,7 +63,10 @@ void main() {
           record.zoneOffsetSeconds,
           FakeData.fakeTime.timeZoneOffset.inSeconds,
         );
-        expect(record.metadata.dataOrigin.packageName, FakeData.fakeDataOrigin);
+        expect(
+          record.metadata.dataOrigin?.packageName,
+          FakeData.fakeDataOrigin,
+        );
         expect(record.value.inKilograms, closeTo(10.0, 0.0001));
         expect(record.foodName, 'Test Food');
         expect(record.mealType, MealType.breakfast);

--- a/packages/health_connector_hk_ios/test/unit_tests/src/mappers/health_record_mappers/nutrition/vitamin_e_nutrient_record_mapper_test.dart
+++ b/packages/health_connector_hk_ios/test/unit_tests/src/mappers/health_record_mappers/nutrition/vitamin_e_nutrient_record_mapper_test.dart
@@ -13,11 +13,11 @@ void main() {
         final record = VitaminENutrientRecord(
           time: FakeData.fakeTime,
           zoneOffsetSeconds: FakeData.fakeTime.timeZoneOffset.inSeconds,
-          metadata: const Metadata(
-            dataOrigin: DataOrigin(FakeData.fakeDataOrigin),
+          metadata: Metadata.internal(
+            dataOrigin: const DataOrigin(FakeData.fakeDataOrigin),
             recordingMethod: RecordingMethod.manualEntry,
             clientRecordVersion: 1,
-            device: Device(type: DeviceType.phone),
+            device: const Device(type: DeviceType.phone),
           ),
           value: const Mass.grams(10),
           foodName: 'Test Food',
@@ -62,7 +62,10 @@ void main() {
           record.zoneOffsetSeconds,
           FakeData.fakeTime.timeZoneOffset.inSeconds,
         );
-        expect(record.metadata.dataOrigin.packageName, FakeData.fakeDataOrigin);
+        expect(
+          record.metadata.dataOrigin?.packageName,
+          FakeData.fakeDataOrigin,
+        );
         expect(record.value.inKilograms, closeTo(10.0, 0.0001));
         expect(record.foodName, 'Test Food');
         expect(record.mealType, MealType.breakfast);

--- a/packages/health_connector_hk_ios/test/unit_tests/src/mappers/health_record_mappers/nutrition/vitamin_k_nutrient_record_mapper_test.dart
+++ b/packages/health_connector_hk_ios/test/unit_tests/src/mappers/health_record_mappers/nutrition/vitamin_k_nutrient_record_mapper_test.dart
@@ -13,11 +13,11 @@ void main() {
         final record = VitaminKNutrientRecord(
           time: FakeData.fakeTime,
           zoneOffsetSeconds: FakeData.fakeTime.timeZoneOffset.inSeconds,
-          metadata: const Metadata(
-            dataOrigin: DataOrigin(FakeData.fakeDataOrigin),
+          metadata: Metadata.internal(
+            dataOrigin: const DataOrigin(FakeData.fakeDataOrigin),
             recordingMethod: RecordingMethod.manualEntry,
             clientRecordVersion: 1,
-            device: Device(type: DeviceType.phone),
+            device: const Device(type: DeviceType.phone),
           ),
           value: const Mass.grams(10),
           foodName: 'Test Food',
@@ -63,7 +63,10 @@ void main() {
           record.zoneOffsetSeconds,
           FakeData.fakeTime.timeZoneOffset.inSeconds,
         );
-        expect(record.metadata.dataOrigin.packageName, FakeData.fakeDataOrigin);
+        expect(
+          record.metadata.dataOrigin?.packageName,
+          FakeData.fakeDataOrigin,
+        );
         expect(record.value.inKilograms, closeTo(10.0, 0.0001));
         expect(record.foodName, 'Test Food');
         expect(record.mealType, MealType.breakfast);

--- a/packages/health_connector_hk_ios/test/unit_tests/src/mappers/health_record_mappers/nutrition/zinc_nutrient_record_mapper_test.dart
+++ b/packages/health_connector_hk_ios/test/unit_tests/src/mappers/health_record_mappers/nutrition/zinc_nutrient_record_mapper_test.dart
@@ -11,11 +11,11 @@ void main() {
       final record = ZincNutrientRecord(
         time: FakeData.fakeTime,
         zoneOffsetSeconds: FakeData.fakeTime.timeZoneOffset.inSeconds,
-        metadata: const Metadata(
-          dataOrigin: DataOrigin(FakeData.fakeDataOrigin),
+        metadata: Metadata.internal(
+          dataOrigin: const DataOrigin(FakeData.fakeDataOrigin),
           recordingMethod: RecordingMethod.manualEntry,
           clientRecordVersion: 1,
-          device: Device(type: DeviceType.phone),
+          device: const Device(type: DeviceType.phone),
         ),
         value: const Mass.grams(10),
         foodName: 'Test Food',
@@ -53,7 +53,7 @@ void main() {
         record.zoneOffsetSeconds,
         FakeData.fakeTime.timeZoneOffset.inSeconds,
       );
-      expect(record.metadata.dataOrigin.packageName, FakeData.fakeDataOrigin);
+      expect(record.metadata.dataOrigin?.packageName, FakeData.fakeDataOrigin);
       expect(record.value.inKilograms, closeTo(10.0, 0.0001));
       expect(record.foodName, 'Test Food');
       expect(record.mealType, MealType.breakfast);

--- a/packages/health_connector_hk_ios/test/unit_tests/src/mappers/health_record_mappers/oxygen_saturation_record_mapper_test.dart
+++ b/packages/health_connector_hk_ios/test/unit_tests/src/mappers/health_record_mappers/oxygen_saturation_record_mapper_test.dart
@@ -21,8 +21,8 @@ void main() {
                 id: HealthRecordId(FakeData.fakeId),
                 time: time,
                 zoneOffsetSeconds: FakeData.fakeTime.timeZoneOffset.inSeconds,
-                metadata: const Metadata(
-                  dataOrigin: DataOrigin(FakeData.fakeDataOrigin),
+                metadata: Metadata.internal(
+                  dataOrigin: const DataOrigin(FakeData.fakeDataOrigin),
                   recordingMethod: RecordingMethod.activelyRecorded,
                   clientRecordVersion: 1,
                   device: Device(type: DeviceType.watch),
@@ -72,7 +72,7 @@ void main() {
               expect(record.time, time);
               expect(record.percentage.asDecimal, 97.0);
               expect(
-                record.metadata.dataOrigin.packageName,
+                record.metadata.dataOrigin?.packageName,
                 FakeData.fakeDataOrigin,
               );
             },

--- a/packages/health_connector_hk_ios/test/unit_tests/src/mappers/health_record_mappers/power/cycling_power_record_mapper_test.dart
+++ b/packages/health_connector_hk_ios/test/unit_tests/src/mappers/health_record_mappers/power/cycling_power_record_mapper_test.dart
@@ -21,11 +21,11 @@ void main() {
                 id: HealthRecordId(FakeData.fakeId),
                 time: time,
                 zoneOffsetSeconds: FakeData.fakeTime.timeZoneOffset.inSeconds,
-                metadata: const Metadata(
-                  dataOrigin: DataOrigin(FakeData.fakeDataOrigin),
+                metadata: Metadata.internal(
+                  dataOrigin: const DataOrigin(FakeData.fakeDataOrigin),
                   recordingMethod: RecordingMethod.manualEntry,
                   clientRecordVersion: 1,
-                  device: Device(type: DeviceType.phone),
+                  device: const Device(type: DeviceType.phone),
                 ),
                 power: const Power.watts(250.0),
               );
@@ -72,7 +72,7 @@ void main() {
               expect(record.time, time);
               expect(record.power.inWatts, 220.0);
               expect(
-                record.metadata.dataOrigin.packageName,
+                record.metadata.dataOrigin?.packageName,
                 FakeData.fakeDataOrigin,
               );
             },

--- a/packages/health_connector_hk_ios/test/unit_tests/src/mappers/health_record_mappers/respiratory_rate_record_mapper_test.dart
+++ b/packages/health_connector_hk_ios/test/unit_tests/src/mappers/health_record_mappers/respiratory_rate_record_mapper_test.dart
@@ -21,8 +21,8 @@ void main() {
                 id: HealthRecordId(FakeData.fakeId),
                 time: time,
                 zoneOffsetSeconds: FakeData.fakeTime.timeZoneOffset.inSeconds,
-                metadata: const Metadata(
-                  dataOrigin: DataOrigin(FakeData.fakeDataOrigin),
+                metadata: Metadata.internal(
+                  dataOrigin: const DataOrigin(FakeData.fakeDataOrigin),
                   recordingMethod: RecordingMethod.activelyRecorded,
                   clientRecordVersion: 1,
                   device: Device(type: DeviceType.watch),
@@ -72,7 +72,7 @@ void main() {
               expect(record.time, time);
               expect(record.breathsPerMin.inPerMinute, 14.0);
               expect(
-                record.metadata.dataOrigin.packageName,
+                record.metadata.dataOrigin?.packageName,
                 FakeData.fakeDataOrigin,
               );
             },

--- a/packages/health_connector_hk_ios/test/unit_tests/src/mappers/health_record_mappers/sexual_activity/sexual_activity_record_mapper_test.dart
+++ b/packages/health_connector_hk_ios/test/unit_tests/src/mappers/health_record_mappers/sexual_activity/sexual_activity_record_mapper_test.dart
@@ -21,11 +21,11 @@ void main() {
                 id: HealthRecordId(FakeData.fakeId),
                 time: time,
                 zoneOffsetSeconds: FakeData.fakeTime.timeZoneOffset.inSeconds,
-                metadata: const Metadata(
-                  dataOrigin: DataOrigin(FakeData.fakeDataOrigin),
+                metadata: Metadata.internal(
+                  dataOrigin: const DataOrigin(FakeData.fakeDataOrigin),
                   recordingMethod: RecordingMethod.manualEntry,
                   clientRecordVersion: 1,
-                  device: Device(type: DeviceType.phone),
+                  device: const Device(type: DeviceType.phone),
                 ),
                 protectionUsed: SexualActivityProtectionUsedType.protected,
               );
@@ -78,7 +78,7 @@ void main() {
                 SexualActivityProtectionUsedType.unprotected,
               );
               expect(
-                record.metadata.dataOrigin.packageName,
+                record.metadata.dataOrigin?.packageName,
                 FakeData.fakeDataOrigin,
               );
             },

--- a/packages/health_connector_hk_ios/test/unit_tests/src/mappers/health_record_mappers/sleep/sleep_stage_record_mapper_test.dart
+++ b/packages/health_connector_hk_ios/test/unit_tests/src/mappers/health_record_mappers/sleep/sleep_stage_record_mapper_test.dart
@@ -19,11 +19,11 @@ void main() {
                 id: HealthRecordId(FakeData.fakeId),
                 startTime: FakeData.fakeStartTime,
                 endTime: FakeData.fakeEndTime,
-                metadata: const Metadata(
-                  dataOrigin: DataOrigin(FakeData.fakeDataOrigin),
+                metadata: Metadata.internal(
+                  dataOrigin: const DataOrigin(FakeData.fakeDataOrigin),
                   recordingMethod: RecordingMethod.manualEntry,
                   clientRecordVersion: 1,
-                  device: Device(type: DeviceType.phone),
+                  device: const Device(type: DeviceType.phone),
                 ),
                 stageType: SleepStageType.deep,
               );
@@ -73,7 +73,7 @@ void main() {
               expect(record.endTime, FakeData.fakeEndTime);
               expect(record.stageType, SleepStageType.rem);
               expect(
-                record.metadata.dataOrigin.packageName,
+                record.metadata.dataOrigin?.packageName,
                 FakeData.fakeDataOrigin,
               );
             },

--- a/packages/health_connector_hk_ios/test/unit_tests/src/mappers/health_record_mappers/speed/running_speed_record_mapper_test.dart
+++ b/packages/health_connector_hk_ios/test/unit_tests/src/mappers/health_record_mappers/speed/running_speed_record_mapper_test.dart
@@ -22,8 +22,8 @@ void main() {
                 id: HealthRecordId(FakeData.fakeId),
                 time: time,
                 zoneOffsetSeconds: FakeData.fakeTime.timeZoneOffset.inSeconds,
-                metadata: const Metadata(
-                  dataOrigin: DataOrigin(FakeData.fakeDataOrigin),
+                metadata: Metadata.internal(
+                  dataOrigin: const DataOrigin(FakeData.fakeDataOrigin),
                   recordingMethod: RecordingMethod.activelyRecorded,
                   clientRecordVersion: 1,
                   device: Device(type: DeviceType.watch),
@@ -64,11 +64,11 @@ void main() {
                 id: HealthRecordId(FakeData.fakeId),
                 time: time,
                 zoneOffsetSeconds: FakeData.fakeTime.timeZoneOffset.inSeconds,
-                metadata: const Metadata(
-                  dataOrigin: DataOrigin(FakeData.fakeDataOrigin),
+                metadata: Metadata.internal(
+                  dataOrigin: const DataOrigin(FakeData.fakeDataOrigin),
                   recordingMethod: RecordingMethod.manualEntry,
                   clientRecordVersion: 2,
-                  device: Device(type: DeviceType.phone),
+                  device: const Device(type: DeviceType.phone),
                 ),
                 speed: const Velocity.metersPerSecond(5.2),
               );
@@ -125,7 +125,7 @@ void main() {
               );
               expect(record.speed.inMetersPerSecond, 4.2);
               expect(
-                record.metadata.dataOrigin.packageName,
+                record.metadata.dataOrigin?.packageName,
                 FakeData.fakeDataOrigin,
               );
               expect(

--- a/packages/health_connector_hk_ios/test/unit_tests/src/mappers/health_record_mappers/speed/speed_activity_record_mapper_test.dart
+++ b/packages/health_connector_hk_ios/test/unit_tests/src/mappers/health_record_mappers/speed/speed_activity_record_mapper_test.dart
@@ -20,8 +20,8 @@ void main() {
                 id: HealthRecordId(FakeData.fakeId),
                 time: FakeData.fakeTime,
                 zoneOffsetSeconds: FakeData.fakeTime.timeZoneOffset.inSeconds,
-                metadata: const Metadata(
-                  dataOrigin: DataOrigin(FakeData.fakeDataOrigin),
+                metadata: Metadata.internal(
+                  dataOrigin: const DataOrigin(FakeData.fakeDataOrigin),
                   recordingMethod: RecordingMethod.activelyRecorded,
                   clientRecordVersion: 1,
                   device: Device(type: DeviceType.watch),
@@ -46,8 +46,8 @@ void main() {
                 id: HealthRecordId(FakeData.fakeId),
                 time: FakeData.fakeTime,
                 zoneOffsetSeconds: FakeData.fakeTime.timeZoneOffset.inSeconds,
-                metadata: const Metadata(
-                  dataOrigin: DataOrigin(FakeData.fakeDataOrigin),
+                metadata: Metadata.internal(
+                  dataOrigin: const DataOrigin(FakeData.fakeDataOrigin),
                   recordingMethod: RecordingMethod.activelyRecorded,
                   clientRecordVersion: 1,
                   device: Device(type: DeviceType.watch),
@@ -72,8 +72,8 @@ void main() {
                 id: HealthRecordId(FakeData.fakeId),
                 time: FakeData.fakeTime,
                 zoneOffsetSeconds: FakeData.fakeTime.timeZoneOffset.inSeconds,
-                metadata: const Metadata(
-                  dataOrigin: DataOrigin(FakeData.fakeDataOrigin),
+                metadata: Metadata.internal(
+                  dataOrigin: const DataOrigin(FakeData.fakeDataOrigin),
                   recordingMethod: RecordingMethod.activelyRecorded,
                   clientRecordVersion: 1,
                   device: Device(type: DeviceType.watch),
@@ -98,8 +98,8 @@ void main() {
                 id: HealthRecordId(FakeData.fakeId),
                 time: FakeData.fakeTime,
                 zoneOffsetSeconds: FakeData.fakeTime.timeZoneOffset.inSeconds,
-                metadata: const Metadata(
-                  dataOrigin: DataOrigin(FakeData.fakeDataOrigin),
+                metadata: Metadata.internal(
+                  dataOrigin: const DataOrigin(FakeData.fakeDataOrigin),
                   recordingMethod: RecordingMethod.activelyRecorded,
                   clientRecordVersion: 1,
                   device: Device(type: DeviceType.watch),

--- a/packages/health_connector_hk_ios/test/unit_tests/src/mappers/health_record_mappers/speed/stair_ascent_speed_record_mapper_test.dart
+++ b/packages/health_connector_hk_ios/test/unit_tests/src/mappers/health_record_mappers/speed/stair_ascent_speed_record_mapper_test.dart
@@ -22,8 +22,8 @@ void main() {
                 id: HealthRecordId(FakeData.fakeId),
                 time: time,
                 zoneOffsetSeconds: FakeData.fakeTime.timeZoneOffset.inSeconds,
-                metadata: const Metadata(
-                  dataOrigin: DataOrigin(FakeData.fakeDataOrigin),
+                metadata: Metadata.internal(
+                  dataOrigin: const DataOrigin(FakeData.fakeDataOrigin),
                   recordingMethod: RecordingMethod.activelyRecorded,
                   clientRecordVersion: 1,
                   device: Device(type: DeviceType.watch),
@@ -64,11 +64,11 @@ void main() {
                 id: HealthRecordId(FakeData.fakeId),
                 time: time,
                 zoneOffsetSeconds: FakeData.fakeTime.timeZoneOffset.inSeconds,
-                metadata: const Metadata(
-                  dataOrigin: DataOrigin(FakeData.fakeDataOrigin),
+                metadata: Metadata.internal(
+                  dataOrigin: const DataOrigin(FakeData.fakeDataOrigin),
                   recordingMethod: RecordingMethod.manualEntry,
                   clientRecordVersion: 2,
-                  device: Device(type: DeviceType.phone),
+                  device: const Device(type: DeviceType.phone),
                 ),
                 speed: const Velocity.metersPerSecond(1.2),
               );
@@ -125,7 +125,7 @@ void main() {
               );
               expect(record.speed.inMetersPerSecond, 0.7);
               expect(
-                record.metadata.dataOrigin.packageName,
+                record.metadata.dataOrigin?.packageName,
                 FakeData.fakeDataOrigin,
               );
               expect(

--- a/packages/health_connector_hk_ios/test/unit_tests/src/mappers/health_record_mappers/speed/stair_descent_speed_record_mapper_test.dart
+++ b/packages/health_connector_hk_ios/test/unit_tests/src/mappers/health_record_mappers/speed/stair_descent_speed_record_mapper_test.dart
@@ -22,8 +22,8 @@ void main() {
                 id: HealthRecordId(FakeData.fakeId),
                 time: time,
                 zoneOffsetSeconds: FakeData.fakeTime.timeZoneOffset.inSeconds,
-                metadata: const Metadata(
-                  dataOrigin: DataOrigin(FakeData.fakeDataOrigin),
+                metadata: Metadata.internal(
+                  dataOrigin: const DataOrigin(FakeData.fakeDataOrigin),
                   recordingMethod: RecordingMethod.activelyRecorded,
                   clientRecordVersion: 1,
                   device: Device(type: DeviceType.watch),
@@ -64,11 +64,11 @@ void main() {
                 id: HealthRecordId(FakeData.fakeId),
                 time: time,
                 zoneOffsetSeconds: FakeData.fakeTime.timeZoneOffset.inSeconds,
-                metadata: const Metadata(
-                  dataOrigin: DataOrigin(FakeData.fakeDataOrigin),
+                metadata: Metadata.internal(
+                  dataOrigin: const DataOrigin(FakeData.fakeDataOrigin),
                   recordingMethod: RecordingMethod.manualEntry,
                   clientRecordVersion: 2,
-                  device: Device(type: DeviceType.phone),
+                  device: const Device(type: DeviceType.phone),
                 ),
                 speed: const Velocity.metersPerSecond(1.5),
               );
@@ -125,7 +125,7 @@ void main() {
               );
               expect(record.speed.inMetersPerSecond, 0.9);
               expect(
-                record.metadata.dataOrigin.packageName,
+                record.metadata.dataOrigin?.packageName,
                 FakeData.fakeDataOrigin,
               );
               expect(

--- a/packages/health_connector_hk_ios/test/unit_tests/src/mappers/health_record_mappers/speed/walking_speed_record_mapper_test.dart
+++ b/packages/health_connector_hk_ios/test/unit_tests/src/mappers/health_record_mappers/speed/walking_speed_record_mapper_test.dart
@@ -22,8 +22,8 @@ void main() {
                 id: HealthRecordId(FakeData.fakeId),
                 time: time,
                 zoneOffsetSeconds: FakeData.fakeTime.timeZoneOffset.inSeconds,
-                metadata: const Metadata(
-                  dataOrigin: DataOrigin(FakeData.fakeDataOrigin),
+                metadata: Metadata.internal(
+                  dataOrigin: const DataOrigin(FakeData.fakeDataOrigin),
                   recordingMethod: RecordingMethod.activelyRecorded,
                   clientRecordVersion: 1,
                   device: Device(type: DeviceType.watch),
@@ -64,11 +64,11 @@ void main() {
                 id: HealthRecordId(FakeData.fakeId),
                 time: time,
                 zoneOffsetSeconds: FakeData.fakeTime.timeZoneOffset.inSeconds,
-                metadata: const Metadata(
-                  dataOrigin: DataOrigin(FakeData.fakeDataOrigin),
+                metadata: Metadata.internal(
+                  dataOrigin: const DataOrigin(FakeData.fakeDataOrigin),
                   recordingMethod: RecordingMethod.manualEntry,
                   clientRecordVersion: 2,
-                  device: Device(type: DeviceType.phone),
+                  device: const Device(type: DeviceType.phone),
                 ),
                 speed: const Velocity.metersPerSecond(2.3),
               );
@@ -125,7 +125,7 @@ void main() {
               );
               expect(record.speed.inMetersPerSecond, 1.3);
               expect(
-                record.metadata.dataOrigin.packageName,
+                record.metadata.dataOrigin?.packageName,
                 FakeData.fakeDataOrigin,
               );
               expect(

--- a/packages/health_connector_hk_ios/test/unit_tests/src/mappers/health_record_mappers/steps_record_mapper_test.dart
+++ b/packages/health_connector_hk_ios/test/unit_tests/src/mappers/health_record_mappers/steps_record_mapper_test.dart
@@ -23,11 +23,11 @@ void main() {
                     FakeData.fakeStartTime.timeZoneOffset.inSeconds,
                 endZoneOffsetSeconds:
                     FakeData.fakeEndTime.timeZoneOffset.inSeconds,
-                metadata: const Metadata(
-                  dataOrigin: DataOrigin(FakeData.fakeDataOrigin),
+                metadata: Metadata.internal(
+                  dataOrigin: const DataOrigin(FakeData.fakeDataOrigin),
                   recordingMethod: RecordingMethod.activelyRecorded,
                   clientRecordVersion: 1,
-                  device: Device(type: DeviceType.phone),
+                  device: const Device(type: DeviceType.phone),
                 ),
                 count: const Number(12000),
               );
@@ -83,7 +83,7 @@ void main() {
               expect(record.endTime, FakeData.fakeEndTime);
               expect(record.count.value, 8500);
               expect(
-                record.metadata.dataOrigin.packageName,
+                record.metadata.dataOrigin?.packageName,
                 FakeData.fakeDataOrigin,
               );
             },

--- a/packages/health_connector_hk_ios/test/unit_tests/src/mappers/health_record_mappers/temperature/basal_body_temperature_record_mapper_test.dart
+++ b/packages/health_connector_hk_ios/test/unit_tests/src/mappers/health_record_mappers/temperature/basal_body_temperature_record_mapper_test.dart
@@ -22,11 +22,11 @@ void main() {
                 id: HealthRecordId(FakeData.fakeId),
                 time: time,
                 zoneOffsetSeconds: FakeData.fakeTime.timeZoneOffset.inSeconds,
-                metadata: const Metadata(
-                  dataOrigin: DataOrigin(FakeData.fakeDataOrigin),
+                metadata: Metadata.internal(
+                  dataOrigin: const DataOrigin(FakeData.fakeDataOrigin),
                   recordingMethod: RecordingMethod.manualEntry,
                   clientRecordVersion: 1,
-                  device: Device(type: DeviceType.phone),
+                  device: const Device(type: DeviceType.phone),
                 ),
                 temperature: const Temperature.celsius(36.5),
               );
@@ -76,7 +76,7 @@ void main() {
               expect(record.time, time);
               expect(record.temperature.inCelsius, 36.8);
               expect(
-                record.metadata.dataOrigin.packageName,
+                record.metadata.dataOrigin?.packageName,
                 FakeData.fakeDataOrigin,
               );
             },

--- a/packages/health_connector_hk_ios/test/unit_tests/src/mappers/health_record_mappers/temperature/body_temperature_record_mapper_test.dart
+++ b/packages/health_connector_hk_ios/test/unit_tests/src/mappers/health_record_mappers/temperature/body_temperature_record_mapper_test.dart
@@ -21,11 +21,11 @@ void main() {
                 id: HealthRecordId(FakeData.fakeId),
                 time: time,
                 zoneOffsetSeconds: FakeData.fakeTime.timeZoneOffset.inSeconds,
-                metadata: const Metadata(
-                  dataOrigin: DataOrigin(FakeData.fakeDataOrigin),
+                metadata: Metadata.internal(
+                  dataOrigin: const DataOrigin(FakeData.fakeDataOrigin),
                   recordingMethod: RecordingMethod.manualEntry,
                   clientRecordVersion: 1,
-                  device: Device(type: DeviceType.phone),
+                  device: const Device(type: DeviceType.phone),
                 ),
                 temperature: const Temperature.celsius(37.2),
               );
@@ -72,7 +72,7 @@ void main() {
               expect(record.time, time);
               expect(record.temperature.inCelsius, 36.8);
               expect(
-                record.metadata.dataOrigin.packageName,
+                record.metadata.dataOrigin?.packageName,
                 FakeData.fakeDataOrigin,
               );
             },

--- a/packages/health_connector_hk_ios/test/unit_tests/src/mappers/health_record_mappers/vo2_max_record_mapper_test.dart
+++ b/packages/health_connector_hk_ios/test/unit_tests/src/mappers/health_record_mappers/vo2_max_record_mapper_test.dart
@@ -21,8 +21,8 @@ void main() {
                 id: HealthRecordId(FakeData.fakeId),
                 time: time,
                 zoneOffsetSeconds: FakeData.fakeTime.timeZoneOffset.inSeconds,
-                metadata: const Metadata(
-                  dataOrigin: DataOrigin(FakeData.fakeDataOrigin),
+                metadata: Metadata.internal(
+                  dataOrigin: const DataOrigin(FakeData.fakeDataOrigin),
                   recordingMethod: RecordingMethod.activelyRecorded,
                   clientRecordVersion: 1,
                   device: Device(type: DeviceType.watch),
@@ -72,7 +72,7 @@ void main() {
               expect(record.time, time);
               expect(record.mLPerKgPerMin.value, 42.3);
               expect(
-                record.metadata.dataOrigin.packageName,
+                record.metadata.dataOrigin?.packageName,
                 FakeData.fakeDataOrigin,
               );
             },

--- a/packages/health_connector_hk_ios/test/unit_tests/src/mappers/health_record_mappers/waist_circumference_record_mapper_test.dart
+++ b/packages/health_connector_hk_ios/test/unit_tests/src/mappers/health_record_mappers/waist_circumference_record_mapper_test.dart
@@ -21,11 +21,11 @@ void main() {
                 id: HealthRecordId(FakeData.fakeId),
                 time: time,
                 zoneOffsetSeconds: FakeData.fakeTime.timeZoneOffset.inSeconds,
-                metadata: const Metadata(
-                  dataOrigin: DataOrigin(FakeData.fakeDataOrigin),
+                metadata: Metadata.internal(
+                  dataOrigin: const DataOrigin(FakeData.fakeDataOrigin),
                   recordingMethod: RecordingMethod.manualEntry,
                   clientRecordVersion: 1,
-                  device: Device(type: DeviceType.phone),
+                  device: const Device(type: DeviceType.phone),
                 ),
                 circumference: const Length.meters(0.85),
               );
@@ -72,7 +72,7 @@ void main() {
               expect(record.time, time);
               expect(record.circumference.inMeters, 0.90);
               expect(
-                record.metadata.dataOrigin.packageName,
+                record.metadata.dataOrigin?.packageName,
                 FakeData.fakeDataOrigin,
               );
             },

--- a/packages/health_connector_hk_ios/test/unit_tests/src/mappers/health_record_mappers/weight_record_mapper_test.dart
+++ b/packages/health_connector_hk_ios/test/unit_tests/src/mappers/health_record_mappers/weight_record_mapper_test.dart
@@ -21,8 +21,8 @@ void main() {
                 id: HealthRecordId(FakeData.fakeId),
                 time: time,
                 zoneOffsetSeconds: 3_600,
-                metadata: const Metadata(
-                  dataOrigin: DataOrigin(FakeData.fakeDataOrigin),
+                metadata: Metadata.internal(
+                  dataOrigin: const DataOrigin(FakeData.fakeDataOrigin),
                   recordingMethod: RecordingMethod.manualEntry,
                   clientRecordVersion: 1,
                   device: Device(type: DeviceType.scale),
@@ -69,7 +69,7 @@ void main() {
               expect(record.time, time);
               expect(record.weight.inKilograms, 68.2);
               expect(
-                record.metadata.dataOrigin.packageName,
+                record.metadata.dataOrigin?.packageName,
                 FakeData.fakeDataOrigin,
               );
             },

--- a/packages/health_connector_hk_ios/test/unit_tests/src/mappers/health_record_mappers/wheelchair_pushes_record_mapper_test.dart
+++ b/packages/health_connector_hk_ios/test/unit_tests/src/mappers/health_record_mappers/wheelchair_pushes_record_mapper_test.dart
@@ -23,8 +23,8 @@ void main() {
                     FakeData.fakeStartTime.timeZoneOffset.inSeconds,
                 endZoneOffsetSeconds:
                     FakeData.fakeEndTime.timeZoneOffset.inSeconds,
-                metadata: const Metadata(
-                  dataOrigin: DataOrigin(FakeData.fakeDataOrigin),
+                metadata: Metadata.internal(
+                  dataOrigin: const DataOrigin(FakeData.fakeDataOrigin),
                   recordingMethod: RecordingMethod.activelyRecorded,
                   clientRecordVersion: 1,
                   device: Device(type: DeviceType.watch),
@@ -83,7 +83,7 @@ void main() {
               expect(record.endTime, FakeData.fakeEndTime);
               expect(record.pushes.value, 35.0);
               expect(
-                record.metadata.dataOrigin.packageName,
+                record.metadata.dataOrigin?.packageName,
                 FakeData.fakeDataOrigin,
               );
             },

--- a/packages/health_connector_hk_ios/test/unit_tests/src/mappers/metadata_mappers/metadata_mapper_test.dart
+++ b/packages/health_connector_hk_ios/test/unit_tests/src/mappers/metadata_mappers/metadata_mapper_test.dart
@@ -17,7 +17,7 @@ void main() {
           test(
             'maps Metadata to MetadataDto with all fields populated',
             () {
-              const metadata = Metadata(
+              final metadata = Metadata.internal(
                 dataOrigin: DataOrigin(dataOriginName),
                 recordingMethod: RecordingMethod.activelyRecorded,
                 clientRecordId: clientRecordId,
@@ -59,7 +59,7 @@ void main() {
           test(
             'maps Metadata to MetadataDto with minimal fields',
             () {
-              const metadata = Metadata(
+              final metadata = Metadata.internal(
                 dataOrigin: DataOrigin(dataOriginName),
                 recordingMethod: RecordingMethod.unknown,
                 clientRecordVersion: 0,
@@ -102,7 +102,7 @@ void main() {
 
               final metadata = dto.toDomain();
 
-              expect(metadata.dataOrigin.packageName, dataOriginName);
+              expect(metadata.dataOrigin?.packageName, dataOriginName);
               expect(metadata.recordingMethod, RecordingMethod.manualEntry);
               expect(metadata.clientRecordId, clientRecordId);
               expect(metadata.clientRecordVersion, clientRecordVersion);
@@ -130,7 +130,7 @@ void main() {
 
               final metadata = dto.toDomain();
 
-              expect(metadata.dataOrigin.packageName, dataOriginName);
+              expect(metadata.dataOrigin?.packageName, dataOriginName);
               expect(metadata.recordingMethod, RecordingMethod.unknown);
               expect(metadata.clientRecordId, null);
               expect(metadata.clientRecordVersion, 0);


### PR DESCRIPTION
### **User description**
Health platforms automatically assign data origin based on calling app identity - manual specification was ignored. `Metadata.dataOrigin` property is now read-only and only appears on retrieved records.

BREAKING CHANGE: `dataOrigin` parameter removed from all `Metadata` public constructors and `copyWith` methods.

Closes #77 


___

### **PR Type**
Bug fix, Tests


___

### **Description**
- Removed non-functional `dataOrigin` parameter from all public `Metadata` constructors and `copyWith()` methods since health platforms automatically assign data origin based on calling app identity

- Made the primary `Metadata` constructor private and added new `Metadata.internal()` factory for platform implementations to set `dataOrigin`

- Changed `dataOrigin` field from required to nullable (`DataOrigin?`) and made it read-only on public API

- Updated 60+ test files across health connector packages to use the new `Metadata.internal()` factory and handle nullable `dataOrigin` with optional chaining

- Updated documentation examples and example application code to remove manual `dataOrigin` specification

- Added comprehensive unit tests for `Metadata` class covering all factory constructors and `copyWith()` behavior


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Public Metadata<br/>Constructors"] -->|"Remove dataOrigin<br/>parameter"| B["Simplified<br/>Public API"]
  C["Metadata.internal()<br/>Factory"] -->|"Set dataOrigin<br/>for platform use"| D["Platform<br/>Implementations"]
  E["dataOrigin Field"] -->|"Make nullable<br/>and read-only"| F["Retrieved Records<br/>Only"]
  B --> G["Updated Tests<br/>& Examples"]
  D --> G
  F --> G
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Breaking change</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td>
    <details>
      <summary><strong>metadata.dart</strong><dd><code>Remove dataOrigin from public Metadata constructors</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/health_connector_core/lib/src/models/metadata/metadata.dart

<ul><li>Made the primary constructor private (<code>Metadata._</code>) and removed required <br><code>dataOrigin</code> parameter<br> <li> Added new <code>Metadata.internal()</code> factory for platform implementations to <br>set <code>dataOrigin</code><br> <li> Changed <code>dataOrigin</code> field from required to nullable (<code>DataOrigin?</code>)<br> <li> Removed <code>dataOrigin</code> parameter from public factory constructors <br>(<code>manualEntry</code>, <code>automaticallyRecorded</code>, <code>activelyRecorded</code>, <br><code>unknownRecordingMethod</code>)<br> <li> Updated <code>copyWith()</code> method to remove <code>dataOrigin</code> parameter and preserve <br>existing value<br> <li> Added <code>@internalUse</code> annotation to <code>Metadata.internal()</code> factory</ul>


</details>


  </td>
  <td><a href="https://github.com/fam-tung-lam/health_connector/pull/94/files#diff-fcc5a23fb16de03644140316c427620960398065c71e0e31465347a694ebac2a">+49/-26</a>&nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Tests</strong></td><td><details><summary>53 files</summary><table>
<tr>
  <td>
    <details>
      <summary><strong>metadata_test.dart</strong><dd><code>Add comprehensive Metadata unit tests</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/health_connector_core/test/src/models/metadata/metadata_test.dart

<ul><li>New comprehensive test file for <code>Metadata</code> class<br> <li> Tests for <code>internal()</code> factory with all fields and nullable fields<br> <li> Tests for all public factory constructors (<code>manualEntry</code>, <br><code>automaticallyRecorded</code>, <code>activelyRecorded</code>, <code>unknownRecordingMethod</code>)<br> <li> Tests for <code>copyWith()</code> method behavior and field preservation<br> <li> Tests for equality and hash code implementation</ul>


</details>


  </td>
  <td><a href="https://github.com/fam-tung-lam/health_connector/pull/94/files#diff-56c6766b6dcf7e6f0a5bcb82ae49678b7df977ba7a7e0e4e45523169245140c4">+176/-0</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>health_connector_impl_test.dart</strong><dd><code>Update health connector tests to remove dataOrigin</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/health_connector/test/unit_tests/src/health_connector_impl_test.dart

<ul><li>Removed <code>dataOrigin</code> parameter from all <code>Metadata.manualEntry()</code> calls (16 <br>occurrences)<br> <li> Simplified metadata instantiation by removing the <code>DataOrigin</code> wrapping</ul>


</details>


  </td>
  <td><a href="https://github.com/fam-tung-lam/health_connector/pull/94/files#diff-da8c12d3ebb1e3397fb5c3893546ffdcccd84e251a1e00024bf04f18d3130864">+19/-57</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>distance_activity_record_mapper_test.dart</strong><dd><code>Update distance activity mapper tests to use internal factory</code></dd></summary>
<hr>

packages/health_connector_hk_ios/test/unit_tests/src/mappers/health_record_mappers/distance/distance_activity_record_mapper_test.dart

<ul><li>Changed <code>Metadata()</code> constructor calls to <code>Metadata.internal()</code> factory<br> <li> Removed <code>dataOrigin</code> parameter from constructor calls<br> <li> Added <code>const</code> keyword to <code>DataOrigin</code> instantiation</ul>


</details>


  </td>
  <td><a href="https://github.com/fam-tung-lam/health_connector/pull/94/files#diff-d40e2d9d9c8286b093fcc07af6294c45eeff2636fdbd2f73ba69aa3639d7cc4e">+21/-21</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>health_record_mapper_test.dart</strong><dd><code>Update health record mapper tests to use internal factory</code></dd></summary>
<hr>

packages/health_connector_hk_ios/test/unit_tests/src/mappers/health_record_mappers/health_record_mapper_test.dart

<ul><li>Changed <code>Metadata()</code> constructor calls to <code>Metadata.internal()</code> factory<br> <li> Removed <code>dataOrigin</code> parameter from constructor calls<br> <li> Added <code>const</code> keyword to <code>Device</code> and <code>DataOrigin</code> instantiations</ul>


</details>


  </td>
  <td><a href="https://github.com/fam-tung-lam/health_connector/pull/94/files#diff-080711a06c1aa7459eb093cd21f9698de55d730eb24b980b09847c2c6ca3b8c7">+17/-17</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>health_connector_hk_client_test.dart</strong><dd><code>Update iOS health connector tests to remove dataOrigin</code>&nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/health_connector_hk_ios/test/unit_tests/src/health_connector_hk_client_test.dart

<ul><li>Removed <code>dataOrigin</code> parameter from all <code>Metadata.manualEntry()</code> calls (8 <br>occurrences)<br> <li> Simplified metadata instantiation across multiple test cases</ul>


</details>


  </td>
  <td><a href="https://github.com/fam-tung-lam/health_connector/pull/94/files#diff-60fb42c57f51ecd7682eb7685778bd4b30a9b136eeefd543431844a2bb409eaf">+7/-21</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>health_connector_hc_client_test.dart</strong><dd><code>Update Android health connector tests to remove dataOrigin</code></dd></summary>
<hr>

packages/health_connector_hc_android/test/unit_tests/src/health_connector_hc_client_test.dart

<ul><li>Removed <code>dataOrigin</code> parameter from all <code>Metadata.manualEntry()</code> calls (8 <br>occurrences)<br> <li> Simplified metadata instantiation across multiple test cases</ul>


</details>


  </td>
  <td><a href="https://github.com/fam-tung-lam/health_connector/pull/94/files#diff-e7506b9720b349586199850fae3a6e6d5009c698d23426a102f11df068489397">+7/-21</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>speed_activity_record_mapper_test.dart</strong><dd><code>Update speed activity mapper tests to use internal factory</code></dd></summary>
<hr>

packages/health_connector_hk_ios/test/unit_tests/src/mappers/health_record_mappers/speed/speed_activity_record_mapper_test.dart

<ul><li>Changed <code>Metadata()</code> constructor calls to <code>Metadata.internal()</code> factory<br> <li> Removed <code>dataOrigin</code> parameter from constructor calls<br> <li> Added <code>const</code> keyword to <code>DataOrigin</code> instantiation</ul>


</details>


  </td>
  <td><a href="https://github.com/fam-tung-lam/health_connector/pull/94/files#diff-d01463c3488a3eefeb9c978066b5dd3bc88358d1d189568c458de1d696c7cce7">+8/-8</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>health_record_mapper_test.dart</strong><dd><code>Update Android health record mapper tests to remove dataOrigin</code></dd></summary>
<hr>

packages/health_connector_hc_android/test/unit_tests/src/mappers/health_record_mappers/health_record_mapper_test.dart

<ul><li>Removed <code>dataOrigin</code> parameter from all <code>Metadata.manualEntry()</code> calls (5 <br>occurrences)<br> <li> Simplified metadata instantiation in test cases</ul>


</details>


  </td>
  <td><a href="https://github.com/fam-tung-lam/health_connector/pull/94/files#diff-62ceb55315edd2b6ad433eff8cdc30d149b779f20342ed281511e558974b909a">+5/-15</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>vo2_max_record_mapper_test.dart</strong><dd><code>Update VO2 max mapper tests for nullable dataOrigin</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/health_connector_hc_android/test/unit_tests/src/mappers/health_record_mappers/vo2_max_record_mapper_test.dart

<ul><li>Removed <code>dataOrigin</code> parameter from <code>Metadata.manualEntry()</code> call<br> <li> Updated assertions to use optional chaining (<code>?.</code>) for nullable <br><code>dataOrigin</code> field<br> <li> Changed expectation from <code>isEmpty</code> to checking nullable property</ul>


</details>


  </td>
  <td><a href="https://github.com/fam-tung-lam/health_connector/pull/94/files#diff-f958d2a32aaa2376aa18ae364fdfc28471d53beed9716b997b3878c1f844e6c6">+4/-8</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>cross_country_skiing_distance_record_mapper_test.dart</strong><dd><code>Update cross country skiing mapper tests for internal factory</code></dd></summary>
<hr>

packages/health_connector_hk_ios/test/unit_tests/src/mappers/health_record_mappers/distance/cross_country_skiing_distance_record_mapper_test.dart

<ul><li>Changed <code>Metadata()</code> constructor calls to <code>Metadata.internal()</code> factory<br> <li> Removed <code>dataOrigin</code> parameter from constructor calls<br> <li> Updated assertions to use optional chaining (<code>?.</code>) for nullable <br><code>dataOrigin</code> field</ul>


</details>


  </td>
  <td><a href="https://github.com/fam-tung-lam/health_connector/pull/94/files#diff-deafddce38dd7c2be8076888667f31e14aea6bebf31585494edcab283ff7f6c2">+6/-6</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>downhill_snow_sports_distance_record_mapper_test.dart</strong><dd><code>Update downhill snow sports mapper tests for internal factory</code></dd></summary>
<hr>

packages/health_connector_hk_ios/test/unit_tests/src/mappers/health_record_mappers/distance/downhill_snow_sports_distance_record_mapper_test.dart

<ul><li>Changed <code>Metadata()</code> constructor calls to <code>Metadata.internal()</code> factory<br> <li> Removed <code>dataOrigin</code> parameter from constructor calls<br> <li> Updated assertions to use optional chaining (<code>?.</code>) for nullable <br><code>dataOrigin</code> field</ul>


</details>


  </td>
  <td><a href="https://github.com/fam-tung-lam/health_connector/pull/94/files#diff-0d9244f30cb7c7d74baf7d90ba3df7df4c1638fc0813caa4d21d5ea970a314cf">+6/-6</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>paddle_sports_distance_record_mapper_test.dart</strong><dd><code>Update paddle sports mapper tests for internal factory</code>&nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/health_connector_hk_ios/test/unit_tests/src/mappers/health_record_mappers/distance/paddle_sports_distance_record_mapper_test.dart

<ul><li>Changed <code>Metadata()</code> constructor calls to <code>Metadata.internal()</code> factory<br> <li> Removed <code>dataOrigin</code> parameter from constructor calls<br> <li> Updated assertions to use optional chaining (<code>?.</code>) for nullable <br><code>dataOrigin</code> field</ul>


</details>


  </td>
  <td><a href="https://github.com/fam-tung-lam/health_connector/pull/94/files#diff-b1e23c2f8501f5881ead060063a264bdbe417ae72b5e95b8c90a4c59570aeae4">+6/-6</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>six_minute_walk_test_distance_record_mapper_test.dart</strong><dd><code>Update six minute walk test mapper tests for internal factory</code></dd></summary>
<hr>

packages/health_connector_hk_ios/test/unit_tests/src/mappers/health_record_mappers/distance/six_minute_walk_test_distance_record_mapper_test.dart

<ul><li>Changed <code>Metadata()</code> constructor calls to <code>Metadata.internal()</code> factory<br> <li> Removed <code>dataOrigin</code> parameter from constructor calls<br> <li> Updated assertions to use optional chaining (<code>?.</code>) for nullable <br><code>dataOrigin</code> field</ul>


</details>


  </td>
  <td><a href="https://github.com/fam-tung-lam/health_connector/pull/94/files#diff-9bfb94b87024151cbc42ef0ce3e9812c1b7beac6e8985a47ee6f8309fda4326d">+6/-6</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>skating_sports_distance_record_mapper_test.dart</strong><dd><code>Update skating sports mapper tests for internal factory</code>&nbsp; &nbsp; </dd></summary>
<hr>

packages/health_connector_hk_ios/test/unit_tests/src/mappers/health_record_mappers/distance/skating_sports_distance_record_mapper_test.dart

<ul><li>Changed <code>Metadata()</code> constructor calls to <code>Metadata.internal()</code> factory<br> <li> Removed <code>dataOrigin</code> parameter from constructor calls<br> <li> Updated assertions to use optional chaining (<code>?.</code>) for nullable <br><code>dataOrigin</code> field</ul>


</details>


  </td>
  <td><a href="https://github.com/fam-tung-lam/health_connector/pull/94/files#diff-0a6a0ee2a3de8236dae6a4c1ba5d3c38a8c2e4966f5181d324bea8c3e0c41d12">+6/-6</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>walking_running_distance_record_mapper_test.dart</strong><dd><code>Update walking running mapper tests for internal factory</code>&nbsp; </dd></summary>
<hr>

packages/health_connector_hk_ios/test/unit_tests/src/mappers/health_record_mappers/distance/walking_running_distance_record_mapper_test.dart

<ul><li>Changed <code>Metadata()</code> constructor calls to <code>Metadata.internal()</code> factory<br> <li> Removed <code>dataOrigin</code> parameter from constructor calls<br> <li> Updated assertions to use optional chaining (<code>?.</code>) for nullable <br><code>dataOrigin</code> field</ul>


</details>


  </td>
  <td><a href="https://github.com/fam-tung-lam/health_connector/pull/94/files#diff-efdfabecccec971b2d32a3f86b48db1f192d496492ea933341f5a9c4b673579b">+6/-6</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>wheelchair_distance_record_mapper_test.dart</strong><dd><code>Update wheelchair distance mapper tests for internal factory</code></dd></summary>
<hr>

packages/health_connector_hk_ios/test/unit_tests/src/mappers/health_record_mappers/distance/wheelchair_distance_record_mapper_test.dart

<ul><li>Changed <code>Metadata()</code> constructor calls to <code>Metadata.internal()</code> factory<br> <li> Removed <code>dataOrigin</code> parameter from constructor calls<br> <li> Updated assertions to use optional chaining (<code>?.</code>) for nullable <br><code>dataOrigin</code> field</ul>


</details>


  </td>
  <td><a href="https://github.com/fam-tung-lam/health_connector/pull/94/files#diff-98e36f9bd291024afee20cea06d8820d5a0693e6d869b0e059a397e81f93f74b">+6/-6</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>rowing_distance_record_mapper_test.dart</strong><dd><code>Update rowing distance mapper tests for internal factory</code>&nbsp; </dd></summary>
<hr>

packages/health_connector_hk_ios/test/unit_tests/src/mappers/health_record_mappers/distance/rowing_distance_record_mapper_test.dart

<ul><li>Changed <code>Metadata()</code> constructor calls to <code>Metadata.internal()</code> factory<br> <li> Removed <code>dataOrigin</code> parameter from constructor calls<br> <li> Updated assertions to use optional chaining (<code>?.</code>) for nullable <br><code>dataOrigin</code> field</ul>


</details>


  </td>
  <td><a href="https://github.com/fam-tung-lam/health_connector/pull/94/files#diff-774d6c9ef1f20284f74174ebf7c7717cc7ff2cde1fa9c57de91fd674bc4a7e4d">+6/-6</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>stair_ascent_speed_record_mapper_test.dart</strong><dd><code>Update stair ascent speed mapper tests for internal factory</code></dd></summary>
<hr>

packages/health_connector_hk_ios/test/unit_tests/src/mappers/health_record_mappers/speed/stair_ascent_speed_record_mapper_test.dart

<ul><li>Changed <code>Metadata()</code> constructor calls to <code>Metadata.internal()</code> factory<br> <li> Removed <code>dataOrigin</code> parameter from constructor calls<br> <li> Updated assertions to use optional chaining (<code>?.</code>) for nullable <br><code>dataOrigin</code> field</ul>


</details>


  </td>
  <td><a href="https://github.com/fam-tung-lam/health_connector/pull/94/files#diff-1299515658b34508d9c923c3e9e62732037e5a673aa6ef362f60f2cf82c6c7fc">+6/-6</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>stair_descent_speed_record_mapper_test.dart</strong><dd><code>Update stair descent speed mapper tests for internal factory</code></dd></summary>
<hr>

packages/health_connector_hk_ios/test/unit_tests/src/mappers/health_record_mappers/speed/stair_descent_speed_record_mapper_test.dart

<ul><li>Changed <code>Metadata()</code> constructor calls to <code>Metadata.internal()</code> factory<br> <li> Removed <code>dataOrigin</code> parameter from constructor calls<br> <li> Updated assertions to use optional chaining (<code>?.</code>) for nullable <br><code>dataOrigin</code> field</ul>


</details>


  </td>
  <td><a href="https://github.com/fam-tung-lam/health_connector/pull/94/files#diff-3f513fa678a33b1a9397495541dafec4083b2cadae2f9ba38450cf3335cb841c">+6/-6</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>running_speed_record_mapper_test.dart</strong><dd><code>Update running speed mapper tests for internal factory</code>&nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/health_connector_hk_ios/test/unit_tests/src/mappers/health_record_mappers/speed/running_speed_record_mapper_test.dart

<ul><li>Changed <code>Metadata()</code> constructor calls to <code>Metadata.internal()</code> factory<br> <li> Removed <code>dataOrigin</code> parameter from constructor calls<br> <li> Updated assertions to use optional chaining (<code>?.</code>) for nullable <br><code>dataOrigin</code> field</ul>


</details>


  </td>
  <td><a href="https://github.com/fam-tung-lam/health_connector/pull/94/files#diff-4386b372b841a3d5ace7253cf74aa82a405a465543451d88ef627a651e3c1eb1">+6/-6</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>walking_speed_record_mapper_test.dart</strong><dd><code>Update walking speed mapper tests for internal factory</code>&nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/health_connector_hk_ios/test/unit_tests/src/mappers/health_record_mappers/speed/walking_speed_record_mapper_test.dart

<ul><li>Changed <code>Metadata()</code> constructor calls to <code>Metadata.internal()</code> factory<br> <li> Removed <code>dataOrigin</code> parameter from constructor calls<br> <li> Updated assertions to use optional chaining (<code>?.</code>) for nullable <br><code>dataOrigin</code> field</ul>


</details>


  </td>
  <td><a href="https://github.com/fam-tung-lam/health_connector/pull/94/files#diff-78802662d27effafd50f37543ae6616923567f5d9dbe841fc988a90765390a77">+6/-6</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>cycling_distance_record_mapper_test.dart</strong><dd><code>Update cycling distance mapper tests for internal factory</code></dd></summary>
<hr>

packages/health_connector_hk_ios/test/unit_tests/src/mappers/health_record_mappers/distance/cycling_distance_record_mapper_test.dart

<ul><li>Changed <code>Metadata()</code> constructor calls to <code>Metadata.internal()</code> factory<br> <li> Removed <code>dataOrigin</code> parameter from constructor calls<br> <li> Updated assertions to use optional chaining (<code>?.</code>) for nullable <br><code>dataOrigin</code> field</ul>


</details>


  </td>
  <td><a href="https://github.com/fam-tung-lam/health_connector/pull/94/files#diff-d361d525fbf9a2f80529518b4c343ac5943069b8b8e701bffee33c30118581f8">+6/-6</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>swimming_distance_record_mapper_test.dart</strong><dd><code>Update swimming distance mapper tests for internal factory</code></dd></summary>
<hr>

packages/health_connector_hk_ios/test/unit_tests/src/mappers/health_record_mappers/distance/swimming_distance_record_mapper_test.dart

<ul><li>Changed <code>Metadata()</code> constructor calls to <code>Metadata.internal()</code> factory<br> <li> Removed <code>dataOrigin</code> parameter from constructor calls<br> <li> Updated assertions to use optional chaining (<code>?.</code>) for nullable <br><code>dataOrigin</code> field</ul>


</details>


  </td>
  <td><a href="https://github.com/fam-tung-lam/health_connector/pull/94/files#diff-3d72e58dd95416c832b6df6eb05302c1c1d0a147c4ba1e3cb5469944194394b0">+6/-6</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>metadata_mapper_test.dart</strong><dd><code>Update metadata mapper tests for internal factory</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/health_connector_hk_ios/test/unit_tests/src/mappers/metadata_mappers/metadata_mapper_test.dart

<ul><li>Changed <code>Metadata()</code> constructor calls to <code>Metadata.internal()</code> factory<br> <li> Removed <code>dataOrigin</code> parameter from constructor calls<br> <li> Updated assertions to use optional chaining (<code>?.</code>) for nullable <br><code>dataOrigin</code> field</ul>


</details>


  </td>
  <td><a href="https://github.com/fam-tung-lam/health_connector/pull/94/files#diff-e72b25c1da9747ae1ad88be2dc14a2d711a0a1817f9009c0750cde35c1b822f0">+4/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>metadata_mapper_test.dart</strong><dd><code>Update Android metadata mapper tests for internal factory</code></dd></summary>
<hr>

packages/health_connector_hc_android/test/unit_tests/src/mappers/metadata_mappers/metadata_mapper_test.dart

<ul><li>Changed <code>Metadata()</code> constructor calls to <code>Metadata.internal()</code> factory<br> <li> Removed <code>dataOrigin</code> parameter from constructor calls<br> <li> Updated assertions to use optional chaining (<code>?.</code>) for nullable <br><code>dataOrigin</code> field</ul>


</details>


  </td>
  <td><a href="https://github.com/fam-tung-lam/health_connector/pull/94/files#diff-c8436de2c77200eeddb20a45cb04c7775167431adc502284ba9f93bab0c6b96d">+4/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>pantothenic_acid_nutrient_record_mapper_test.dart</strong><dd><code>Update pantothenic acid nutrient mapper tests for internal factory</code></dd></summary>
<hr>

packages/health_connector_hk_ios/test/unit_tests/src/mappers/health_record_mappers/nutrition/pantothenic_acid_nutrient_record_mapper_test.dart

<ul><li>Changed <code>Metadata()</code> constructor calls to <code>Metadata.internal()</code> factory<br> <li> Removed <code>dataOrigin</code> parameter from constructor calls<br> <li> Updated assertions to use optional chaining (<code>?.</code>) for nullable <br><code>dataOrigin</code> field</ul>


</details>


  </td>
  <td><a href="https://github.com/fam-tung-lam/health_connector/pull/94/files#diff-5286d65e8befba6255eecf3dd28835514b31fa95a894b71aed7800a76805ace4">+7/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>body_fat_percentage_record_mapper_test.dart</strong><dd><code>Update Metadata constructor calls to internal factory</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/health_connector_hc_android/test/unit_tests/src/mappers/health_record_mappers/body_fat_percentage_record_mapper_test.dart

<ul><li>Changed <code>Metadata</code> constructor from <code>const Metadata(...)</code> to <br><code>Metadata.internal(...)</code><br> <li> Added <code>const</code> keyword to <code>DataOrigin</code> and <code>Device</code> instantiations<br> <li> Updated <code>dataOrigin</code> property access to use null-safe operator <br><code>?.packageName</code></ul>


</details>


  </td>
  <td><a href="https://github.com/fam-tung-lam/health_connector/pull/94/files#diff-0a31aa29bef16dc2ff91f5183f3369993e80a37e41542149b49627d2dfac3cd1">+4/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>body_water_mass_record_mapper_test.dart</strong><dd><code>Update Metadata constructor calls to internal factory</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/health_connector_hc_android/test/unit_tests/src/mappers/health_record_mappers/body_water_mass_record_mapper_test.dart

<ul><li>Changed <code>Metadata</code> constructor from <code>const Metadata(...)</code> to <br><code>Metadata.internal(...)</code><br> <li> Added <code>const</code> keyword to <code>DataOrigin</code> and <code>Device</code> instantiations<br> <li> Updated <code>dataOrigin</code> property access to use null-safe operator <br><code>?.packageName</code></ul>


</details>


  </td>
  <td><a href="https://github.com/fam-tung-lam/health_connector/pull/94/files#diff-804dd68191ff36d6e9db0ef1b9a8927b684494f6df9a5d0b85887d028ea5fdc3">+4/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>bone_mass_record_mapper_test.dart</strong><dd><code>Update Metadata constructor calls to internal factory</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/health_connector_hc_android/test/unit_tests/src/mappers/health_record_mappers/bone_mass_record_mapper_test.dart

<ul><li>Changed <code>Metadata</code> constructor from <code>const Metadata(...)</code> to <br><code>Metadata.internal(...)</code><br> <li> Added <code>const</code> keyword to <code>DataOrigin</code> and <code>Device</code> instantiations<br> <li> Updated <code>dataOrigin</code> property access to use null-safe operator <br><code>?.packageName</code></ul>


</details>


  </td>
  <td><a href="https://github.com/fam-tung-lam/health_connector/pull/94/files#diff-02d624256131b162e4c5f7fa1c861960b07dc5a01e18700f5f3b55a93a67945d">+4/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>body_temperature_record_mapper_test.dart</strong><dd><code>Update Metadata constructor calls to internal factory</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/health_connector_hc_android/test/unit_tests/src/mappers/health_record_mappers/temperature/body_temperature_record_mapper_test.dart

<ul><li>Changed <code>Metadata</code> constructor from <code>const Metadata(...)</code> to <br><code>Metadata.internal(...)</code><br> <li> Added <code>const</code> keyword to <code>DataOrigin</code> and <code>Device</code> instantiations<br> <li> Updated <code>dataOrigin</code> property access to use null-safe operator <br><code>?.packageName</code></ul>


</details>


  </td>
  <td><a href="https://github.com/fam-tung-lam/health_connector/pull/94/files#diff-0c98c70a4b44c03ee59b56380d4e80767c556d8c1e6f938d657653de9f3be688">+4/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>menstrual_flow_record_mapper_test.dart</strong><dd><code>Update Metadata constructor calls to internal factory</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/health_connector_hk_ios/test/unit_tests/src/mappers/health_record_mappers/menstruation/menstrual_flow_record_mapper_test.dart

<ul><li>Changed <code>Metadata</code> constructor from <code>const Metadata(...)</code> to <br><code>Metadata.internal(...)</code><br> <li> Added <code>const</code> keyword to <code>DataOrigin</code> and <code>Device</code> instantiations<br> <li> Updated <code>dataOrigin</code> property access to use null-safe operator <br><code>?.packageName</code></ul>


</details>


  </td>
  <td><a href="https://github.com/fam-tung-lam/health_connector/pull/94/files#diff-ad287bd930118369575fee9686b5f79d9237090a2ec8dc6c8789554a75d76794">+4/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>mindfulness_session_record_mapper_test.dart</strong><dd><code>Update Metadata constructor calls to internal factory</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/health_connector_hk_ios/test/unit_tests/src/mappers/health_record_mappers/mindfulness/mindfulness_session_record_mapper_test.dart

<ul><li>Changed <code>Metadata</code> constructor from <code>const Metadata(...)</code> to <br><code>Metadata.internal(...)</code><br> <li> Added <code>const</code> keyword to <code>DataOrigin</code> and <code>Device</code> instantiations<br> <li> Updated <code>dataOrigin</code> property access to use null-safe operator <br><code>?.packageName</code></ul>


</details>


  </td>
  <td><a href="https://github.com/fam-tung-lam/health_connector/pull/94/files#diff-3ebf153995dc42cbca3b794c6605aba6b9aece87553c608580a329ba9a645c02">+4/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>waist_circumference_record_mapper_test.dart</strong><dd><code>Update Metadata constructor calls to internal factory</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/health_connector_hk_ios/test/unit_tests/src/mappers/health_record_mappers/waist_circumference_record_mapper_test.dart

<ul><li>Changed <code>Metadata</code> constructor from <code>const Metadata(...)</code> to <br><code>Metadata.internal(...)</code><br> <li> Added <code>const</code> keyword to <code>DataOrigin</code> and <code>Device</code> instantiations<br> <li> Updated <code>dataOrigin</code> property access to use null-safe operator <br><code>?.packageName</code></ul>


</details>


  </td>
  <td><a href="https://github.com/fam-tung-lam/health_connector/pull/94/files#diff-36e367178d53b2bdc743bcc38ab383e2d74b22f969a3843d1b4ece8ab797d791">+4/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>active_calories_burned_record_mapper_test.dart</strong><dd><code>Update Metadata constructor calls to internal factory</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/health_connector_hc_android/test/unit_tests/src/mappers/health_record_mappers/energy_burned/active_calories_burned_record_mapper_test.dart

<ul><li>Changed <code>Metadata</code> constructor from <code>const Metadata(...)</code> to <br><code>Metadata.internal(...)</code><br> <li> Added <code>const</code> keyword to <code>DataOrigin</code> and <code>Device</code> instantiations<br> <li> Updated <code>dataOrigin</code> property access to use null-safe operator <br><code>?.packageName</code></ul>


</details>


  </td>
  <td><a href="https://github.com/fam-tung-lam/health_connector/pull/94/files#diff-03dbef4402208c6be73805530dc166cc407d80d71ec8c5907a35b2fe99c3751a">+4/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>floors_climbed_record_mapper_test.dart</strong><dd><code>Update Metadata constructor calls to internal factory</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/health_connector_hk_ios/test/unit_tests/src/mappers/health_record_mappers/floors_climbed_record_mapper_test.dart

<ul><li>Changed <code>Metadata</code> constructor from <code>const Metadata(...)</code> to <br><code>Metadata.internal(...)</code><br> <li> Added <code>const</code> keyword to <code>DataOrigin</code> and <code>Device</code> instantiations<br> <li> Updated <code>dataOrigin</code> property access to use null-safe operator <br><code>?.packageName</code></ul>


</details>


  </td>
  <td><a href="https://github.com/fam-tung-lam/health_connector/pull/94/files#diff-6d7f391ea60eb27fe0599f9f4968c895308145af89a4743910ef03fcb8a166d6">+4/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>ovulation_test_record_mapper_test.dart</strong><dd><code>Update Metadata constructor calls to internal factory</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/health_connector_hk_ios/test/unit_tests/src/mappers/health_record_mappers/menstruation/ovulation_test_record_mapper_test.dart

<ul><li>Changed <code>Metadata</code> constructor from <code>const Metadata(...)</code> to <br><code>Metadata.internal(...)</code><br> <li> Added <code>const</code> keyword to <code>DataOrigin</code> and <code>Device</code> instantiations<br> <li> Updated <code>dataOrigin</code> property access to use null-safe operator <br><code>?.packageName</code></ul>


</details>


  </td>
  <td><a href="https://github.com/fam-tung-lam/health_connector/pull/94/files#diff-ac103fe2c8aacf1cfff813e94c6c5a07ad509ceb493f6665f4e25110f51e9984">+4/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>hydration_record_mapper_test.dart</strong><dd><code>Update Metadata constructor calls to internal factory</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/health_connector_hk_ios/test/unit_tests/src/mappers/health_record_mappers/hydration_record_mapper_test.dart

<ul><li>Changed <code>Metadata</code> constructor from <code>const Metadata(...)</code> to <br><code>Metadata.internal(...)</code><br> <li> Added <code>const</code> keyword to <code>DataOrigin</code> and <code>Device</code> instantiations<br> <li> Updated <code>dataOrigin</code> property access to use null-safe operator <br><code>?.packageName</code></ul>


</details>


  </td>
  <td><a href="https://github.com/fam-tung-lam/health_connector/pull/94/files#diff-f4230ec86657b8e647b93a2780263ebf2811570925d8eb0c9909ae86b8d48ae9">+4/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>cycling_power_record_mapper_test.dart</strong><dd><code>Update Metadata constructor calls to internal factory</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/health_connector_hk_ios/test/unit_tests/src/mappers/health_record_mappers/power/cycling_power_record_mapper_test.dart

<ul><li>Changed <code>Metadata</code> constructor from <code>const Metadata(...)</code> to <br><code>Metadata.internal(...)</code><br> <li> Added <code>const</code> keyword to <code>DataOrigin</code> and <code>Device</code> instantiations<br> <li> Updated <code>dataOrigin</code> property access to use null-safe operator <br><code>?.packageName</code></ul>


</details>


  </td>
  <td><a href="https://github.com/fam-tung-lam/health_connector/pull/94/files#diff-2deaf0e9288952bf2b5d9ca20adf2ffe207f5ebdc0f8b722b976ee0d91346e23">+4/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>basal_body_temperature_record_mapper_test.dart</strong><dd><code>Update Metadata constructor calls to internal factory</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/health_connector_hk_ios/test/unit_tests/src/mappers/health_record_mappers/temperature/basal_body_temperature_record_mapper_test.dart

<ul><li>Changed <code>Metadata</code> constructor from <code>const Metadata(...)</code> to <br><code>Metadata.internal(...)</code><br> <li> Added <code>const</code> keyword to <code>DataOrigin</code> and <code>Device</code> instantiations<br> <li> Updated <code>dataOrigin</code> property access to use null-safe operator <br><code>?.packageName</code></ul>


</details>


  </td>
  <td><a href="https://github.com/fam-tung-lam/health_connector/pull/94/files#diff-4c299d5e16c0bb55adad693410b548f2c55a28a4afc136ab496336d39dfba9f0">+4/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>lean_body_mass_record_mapper_test.dart</strong><dd><code>Update Metadata constructor calls to internal factory</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/health_connector_hk_ios/test/unit_tests/src/mappers/health_record_mappers/lean_body_mass_record_mapper_test.dart

<ul><li>Changed <code>Metadata</code> constructor from <code>const Metadata(...)</code> to <br><code>Metadata.internal(...)</code><br> <li> Added <code>const</code> keyword to <code>DataOrigin</code> and <code>Device</code> instantiations<br> <li> Updated <code>dataOrigin</code> property access to use null-safe operator <br><code>?.packageName</code></ul>


</details>


  </td>
  <td><a href="https://github.com/fam-tung-lam/health_connector/pull/94/files#diff-7efde1c82cd5bf73ceab2bbee2210581ccc8850333cb425b236dc7a61710fd5c">+4/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>sleep_stage_record_mapper_test.dart</strong><dd><code>Update Metadata constructor calls to internal factory</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/health_connector_hk_ios/test/unit_tests/src/mappers/health_record_mappers/sleep/sleep_stage_record_mapper_test.dart

<ul><li>Changed <code>Metadata</code> constructor from <code>const Metadata(...)</code> to <br><code>Metadata.internal(...)</code><br> <li> Added <code>const</code> keyword to <code>DataOrigin</code> and <code>Device</code> instantiations<br> <li> Updated <code>dataOrigin</code> property access to use null-safe operator <br><code>?.packageName</code></ul>


</details>


  </td>
  <td><a href="https://github.com/fam-tung-lam/health_connector/pull/94/files#diff-4f5ca3f8d28479f4859bd60292c025344222bd46d64dc879fa0f6f2c890d22b6">+4/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>floors_climbed_record_mapper_test.dart</strong><dd><code>Update Metadata constructor calls to internal factory</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/health_connector_hc_android/test/unit_tests/src/mappers/health_record_mappers/floors_climbed_record_mapper_test.dart

<ul><li>Changed <code>Metadata</code> constructor from <code>const Metadata(...)</code> to <br><code>Metadata.internal(...)</code><br> <li> Added <code>const</code> keyword to <code>DataOrigin</code> and <code>Device</code> instantiations<br> <li> Updated <code>dataOrigin</code> property access to use null-safe operator <br><code>?.packageName</code></ul>


</details>


  </td>
  <td><a href="https://github.com/fam-tung-lam/health_connector/pull/94/files#diff-f59257b4c8c60c62ce5f89e04d3bec285a1d69a53d0f92cc8d41ed4e01c7e839">+4/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>body_fat_percentage_record_mapper_test.dart</strong><dd><code>Update Metadata constructor calls to internal factory</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/health_connector_hk_ios/test/unit_tests/src/mappers/health_record_mappers/body_fat_percentage_record_mapper_test.dart

<ul><li>Changed <code>Metadata</code> constructor from <code>const Metadata(...)</code> to <br><code>Metadata.internal(...)</code><br> <li> Added <code>const</code> keyword to <code>DataOrigin</code> and <code>Device</code> instantiations<br> <li> Updated <code>dataOrigin</code> property access to use null-safe operator <br><code>?.packageName</code></ul>


</details>


  </td>
  <td><a href="https://github.com/fam-tung-lam/health_connector/pull/94/files#diff-f958f0e9034a4b8175b613900601d27667b359933da384a6cb867cb69c332582">+4/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>body_temperature_record_mapper_test.dart</strong><dd><code>Update Metadata constructor calls to internal factory</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/health_connector_hk_ios/test/unit_tests/src/mappers/health_record_mappers/temperature/body_temperature_record_mapper_test.dart

<ul><li>Changed <code>Metadata</code> constructor from <code>const Metadata(...)</code> to <br><code>Metadata.internal(...)</code><br> <li> Added <code>const</code> keyword to <code>DataOrigin</code> and <code>Device</code> instantiations<br> <li> Updated <code>dataOrigin</code> property access to use null-safe operator <br><code>?.packageName</code></ul>


</details>


  </td>
  <td><a href="https://github.com/fam-tung-lam/health_connector/pull/94/files#diff-1aa22885fe8f4bd42f46ce6ffec7914f09ce4ba45f98ad6adc51814944f75be5">+4/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>sexual_activity_record_mapper_test.dart</strong><dd><code>Update Metadata constructor calls to internal factory</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/health_connector_hc_android/test/unit_tests/src/mappers/health_record_mappers/sexual_activity/sexual_activity_record_mapper_test.dart

<ul><li>Changed <code>Metadata</code> constructor from <code>const Metadata(...)</code> to <br><code>Metadata.internal(...)</code><br> <li> Added <code>const</code> keyword to <code>DataOrigin</code> and <code>Device</code> instantiations<br> <li> Updated <code>dataOrigin</code> property access to use null-safe operator <br><code>?.packageName</code></ul>


</details>


  </td>
  <td><a href="https://github.com/fam-tung-lam/health_connector/pull/94/files#diff-42af5e978ef571feaca34372c74e51750ddac01fd8c02c97aa0f731783903e34">+4/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>body_mass_index_record_mapper_test.dart</strong><dd><code>Update Metadata constructor calls to internal factory</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/health_connector_hk_ios/test/unit_tests/src/mappers/health_record_mappers/body_mass_index_record_mapper_test.dart

<ul><li>Changed <code>Metadata</code> constructor from <code>const Metadata(...)</code> to <br><code>Metadata.internal(...)</code><br> <li> Added <code>const</code> keyword to <code>DataOrigin</code> and <code>Device</code> instantiations<br> <li> Updated <code>dataOrigin</code> property access to use null-safe operator <br><code>?.packageName</code></ul>


</details>


  </td>
  <td><a href="https://github.com/fam-tung-lam/health_connector/pull/94/files#diff-b4f6b8c864885676344f77e77292ac2d1a5ed5bd55904c6deba37b2b994fc740">+4/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>exercise_session_record_mapper_test.dart</strong><dd><code>Update Metadata constructor calls to internal factory</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/health_connector_hk_ios/test/unit_tests/src/mappers/health_record_mappers/exercise/exercise_session_record_mapper_test.dart

<ul><li>Changed <code>Metadata</code> constructor from <code>const Metadata(...)</code> to <br><code>Metadata.internal(...)</code><br> <li> Added <code>const</code> keyword to <code>DataOrigin</code> and <code>Device</code> instantiations<br> <li> Updated <code>dataOrigin</code> property access to use null-safe operator <br><code>?.packageName</code></ul>


</details>


  </td>
  <td><a href="https://github.com/fam-tung-lam/health_connector/pull/94/files#diff-d9bec2e7fdde73a2d71028fc2b3c7f5b2d1885f7b92be664b86348fda3ed0529">+4/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>cycling_pedaling_cadence_series_record_mapper_test.dart</strong><dd><code>Update Metadata constructor calls to internal factory</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/health_connector_hc_android/test/unit_tests/src/mappers/health_record_mappers/cycling_pedaling_cadence/cycling_pedaling_cadence_series_record_mapper_test.dart

<ul><li>Changed <code>Metadata</code> constructor from <code>const Metadata(...)</code> to <br><code>Metadata.internal(...)</code><br> <li> Added <code>const</code> keyword to <code>DataOrigin</code> instantiation<br> <li> Updated <code>dataOrigin</code> property access to use null-safe operator <br><code>?.packageName</code></ul>


</details>


  </td>
  <td><a href="https://github.com/fam-tung-lam/health_connector/pull/94/files#diff-77c1ba716327549891c8958921a8f6caa1f4f7680279974ddd2b969eb7bf6466">+3/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>height_record_mapper_test.dart</strong><dd><code>Update Metadata constructor calls to internal factory</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/health_connector_hk_ios/test/unit_tests/src/mappers/health_record_mappers/height_record_mapper_test.dart

<ul><li>Changed <code>Metadata</code> constructor from <code>const Metadata(...)</code> to <br><code>Metadata.internal(...)</code><br> <li> Added <code>const</code> keyword to <code>DataOrigin</code> and <code>Device</code> instantiations<br> <li> Updated <code>dataOrigin</code> property access to use null-safe operator <br><code>?.packageName</code></ul>


</details>


  </td>
  <td><a href="https://github.com/fam-tung-lam/health_connector/pull/94/files#diff-db8e66872a2f5b18c91c08ce8bd4c60fcac680dec1f938a7bc88e39fbaafc244">+4/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>steps_record_mapper_test.dart</strong><dd><code>Update Metadata constructor calls to internal factory</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/health_connector_hk_ios/test/unit_tests/src/mappers/health_record_mappers/steps_record_mapper_test.dart

<ul><li>Changed <code>Metadata</code> constructor from <code>const Metadata(...)</code> to <br><code>Metadata.internal(...)</code><br> <li> Added <code>const</code> keyword to <code>DataOrigin</code> and <code>Device</code> instantiations<br> <li> Updated <code>dataOrigin</code> property access to use null-safe operator <br><code>?.packageName</code></ul>


</details>


  </td>
  <td><a href="https://github.com/fam-tung-lam/health_connector/pull/94/files#diff-17e5bc21821f8d85ede69bc3b4a23cd8c9a6a559762cc5f9f2560fcba586318b">+4/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>sexual_activity_record_mapper_test.dart</strong><dd><code>Update Metadata constructor calls to internal factory</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/health_connector_hk_ios/test/unit_tests/src/mappers/health_record_mappers/sexual_activity/sexual_activity_record_mapper_test.dart

<ul><li>Changed <code>Metadata</code> constructor from <code>const Metadata(...)</code> to <br><code>Metadata.internal(...)</code><br> <li> Added <code>const</code> keyword to <code>DataOrigin</code> and <code>Device</code> instantiations<br> <li> Updated <code>dataOrigin</code> property access to use null-safe operator <br><code>?.packageName</code></ul>


</details>


  </td>
  <td><a href="https://github.com/fam-tung-lam/health_connector/pull/94/files#diff-ebe1da776d7fc406ed78d220c482f16ee1fa4dd4ccab6d7172d5e8e83ab174d7">+4/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>intermenstrual_bleeding_record_mapper_test.dart</strong><dd><code>Update Metadata constructor calls to internal factory</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/health_connector_hk_ios/test/unit_tests/src/mappers/health_record_mappers/menstruation/intermenstrual_bleeding_record_mapper_test.dart

<ul><li>Changed <code>Metadata</code> constructor from <code>const Metadata(...)</code> to <br><code>Metadata.internal(...)</code><br> <li> Added <code>const</code> keyword to <code>DataOrigin</code> and <code>Device</code> instantiations<br> <li> Updated <code>dataOrigin</code> property access to use null-safe operator <br><code>?.packageName</code></ul>


</details>


  </td>
  <td><a href="https://github.com/fam-tung-lam/health_connector/pull/94/files#diff-ac08f54bdf94ef251a15715cd9524074ee263b917097b608236b4502a022cb23">+4/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>heart_rate_variability_rmssd_record_mapper_test.dart</strong><dd><code>Update Metadata constructor calls to internal factory</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/health_connector_hc_android/test/unit_tests/src/mappers/health_record_mappers/heart_rate/heart_rate_variability_rmssd_record_mapper_test.dart

<ul><li>Changed <code>Metadata</code> constructor from <code>const Metadata(...)</code> to <br><code>Metadata.internal(...)</code><br> <li> Added <code>const</code> keyword to <code>DataOrigin</code> instantiation<br> <li> Updated <code>dataOrigin</code> property access to use null-safe operator <br><code>?.packageName</code></ul>


</details>


  </td>
  <td><a href="https://github.com/fam-tung-lam/health_connector/pull/94/files#diff-1818d8fea52b14ba0f18d6f5633f602a00ae69ef1ef365dc7c45171e3cd95752">+3/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Documentation</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td>
    <details>
      <summary><strong>menstrual_flow_record.dart</strong><dd><code>Update menstrual flow record documentation examples</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/health_connector_core/lib/src/models/health_records/menstruation/menstrual_flow_record.dart

<ul><li>Updated documentation examples to remove <code>dataOrigin</code> parameter from <br><code>Metadata.manualEntry()</code> calls (3 occurrences)<br> <li> Simplified example code in docstrings</ul>


</details>


  </td>
  <td><a href="https://github.com/fam-tung-lam/health_connector/pull/94/files#diff-11b1316456f842266900ae54755e6cac7f438a5e72a3209dedd696c4b87f8bce">+3/-9</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Enhancement</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td>
    <details>
      <summary><strong>base_health_record_write_form.dart</strong><dd><code>Remove dataOrigin from toolbox example write forms</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

examples/health_connector_toolbox/lib/src/features/write_health_record/widgets/write_forms/base_health_record_write_form.dart

<ul><li>Removed static <code>_dataOrigin</code> constant definition<br> <li> Removed <code>dataOrigin</code> parameter from all <code>Metadata</code> factory constructor <br>calls (4 occurrences)<br> <li> Simplified metadata instantiation in the <code>metadata</code> getter</ul>


</details>


  </td>
  <td><a href="https://github.com/fam-tung-lam/health_connector/pull/94/files#diff-2c6b0c371ab55a579ac66b6ebfcfa89a2ab99965853a0b3373e2e41bd64e8ee9">+1/-10</a>&nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Additional files</strong></td><td><details><summary>101 files</summary><table>
<tr>
  <td><strong>health_record_metadata_info.dart</strong></td>
  <td><a href="https://github.com/fam-tung-lam/health_connector/pull/94/files#diff-4340ffb7a9c0e83d208426fada33a30c60fbec5ea992ea3069961c3b5987ff9b">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>README.md</strong></td>
  <td><a href="https://github.com/fam-tung-lam/health_connector/pull/94/files#diff-38a7cefa07c71f9bfd044cbcf52e844337fe3fb44b683c72eaa23213fcb700c9">+0/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>main.dart</strong></td>
  <td><a href="https://github.com/fam-tung-lam/health_connector/pull/94/files#diff-bf11050e89e9b435ace8fb89b3d59368ac888f38f4771df8ef570b7a4e1b4fe7">+0/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>blood_glucose_record.dart</strong></td>
  <td><a href="https://github.com/fam-tung-lam/health_connector/pull/94/files#diff-75fe3eec631753624df31e82621cb4dc94793d49fd0cd2f2b11cf75d5bc3620a">+1/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>blood_pressure_record.dart</strong></td>
  <td><a href="https://github.com/fam-tung-lam/health_connector/pull/94/files#diff-e146704bc4123f7278369498b5c95215cb6f50a1fe5dc894a6be9b5b49a55dc2">+1/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>diastolic_blood_pressure_record.dart</strong></td>
  <td><a href="https://github.com/fam-tung-lam/health_connector/pull/94/files#diff-044de3feba960b254812b32991f250caafa9fdeadc231b26316b5dc435ae5ece">+1/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>systolic_blood_pressure_record.dart</strong></td>
  <td><a href="https://github.com/fam-tung-lam/health_connector/pull/94/files#diff-9b1985784fb1a27233079e5f865766a01f8e0311f8dd0dbaa828220af2622b3f">+1/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>body_fat_percentage_record.dart</strong></td>
  <td><a href="https://github.com/fam-tung-lam/health_connector/pull/94/files#diff-e051d733889eda43c6e204c00d70e697316a88367307695410bc4e2fa7436a0f">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>body_mass_index_record.dart</strong></td>
  <td><a href="https://github.com/fam-tung-lam/health_connector/pull/94/files#diff-25ba7aa894c6f1d903036f0cc11426ec62792dbc209f74e8971199dd77ec37a2">+1/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>cycling_pedaling_cadence_measurement_record.dart</strong></td>
  <td><a href="https://github.com/fam-tung-lam/health_connector/pull/94/files#diff-94117897b7a95e1117358e1894563b74868b420d5dbd2fcdeec3f8a5ff52b300">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>cycling_pedaling_cadence_series_record.dart</strong></td>
  <td><a href="https://github.com/fam-tung-lam/health_connector/pull/94/files#diff-fe7d1814a699749b91291df967af7878f551b86be8130b712af3b092d4ce6fd3">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>distance_record.dart</strong></td>
  <td><a href="https://github.com/fam-tung-lam/health_connector/pull/94/files#diff-c389f70b705aab01e588e62ed6ba6db21d7ec9e5d223a7abc517e97255af5816">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>active_calories_burned_record.dart</strong></td>
  <td><a href="https://github.com/fam-tung-lam/health_connector/pull/94/files#diff-d439ae55adef96d22013b71263da69fa6617957b1ab2a56349d5c85d3fe65692">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>basal_energy_burned_record.dart</strong></td>
  <td><a href="https://github.com/fam-tung-lam/health_connector/pull/94/files#diff-9cf13f249c860b555bc2b4e7233bc94fc208d1dc9042fc387702d1fc2e387232">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>total_calories_burned_record.dart</strong></td>
  <td><a href="https://github.com/fam-tung-lam/health_connector/pull/94/files#diff-8cd5a06762f4c715aaa19280342e4305b54471bfe19baef24ff996f00528a901">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>exercise_session_record.dart</strong></td>
  <td><a href="https://github.com/fam-tung-lam/health_connector/pull/94/files#diff-b86f113e9d1dd051b8e0a4760e345200a22a410aab28181c11b0561abedf6b07">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>floors_climbed_record.dart</strong></td>
  <td><a href="https://github.com/fam-tung-lam/health_connector/pull/94/files#diff-ce9131c33cc3c72d41a25f942e37ed3317b79558d9dd3b58c66cf6baf55925c3">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>heart_rate_measurement_record.dart</strong></td>
  <td><a href="https://github.com/fam-tung-lam/health_connector/pull/94/files#diff-08426d8fe0df5e676bfa8c23f99ccf0b6557e33ebcdcf15cec9d12a256e62032">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>heart_rate_series_record.dart</strong></td>
  <td><a href="https://github.com/fam-tung-lam/health_connector/pull/94/files#diff-02a3765618d966ab52b61e777b2c4509fd67d988f72ea7eaa6288dbd9970c2ff">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>heart_rate_variability_sdnn_record.dart</strong></td>
  <td><a href="https://github.com/fam-tung-lam/health_connector/pull/94/files#diff-6bb1b0a0c24d22ddd942a6b030d1e5b6735ad31fb8ead5f4dbdec2330a79fea2">+1/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>resting_heart_rate_record.dart</strong></td>
  <td><a href="https://github.com/fam-tung-lam/health_connector/pull/94/files#diff-47b76d6d518a4f19fb363345d3a443b53cbd97b8eeaecd488d20f8cbe9d0a522">+1/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>height_record.dart</strong></td>
  <td><a href="https://github.com/fam-tung-lam/health_connector/pull/94/files#diff-66f9b03f9ee7cd6e9e7a48b812300655666709d1c58c18379a88ada41cdf2d23">+1/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>hydration_record.dart</strong></td>
  <td><a href="https://github.com/fam-tung-lam/health_connector/pull/94/files#diff-7fa3a0c37882b00538fb9688ff839c7ce59edcb8a9352417ee68abc33bfef5f6">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>lean_body_mass_record.dart</strong></td>
  <td><a href="https://github.com/fam-tung-lam/health_connector/pull/94/files#diff-ad580c8c8ff4d9fe2958b790bac3b60587f2e3f20443d0b54c828c1133f3f009">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>intermenstrual_bleeding_record.dart</strong></td>
  <td><a href="https://github.com/fam-tung-lam/health_connector/pull/94/files#diff-c7dd1f76ebb371419cbda70fdb6b18123684fb967640405d7dd7ce2507f7d632">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>menstrual_flow_instant_record.dart</strong></td>
  <td><a href="https://github.com/fam-tung-lam/health_connector/pull/94/files#diff-6f49a342a2991c3a52adc7dde36ff2d6bf4244562255deb642682de86a2af9fe">+1/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>ovulation_test_record.dart</strong></td>
  <td><a href="https://github.com/fam-tung-lam/health_connector/pull/94/files#diff-f0d8a09b6b642a5e67efe4468c081e35dd14335cd00a19c7d80084b8121bd134">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>mindfulness_session_record.dart</strong></td>
  <td><a href="https://github.com/fam-tung-lam/health_connector/pull/94/files#diff-a50cc304ddf77ecc5aa7602b638e2b742b02344d0d8fc96df41f81f4ce37b3be">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>biotin_nutrient_record.dart</strong></td>
  <td><a href="https://github.com/fam-tung-lam/health_connector/pull/94/files#diff-06d64597e2fd44c8efe589a1bfa76b5055191e4381d26ea5ef8637da9a24a07d">+1/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>caffeine_nutrient_record.dart</strong></td>
  <td><a href="https://github.com/fam-tung-lam/health_connector/pull/94/files#diff-a6d742c2a5b82a854e7a82012a9c65283b4354f0ef285097a00b5d0a9f7bbf63">+1/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>calcium_nutrient_record.dart</strong></td>
  <td><a href="https://github.com/fam-tung-lam/health_connector/pull/94/files#diff-48146a37dccb76c8097b217176f23607d024bcd15425d29b17204c39dd9ae9ad">+1/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>cholesterol_nutrient_record.dart</strong></td>
  <td><a href="https://github.com/fam-tung-lam/health_connector/pull/94/files#diff-474e6c485e95a2d65c1c07e5073b4605151b29be22b727a1e65d69ad30da8480">+1/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>dietary_fiber_nutrient_record.dart</strong></td>
  <td><a href="https://github.com/fam-tung-lam/health_connector/pull/94/files#diff-ba6321867bfa6acfa0517b5dda41ae5fc34ca0d552080f17cc374cac70c8c72d">+1/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>energy_nutrient_record.dart</strong></td>
  <td><a href="https://github.com/fam-tung-lam/health_connector/pull/94/files#diff-991f16076ece426fbf445911c3cb6e7330508a957e8c802bbd33eb0c677699b1">+1/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>folate_nutrient_record.dart</strong></td>
  <td><a href="https://github.com/fam-tung-lam/health_connector/pull/94/files#diff-391a6bf507ef2a968ea46be353bbdfc9d47976ef7343d645b499d42d7df4cb50">+1/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>iron_nutrient_record.dart</strong></td>
  <td><a href="https://github.com/fam-tung-lam/health_connector/pull/94/files#diff-b5386b02d9f25bd1dc20f24ebbec7eb64d4ab75da51166bfa43ad5256497a0c5">+1/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>magnesium_nutrient_record.dart</strong></td>
  <td><a href="https://github.com/fam-tung-lam/health_connector/pull/94/files#diff-e044469044bfef5b5bea7778a3f9d013e0d8f4f3989b7e419f3558e07316fa4e">+1/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>manganese_nutrient_record.dart</strong></td>
  <td><a href="https://github.com/fam-tung-lam/health_connector/pull/94/files#diff-706b17cb3d7d3755c8172d60d15bbf2fa687b34b2dd1ce29350dcb25f9cb3c7d">+1/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>monounsaturated_fat_nutrient_record.dart</strong></td>
  <td><a href="https://github.com/fam-tung-lam/health_connector/pull/94/files#diff-1736bf6c9c4c07ef7225b5570191fbd03b665a012c6ef239e0ddf447e372dc11">+1/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>niacin_nutrient_record.dart</strong></td>
  <td><a href="https://github.com/fam-tung-lam/health_connector/pull/94/files#diff-2c1a72493df85872b5c5c8c483134079bb7485661fd26c2a92c05cb2790e026f">+1/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>nutrition_record.dart</strong></td>
  <td><a href="https://github.com/fam-tung-lam/health_connector/pull/94/files#diff-872f880443d505bb5682981edbe14f4c9d528527fddfa2039a890512f21424c5">+1/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>pantothenic_acid_nutrient_record.dart</strong></td>
  <td><a href="https://github.com/fam-tung-lam/health_connector/pull/94/files#diff-5fd1fee1a68f097fda9b33f7cc8dd0e1a383e95dff4c7db4403f9917c68e301f">+1/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>phosphorus_nutrient_record.dart</strong></td>
  <td><a href="https://github.com/fam-tung-lam/health_connector/pull/94/files#diff-2390533254acb9b536fea60f6450ac19012f314598fb787d2cde1716f3c73b56">+1/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>polyunsaturated_fat_nutrient_record.dart</strong></td>
  <td><a href="https://github.com/fam-tung-lam/health_connector/pull/94/files#diff-b728fcdc5e2f46524f47064f0a9fa3aff7f917a347b2f4fe85de626994a63c9d">+1/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>potassium_nutrient_record.dart</strong></td>
  <td><a href="https://github.com/fam-tung-lam/health_connector/pull/94/files#diff-8b3210bca2b99732818318a588176c902669ab0e00c83c5aa7cb2204c86423e7">+1/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>protein_nutrient_record.dart</strong></td>
  <td><a href="https://github.com/fam-tung-lam/health_connector/pull/94/files#diff-d78f807ef0cefd86f351196794710b53468591712fbb077f6b4f36bf0b0b1e3c">+1/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>riboflavin_nutrient_record.dart</strong></td>
  <td><a href="https://github.com/fam-tung-lam/health_connector/pull/94/files#diff-d96aad0606ad9de6c092171d5601df83e4e4b11ba0a9f536a64f1e09f5e9160d">+1/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>saturated_fat_nutrient_record.dart</strong></td>
  <td><a href="https://github.com/fam-tung-lam/health_connector/pull/94/files#diff-507d03ccea5a7ea3d65c177bd6cacf85ebabfb6cc7aa08e61fdb43326c28c5a9">+1/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>selenium_nutrient_record.dart</strong></td>
  <td><a href="https://github.com/fam-tung-lam/health_connector/pull/94/files#diff-cbac0251e418698f304d8a9548d25de75b3c1cdba9f1a78d6d1d33a51d87dba6">+1/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>sodium_nutrient_record.dart</strong></td>
  <td><a href="https://github.com/fam-tung-lam/health_connector/pull/94/files#diff-f2549763eab416f13600ce0f91cbb7c2a3496bcb190fcf4f9c45b3af658cb074">+1/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>sugar_nutrient_record.dart</strong></td>
  <td><a href="https://github.com/fam-tung-lam/health_connector/pull/94/files#diff-cf8e0df293737ed31b77ae44eaf874953e9efe753b1b5eef8d0063136f1b59ec">+1/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>thiamin_nutrient_record.dart</strong></td>
  <td><a href="https://github.com/fam-tung-lam/health_connector/pull/94/files#diff-1cf691d800cb9075b9b4708259a1f0978db224e8f0752c8ecfa112fbb645ba24">+1/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>total_carbohydrate_nutrient_record.dart</strong></td>
  <td><a href="https://github.com/fam-tung-lam/health_connector/pull/94/files#diff-ea748b60ea5eaf05c14a2ab7d97360de372557bc0b497f7ac3971742b2ae6d32">+1/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>total_fat_nutrient_record.dart</strong></td>
  <td><a href="https://github.com/fam-tung-lam/health_connector/pull/94/files#diff-1e77630fbee8d23a4f63fd2be400fdc5a7aea53d8f432e92a0b2e10e27c650c2">+1/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>vitamin_a_nutrient_record.dart</strong></td>
  <td><a href="https://github.com/fam-tung-lam/health_connector/pull/94/files#diff-d5a245a4cea2192a579294c44ef33c7517855f145a64b3bfecf22758fe8b147d">+1/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>vitamin_b12_nutrient_record.dart</strong></td>
  <td><a href="https://github.com/fam-tung-lam/health_connector/pull/94/files#diff-a7118a58fa09d752870dbea0e85fb4236fe8d5b68607be0507d388f785d7caaf">+1/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>vitamin_b6_nutrient_record.dart</strong></td>
  <td><a href="https://github.com/fam-tung-lam/health_connector/pull/94/files#diff-7cac7df544520269ab05d291d048a0d9ccbaad977b2d54095e7ffeb1240bd8f9">+1/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>vitamin_c_nutrient_record.dart</strong></td>
  <td><a href="https://github.com/fam-tung-lam/health_connector/pull/94/files#diff-98f8ad3ef1aa15c358f42c8ae7eeffbfae8463ec98b25c01886744cf75ce9a36">+1/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>vitamin_d_nutrient_record.dart</strong></td>
  <td><a href="https://github.com/fam-tung-lam/health_connector/pull/94/files#diff-4cde31f52194f862f8c63285a65115f6c82033e34ec7eb2c94ce3c3909a87304">+1/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>vitamin_e_nutrient_record.dart</strong></td>
  <td><a href="https://github.com/fam-tung-lam/health_connector/pull/94/files#diff-77660a62bbce90c71c1a5ffc7030bbfbf92512365c7cc2faa5268b616ba844de">+1/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>vitamin_k_nutrient_record.dart</strong></td>
  <td><a href="https://github.com/fam-tung-lam/health_connector/pull/94/files#diff-9c53b0fdc305cef8b052f272d789f1649718004a4107590d9ad618c4f62f4f2e">+1/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>zinc_nutrient_record.dart</strong></td>
  <td><a href="https://github.com/fam-tung-lam/health_connector/pull/94/files#diff-88001bba423231b93df4864074cfbe9c66810aec82bf0dc1ba7b1b4cf659ede6">+1/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>oxygen_saturation_record.dart</strong></td>
  <td><a href="https://github.com/fam-tung-lam/health_connector/pull/94/files#diff-e3d3e77a59cd084a4130a76ad4fc84b034c2f069673bc710289bf5d3437d4d29">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>respiratory_rate_record.dart</strong></td>
  <td><a href="https://github.com/fam-tung-lam/health_connector/pull/94/files#diff-1f0000cc5e34a3c31899ae6bff5ac864bfcf50f9632079dc5c847985b71ab97a">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>sexual_activity_record.dart</strong></td>
  <td><a href="https://github.com/fam-tung-lam/health_connector/pull/94/files#diff-88e1913f537fea08d2e223e6b3f571403551c6cb83a040961236ddc055bd1d28">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>sleep_session_record.dart</strong></td>
  <td><a href="https://github.com/fam-tung-lam/health_connector/pull/94/files#diff-4568f5e06472f095c854d223e846e626c9613ed4a6365907e6cfd09241ac1df7">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>sleep_stage_record.dart</strong></td>
  <td><a href="https://github.com/fam-tung-lam/health_connector/pull/94/files#diff-daff9a24cd9586ad6fe39d1bd44a12dcb54cfd45627dac6eda80e48562652ecc">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>steps_record.dart</strong></td>
  <td><a href="https://github.com/fam-tung-lam/health_connector/pull/94/files#diff-38dc9b9840b35372e840cc938cbd153d5fccdc6e1cff3177c01cf570e2e14b83">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>basal_body_temperature_record.dart</strong></td>
  <td><a href="https://github.com/fam-tung-lam/health_connector/pull/94/files#diff-4ea0b38a556ef6f1e1d9e64f286b9a2006741dd0d144945e2f93ba28bd30788d">+1/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>body_temperature_record.dart</strong></td>
  <td><a href="https://github.com/fam-tung-lam/health_connector/pull/94/files#diff-68a32b767940c6db6ee125ca726c878e391d8f21b4c23d3c24aa6edde7260b4b">+1/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>vo2_max_record.dart</strong></td>
  <td><a href="https://github.com/fam-tung-lam/health_connector/pull/94/files#diff-bbfbc7df2aa65681c07f2368eba1356a0b352307be8849023b1b2ea42cb75d46">+1/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>waist_circumference_record.dart</strong></td>
  <td><a href="https://github.com/fam-tung-lam/health_connector/pull/94/files#diff-001494b9d69e778af55e8a61bd570ec28e9bc76f4316888be0f17fdd56990f98">+1/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>weight_record.dart</strong></td>
  <td><a href="https://github.com/fam-tung-lam/health_connector/pull/94/files#diff-744aeae5ec60a8a8186355fb529a0f7375be56bb0cbd0b291c269a459c49127b">+1/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>wheelchair_pushes_record.dart</strong></td>
  <td><a href="https://github.com/fam-tung-lam/health_connector/pull/94/files#diff-5325f541334527076b4b3d6254edaa3da58dd8ef1d15dca5ffc1dcaed332fd88">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>health_record_data_type_extension_test.dart</strong></td>
  <td><a href="https://github.com/fam-tung-lam/health_connector/pull/94/files#diff-63304542f81d9d52801b03aa1d9bf280ed64629d7131c5b827131d0bad338aa6">+1/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>main.dart</strong></td>
  <td><a href="https://github.com/fam-tung-lam/health_connector/pull/94/files#diff-408884f24d3f0a63372bacb818f3b393eb1d494bf7317e8450c345e6d06cf762">+0/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>metadata_mapper.dart</strong></td>
  <td><a href="https://github.com/fam-tung-lam/health_connector/pull/94/files#diff-c172617ab37eca1cecbab6c40b2396766a17d7aeea2ac68a15401e243bf84e75">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>blood_glucose_record_mapper_test.dart</strong></td>
  <td><a href="https://github.com/fam-tung-lam/health_connector/pull/94/files#diff-e72a7b7840f263257c96d300234fa6a765b244bc9462ac60da55b213fddeff79">+4/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>blood_pressure_record_mapper_test.dart</strong></td>
  <td><a href="https://github.com/fam-tung-lam/health_connector/pull/94/files#diff-4f92ba18fe669dd80307842e5712ff20c202d3d9267c3676c302c6be6fada95a">+4/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>distance_record_mapper_test.dart</strong></td>
  <td><a href="https://github.com/fam-tung-lam/health_connector/pull/94/files#diff-60e158a90617e6f19be6b56cebfdd8a68c47ab18789a429b689dd212a558260b">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>total_calories_burned_record_mapper_test.dart</strong></td>
  <td><a href="https://github.com/fam-tung-lam/health_connector/pull/94/files#diff-bdc85dfefa3c6ed4bf81db4ccb2bec982f27df91e77f8bdaf8511ee72b66bb2e">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>exercise_session_record_mapper_test.dart</strong></td>
  <td><a href="https://github.com/fam-tung-lam/health_connector/pull/94/files#diff-8bab380899a7cf75e42c2d8f164e164696578a97604bfb61129083da0cdb507b">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>heart_rate_series_record_mapper_test.dart</strong></td>
  <td><a href="https://github.com/fam-tung-lam/health_connector/pull/94/files#diff-be5d39b14ce02cb132756fd74ef508c0faec13991c839146a88c10676fcafd95">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>resting_heart_rate_record_mapper_test.dart</strong></td>
  <td><a href="https://github.com/fam-tung-lam/health_connector/pull/94/files#diff-02154136409be523018dd18f2bf838afb86c382fe0bb86b8ee242f80214ff200">+3/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>height_record_mapper_test.dart</strong></td>
  <td><a href="https://github.com/fam-tung-lam/health_connector/pull/94/files#diff-067c3febe6c03ad29cefd573552f40fc80208d5cebb6904503c112130034daf0">+3/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>hydration_record_mapper_test.dart</strong></td>
  <td><a href="https://github.com/fam-tung-lam/health_connector/pull/94/files#diff-563540ce3a1e95a8958ecb3a18622f9c52d3966498df64a5605841ccd34b2187">+3/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>lean_body_mass_record_mapper_test.dart</strong></td>
  <td><a href="https://github.com/fam-tung-lam/health_connector/pull/94/files#diff-a476067fbfb229803fa0ceeb081862570d1c1c2f34edf9f31e258a7ac6ad0c0a">+4/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>cervical_mucus_record_mapper_test.dart</strong></td>
  <td><a href="https://github.com/fam-tung-lam/health_connector/pull/94/files#diff-ed371b27e677ea7b4e55453093ac4b04a8f7a72e88ffecb9052febb24888b17c">+4/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>intermenstrual_bleeding_record_mapper_test.dart</strong></td>
  <td><a href="https://github.com/fam-tung-lam/health_connector/pull/94/files#diff-c1bb35edac577d0e8dc4d08a1b3ecd69a0ce61f542b157f29f82aed9b007d03f">+3/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>menstrual_flow_instant_record_mapper_test.dart</strong></td>
  <td><a href="https://github.com/fam-tung-lam/health_connector/pull/94/files#diff-dbe2ebe39630e407ddcfb1ed2f30b88540f436313ac790c307fdc618e7158354">+3/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>ovulation_test_record_mapper_test.dart</strong></td>
  <td><a href="https://github.com/fam-tung-lam/health_connector/pull/94/files#diff-ce8aeb3558937388b57df9cefa1783d5ea8fb1497eb8d02410a381d6533dd4f8">+3/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>mindfulness_session_record_mapper_test.dart</strong></td>
  <td><a href="https://github.com/fam-tung-lam/health_connector/pull/94/files#diff-a1f0e794c57a2c47a9017279d98f25608871aa954f2ee730cc2a046a2cb849ce">+4/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>nutrition_record_mapper_test.dart</strong></td>
  <td><a href="https://github.com/fam-tung-lam/health_connector/pull/94/files#diff-5feab8786cf975ff9a4495463761881e8c7fe4963415a780d28928184b2abc27">+4/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>oxygen_saturation_record_mapper_test.dart</strong></td>
  <td><a href="https://github.com/fam-tung-lam/health_connector/pull/94/files#diff-9d284822d3c251ba7e565ab69958f6ef81102178f51e587c73f5dc2f40b89e0b">+3/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>power_record_mapper_test.dart</strong></td>
  <td><a href="https://github.com/fam-tung-lam/health_connector/pull/94/files#diff-e195db71dda4d40bf48650f965caf95f0a0f40594b1cec3f2e1259b51f3b7c65">+3/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>respiratory_rate_record_mapper_test.dart</strong></td>
  <td><a href="https://github.com/fam-tung-lam/health_connector/pull/94/files#diff-e5eb6828f997b2137688f35e5309a2df06a3ab17f0b844165d9a5f73c61582fa">+3/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>sleep_session_record_mapper_test.dart</strong></td>
  <td><a href="https://github.com/fam-tung-lam/health_connector/pull/94/files#diff-ed1f10a599afc2578fe412bc40d977a3bff00465a4611a16aa1ce720ffee57c6">+3/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>speed_record_mapper_test.dart</strong></td>
  <td><a href="https://github.com/fam-tung-lam/health_connector/pull/94/files#diff-0f6c0c8ee99db623077f1995cef8638f14f3fc446cd7a516e917ea6fc45423c0">+3/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>steps_record_mapper_test.dart</strong></td>
  <td><a href="https://github.com/fam-tung-lam/health_connector/pull/94/files#diff-e45d89b12ec15fe83f5cc986971b625d1bd76619eba935ce3bbf92ce85c33f9f">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>basal_body_temperature_record_mapper_test.dart</strong></td>
  <td><a href="https://github.com/fam-tung-lam/health_connector/pull/94/files#diff-a33a8d96197cc1a8ed2e66adf95140064bd54fbbf916d35270f299f3a62bb061">+3/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>Additional files not shown</strong></td>
  <td><a href="https://github.com/fam-tung-lam/health_connector/pull/94/files#diff-2f328e4cd8dbe3ad193e49d92bcf045f47a6b72b1e9487d366f6b8288589b4ca"></a></td>

</tr>
</table></details></td></tr></tbody></table>

</details>

___

