### PR TITLE
fix(health_connector_ios_hk): Fix `dataOrigins` filtering when reading records

### DIFF
--- a/packages/health_connector_hk_ios/ios/health_connector_hk_ios/Sources/health_connector_hk_ios/handlers/ReadableHealthRecordHandler.swift
+++ b/packages/health_connector_hk_ios/ios/health_connector_hk_ios/Sources/health_connector_hk_ios/handlers/ReadableHealthRecordHandler.swift
@@ -235,10 +235,10 @@ extension ReadableHealthRecordHandler {
                     // No matching sources found - return empty result
                     return (records: [], pageToken: nil)
                 }
-                let sourcePredicates = sources.map { HKQuery.predicateForObjects(from: $0) }
-                let sourcePredicate = NSCompoundPredicate(
-                    orPredicateWithSubpredicates: sourcePredicates
-                )
+
+                // Use predicateForObjects(from:) directly with the Set<HKSource>
+                // This API automatically handles multiple sources using an IN operator
+                let sourcePredicate = HKQuery.predicateForObjects(from: sources)
                 predicate = NSCompoundPredicate(andPredicateWithSubpredicates: [
                     sourcePredicate, timePredicate,
                 ])
@@ -251,7 +251,7 @@ extension ReadableHealthRecordHandler {
             if let pageToken {
                 let pageTokenDate = pageToken.toDate()
                 let paginationPredicate = NSPredicate(
-                    format: "startDate > %@", pageTokenDate as NSDate
+                    format: "startDate >= %@", pageTokenDate as NSDate
                 )
                 finalPredicate = NSCompoundPredicate(andPredicateWithSubpredicates: [
                     predicate, paginationPredicate,


### PR DESCRIPTION
### **User description**
Closes #78


___

### **PR Type**
Bug fix


___

### **Description**
- Fix `dataOrigins` filtering by using HKQuery API directly with Set<HKSource>

- Simplify source predicate construction, removing manual OR predicate mapping

- Fix pagination predicate to use >= instead of > for correct boundary handling


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Manual source predicate mapping"] -->|Simplified to| B["Direct HKQuery API with Set"]
  C["Pagination using >"] -->|Fixed to| D["Pagination using >="]
  B --> E["Correct dataOrigins filtering"]
  D --> E
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>ReadableHealthRecordHandler.swift</strong><dd><code>Simplify source filtering and fix pagination predicate</code>&nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/health_connector_hk_ios/ios/health_connector_hk_ios/Sources/health_connector_hk_ios/handlers/ReadableHealthRecordHandler.swift

<ul><li>Replaced manual source predicate construction with direct <br>HKQuery.predicateForObjects(from:) API call accepting Set<HKSource><br> <li> Removed unnecessary map and NSCompoundPredicate creation for source <br>filtering<br> <li> Changed pagination predicate comparison operator from > to >= for <br>inclusive boundary handling<br> <li> Added clarifying comments explaining the HKQuery API behavior with <br>multiple sources</ul>


</details>


  </td>
  <td><a href="https://github.com/fam-tung-lam/health_connector/pull/95/files#diff-ce21c6f85b6667e40ebae52453955032c21cef72d0e535e2a8ca0076c943e6fb">+5/-5</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

