### PR TITLE
feat(health_connector_core)!: Add validation range enforcement at instance creation

### DIFF
--- a/packages/health_connector_core/lib/src/models/health_records/blood_glucose/blood_glucose_record.dart
+++ b/packages/health_connector_core/lib/src/models/health_records/blood_glucose/blood_glucose_record.dart
@@ -32,6 +32,20 @@ part of '../health_record.dart';
 @sinceV1_4_0
 @immutable
 final class BloodGlucoseRecord extends InstantHealthRecord {
+  /// Minimum valid blood glucose (20 mg/dL).
+  ///
+  /// Severe hypoglycemia threshold; values below typically require emergency
+  /// intervention.
+  static const BloodGlucose minBloodGlucose =
+      BloodGlucose.milligramsPerDeciliter(20.0);
+
+  /// Maximum valid blood glucose (700 mg/dL).
+  ///
+  /// Hyperglycemic emergency threshold; higher values indicate measurement
+  /// error.
+  static const BloodGlucose maxBloodGlucose =
+      BloodGlucose.milligramsPerDeciliter(700.0);
+
   /// Creates a blood glucose record.
   ///
   /// ## Parameters
@@ -45,7 +59,19 @@ final class BloodGlucoseRecord extends InstantHealthRecord {
   ///   meal).
   /// - [mealType]: The type of meal (e.g., breakfast, lunch).
   /// - [specimenSource]: The source of the specimen (e.g., capillary blood).
-  const BloodGlucoseRecord({
+  ///
+  /// ## Throws
+  ///
+  /// - [ArgumentError] if [glucoseLevel] is outside the valid range of
+  ///   [minBloodGlucose]-[maxBloodGlucose] (1.1-38.9 mmol/L).
+  ///
+  /// ## Validation Rationale
+  ///
+  /// - **Minimum ([minBloodGlucose] / 1.1 mmol/L)**: Severe hypoglycemia threshold;
+  ///   values below typically require emergency intervention.
+  /// - **Maximum ([maxBloodGlucose] / 38.9 mmol/L)**: Hyperglycemic emergency
+  ///   threshold; higher values indicate measurement error.
+  BloodGlucoseRecord({
     required super.time,
     required super.metadata,
     required this.glucoseLevel,
@@ -54,7 +80,20 @@ final class BloodGlucoseRecord extends InstantHealthRecord {
     this.relationToMeal = BloodGlucoseRelationToMeal.unknown,
     this.mealType = MealType.unknown,
     this.specimenSource = BloodGlucoseSpecimenSource.unknown,
-  });
+  }) {
+    require(
+      condition:
+          glucoseLevel >= minBloodGlucose && glucoseLevel <= maxBloodGlucose,
+      value: glucoseLevel,
+      name: 'glucoseLevel',
+      message:
+          'Blood glucose must be between '
+          '${minBloodGlucose.inMilligramsPerDeciliter.toStringAsFixed(0)}-'
+          '${maxBloodGlucose.inMilligramsPerDeciliter.toStringAsFixed(0)} mg/dL '
+          '(1.1-38.9 mmol/L). '
+          'Got ${glucoseLevel.inMilligramsPerDeciliter.toStringAsFixed(1)} mg/dL.',
+    );
+  }
 
   /// Internal factory for creating [BloodGlucoseRecord] instances without
   /// validation.

--- a/packages/health_connector_core/lib/src/models/health_records/blood_pressure/blood_pressure_record.dart
+++ b/packages/health_connector_core/lib/src/models/health_records/blood_pressure/blood_pressure_record.dart
@@ -40,6 +40,18 @@ part of '../health_record.dart';
 @sinceV1_2_0
 @immutable
 final class BloodPressureRecord extends InstantHealthRecord {
+  /// Minimum valid systolic blood pressure.
+  static const Pressure minSystolic = SystolicBloodPressureRecord.minPressure;
+
+  /// Maximum valid systolic blood pressure.
+  static const Pressure maxSystolic = SystolicBloodPressureRecord.maxPressure;
+
+  /// Minimum valid diastolic blood pressure.
+  static const Pressure minDiastolic = DiastolicBloodPressureRecord.minPressure;
+
+  /// Maximum valid diastolic blood pressure.
+  static const Pressure maxDiastolic = DiastolicBloodPressureRecord.maxPressure;
+
   /// Creates a composite blood pressure record.
   ///
   /// ## Parameters
@@ -52,7 +64,26 @@ final class BloodPressureRecord extends InstantHealthRecord {
   /// - [diastolic]: The diastolic blood pressure measurement.
   /// - [bodyPosition]: Optional body position during measurement.
   /// - [measurementLocation]: Optional location where measurement was taken.
-  const BloodPressureRecord({
+  ///
+  /// ## Throws
+  ///
+  /// - [ArgumentError] if [systolic] is outside
+  ///   [minSystolic]-[maxSystolic] mmHg.
+  /// - [ArgumentError] if [diastolic] is outside
+  ///   [minDiastolic]-[maxDiastolic] mmHg.
+  /// - [ArgumentError] if [systolic] is not greater than [diastolic].
+  ///
+  /// ## Validation Rationale
+  ///
+  /// - **Systolic ([minSystolic]-[maxSystolic] mmHg)**:
+  ///   50 mmHg indicates severe shock; 250 mmHg is hypertensive emergency
+  ///   threshold.
+  /// - **Diastolic ([minDiastolic]-[maxDiastolic] mmHg)**:
+  ///   30 mmHg indicates severe shock; 150 mmHg is hypertensive emergency
+  ///   threshold.
+  /// - **Cross-field**: Systolic pressure must exceed diastolic in all
+  ///   physiological states.
+  BloodPressureRecord({
     required super.time,
     required super.metadata,
     required this.systolic,
@@ -61,7 +92,37 @@ final class BloodPressureRecord extends InstantHealthRecord {
     super.zoneOffsetSeconds,
     this.bodyPosition = BloodPressureBodyPosition.unknown,
     this.measurementLocation = BloodPressureMeasurementLocation.unknown,
-  });
+  }) {
+    require(
+      condition: systolic >= minSystolic && systolic <= maxSystolic,
+      value: systolic,
+      name: 'systolic',
+      message:
+          'Systolic BP must be between '
+          '${minSystolic.inMillimetersOfMercury.toStringAsFixed(0)}-'
+          '${maxSystolic.inMillimetersOfMercury.toStringAsFixed(0)} mmHg. '
+          'Got ${systolic.inMillimetersOfMercury.toStringAsFixed(1)} mmHg.',
+    );
+    require(
+      condition: diastolic >= minDiastolic && diastolic <= maxDiastolic,
+      value: diastolic,
+      name: 'diastolic',
+      message:
+          'Diastolic BP must be between '
+          '${minDiastolic.inMillimetersOfMercury.toStringAsFixed(0)}-'
+          '${maxDiastolic.inMillimetersOfMercury.toStringAsFixed(0)} mmHg. '
+          'Got ${diastolic.inMillimetersOfMercury.toStringAsFixed(1)} mmHg.',
+    );
+    require(
+      condition: systolic > diastolic,
+      value: '$systolic/$diastolic',
+      name: 'blood pressure',
+      message:
+          'Systolic must be greater than diastolic. Got '
+          '${systolic.inMillimetersOfMercury.toStringAsFixed(0)}/'
+          '${diastolic.inMillimetersOfMercury.toStringAsFixed(0)} mmHg.',
+    );
+  }
 
   /// Internal factory for creating [BloodPressureRecord] instances without
   /// validation.

--- a/packages/health_connector_core/lib/src/models/health_records/blood_pressure/diastolic_blood_pressure_record.dart
+++ b/packages/health_connector_core/lib/src/models/health_records/blood_pressure/diastolic_blood_pressure_record.dart
@@ -37,6 +37,19 @@ part of '../health_record.dart';
 @supportedOnAppleHealth
 @immutable
 final class DiastolicBloodPressureRecord extends InstantHealthRecord {
+  /// Minimum valid diastolic blood pressure (30 mmHg).
+  static const Pressure minPressure = Pressure.millimetersOfMercury(30.0);
+
+  ///  Maximum valid diastolic blood pressure.
+  ///
+  /// Valid range: 10-300 mmHg for Android Health Connect SDK.
+  ///
+  /// ## Platform Compatibility
+  ///
+  /// - **Android Health Connect**: [BloodPressureRecord.kt](https://cs.android.com/androidx/platform/frameworks/support/+/androidx-main:health/connect/connect-client/src/main/java/androidx/health/connect/client/records/BloodPressureRecord.kt)
+  /// - **Apple HealthKit**: No platform limits (application-defined)
+  static const Pressure maxPressure = Pressure.millimetersOfMercury(300.0);
+
   /// Creates a diastolic blood pressure record.
   ///
   /// ## Parameters
@@ -48,7 +61,18 @@ final class DiastolicBloodPressureRecord extends InstantHealthRecord {
   /// - [pressure]: The diastolic blood pressure measurement.
   /// - [bodyPosition]: Optional body position during measurement.
   /// - [measurementLocation]: Optional location where measurement was taken.
-  const DiastolicBloodPressureRecord({
+  ///
+  /// ## Throws
+  ///
+  /// - [ArgumentError] if [pressure] is outside the valid range of
+  ///   [minPressure]-[maxPressure] mmHg.
+  ///
+  /// ## Validation Rationale
+  ///
+  /// - **Minimum (30 mmHg)**: Extreme hypotension threshold.
+  /// - **Maximum (150 mmHg)**: Severe hypertension; values above indicate
+  ///   critical medical condition.
+  DiastolicBloodPressureRecord({
     required super.time,
     required super.metadata,
     required this.pressure,
@@ -56,7 +80,18 @@ final class DiastolicBloodPressureRecord extends InstantHealthRecord {
     super.zoneOffsetSeconds,
     this.bodyPosition = BloodPressureBodyPosition.unknown,
     this.measurementLocation = BloodPressureMeasurementLocation.unknown,
-  });
+  }) {
+    require(
+      condition: pressure >= minPressure && pressure <= maxPressure,
+      value: pressure,
+      name: 'diastolic pressure',
+      message:
+          'Diastolic blood pressure must be between '
+          '${minPressure.inMillimetersOfMercury.toStringAsFixed(0)}-'
+          '${maxPressure.inMillimetersOfMercury.toStringAsFixed(0)} mmHg. '
+          'Got ${pressure.inMillimetersOfMercury.toStringAsFixed(0)} mmHg.',
+    );
+  }
 
   /// Internal factory for creating [DiastolicBloodPressureRecord] instances
   /// without

--- a/packages/health_connector_core/lib/src/models/health_records/blood_pressure/systolic_blood_pressure_record.dart
+++ b/packages/health_connector_core/lib/src/models/health_records/blood_pressure/systolic_blood_pressure_record.dart
@@ -37,6 +37,19 @@ part of '../health_record.dart';
 @supportedOnAppleHealth
 @immutable
 final class SystolicBloodPressureRecord extends InstantHealthRecord {
+  /// Minimum valid systolic blood pressure (50 mmHg).
+  static const Pressure minPressure = Pressure.millimetersOfMercury(50.0);
+
+  /// Maximum valid systolic blood pressure.
+  ///
+  /// Valid range: 20-300 mmHg for Android Health Connect.
+  ///
+  /// ## Platform Compatibility
+  ///
+  /// - **Android Health Connect**: [BloodPressureRecord.kt](https://cs.android.com/androidx/platform/frameworks/support/+/androidx-main:health/connect/connect-client/src/main/java/androidx/health/connect/client/records/BloodPressureRecord.kt)
+  /// - **Apple HealthKit**: No platform limits (application-defined)
+  static const Pressure maxPressure = Pressure.millimetersOfMercury(300.0);
+
   /// Creates a systolic blood pressure record.
   ///
   /// ## Parameters
@@ -48,7 +61,18 @@ final class SystolicBloodPressureRecord extends InstantHealthRecord {
   /// - [pressure]: The systolic blood pressure measurement.
   /// - [bodyPosition]: Optional body position during measurement.
   /// - [measurementLocation]: Optional location where measurement was taken.
-  const SystolicBloodPressureRecord({
+  ///
+  /// ## Throws
+  ///
+  /// - [ArgumentError] if [pressure] is outside the valid range of
+  ///   [minPressure]-[maxPressure] mmHg.
+  ///
+  /// ## Validation Rationale
+  ///
+  /// - **Minimum (50 mmHg)**: Severe hypotension/shock threshold.
+  /// - **Maximum (300 mmHg)**: Extreme hypertensive crisis; accommodates
+  ///   Health Connect SDK 17+ platform limit.
+  SystolicBloodPressureRecord({
     required super.time,
     required super.metadata,
     required this.pressure,
@@ -56,7 +80,18 @@ final class SystolicBloodPressureRecord extends InstantHealthRecord {
     super.zoneOffsetSeconds,
     this.bodyPosition = BloodPressureBodyPosition.unknown,
     this.measurementLocation = BloodPressureMeasurementLocation.unknown,
-  });
+  }) {
+    require(
+      condition: pressure >= minPressure && pressure <= maxPressure,
+      value: pressure,
+      name: 'systolic pressure',
+      message:
+          'Systolic blood pressure must be between '
+          '${minPressure.inMillimetersOfMercury.toStringAsFixed(0)}-'
+          '${maxPressure.inMillimetersOfMercury.toStringAsFixed(0)} mmHg. '
+          'Got ${pressure.inMillimetersOfMercury.toStringAsFixed(0)} mmHg.',
+    );
+  }
 
   /// Internal factory for creating [BloodPressureRecord] instances without
   /// validation.

--- a/packages/health_connector_core/lib/src/models/health_records/body_fat_percentage_record.dart
+++ b/packages/health_connector_core/lib/src/models/health_records/body_fat_percentage_record.dart
@@ -32,6 +32,17 @@ part of 'health_record.dart';
 @sinceV1_0_0
 @immutable
 final class BodyFatPercentageRecord extends InstantHealthRecord {
+  /// Minimum valid body fat percentage (2.0%).
+  ///
+  /// Essential fat minimum for males (~3-5%); 2% allows for extreme athletes
+  /// with measurement margins.
+  static const Percentage minPercentage = Percentage.fromWhole(2.0);
+
+  /// Maximum valid body fat percentage (65.0%).
+  ///
+  /// Severe obesity upper limit; typical max ~60% in medical literature.
+  static const Percentage maxPercentage = Percentage.fromWhole(65.0);
+
   /// Creates a body fat percentage record.
   ///
   /// ## Parameters
@@ -41,13 +52,36 @@ final class BodyFatPercentageRecord extends InstantHealthRecord {
   /// - [zoneOffsetSeconds]: Optional timezone offset for the measurement time.
   /// - [metadata]: Metadata about the origin and recording method.
   /// - [percentage]: The body fat percentage measurement (as decimal 0-1).
-  const BodyFatPercentageRecord({
+  ///
+  /// ## Throws
+  ///
+  /// - [ArgumentError] if [percentage] is outside the valid range of
+  ///   [minPercentage]-[maxPercentage]%.
+  ///
+  /// ## Validation Rationale
+  ///
+  /// - **Minimum ([minPercentage]%)**: Essential fat minimum for
+  ///   males (~3-5%); 2% allows for extreme athletes with measurement margins.
+  /// - **Maximum ([maxPercentage]%)**: Severe obesity upper limit; typical max
+  ///   ~60% in medical literature.
+  BodyFatPercentageRecord({
     required super.time,
     required super.metadata,
     required this.percentage,
     super.id,
     super.zoneOffsetSeconds,
-  });
+  }) {
+    require(
+      condition: percentage >= minPercentage && percentage <= maxPercentage,
+      value: percentage,
+      name: 'percentage',
+      message:
+          'Body fat must be between '
+          '${minPercentage.asWhole.toStringAsFixed(1)}-'
+          '${maxPercentage.asWhole.toStringAsFixed(0)}%. '
+          'Got ${percentage.asWhole.toStringAsFixed(1)}%.',
+    );
+  }
 
   /// Internal factory for creating [BodyFatPercentageRecord] instances
   /// without validation.

--- a/packages/health_connector_core/lib/src/models/health_records/body_mass_index_record.dart
+++ b/packages/health_connector_core/lib/src/models/health_records/body_mass_index_record.dart
@@ -30,6 +30,16 @@ part of 'health_record.dart';
 @supportedOnAppleHealth
 @immutable
 final class BodyMassIndexRecord extends InstantHealthRecord {
+  /// Minimum valid BMI (5.0 kg/m²).
+  ///
+  /// Severe malnutrition threshold (life-threatening below ~10 kg/m²).
+  static const Number minBmi = Number(5.0);
+
+  /// Maximum valid BMI (100.0 kg/m²).
+  ///
+  /// Extreme obesity (typical max ~85 kg/m² in medical literature).
+  static const Number maxBmi = Number(100.0);
+
   /// Creates a body mass index record.
   ///
   /// ## Parameters
@@ -42,7 +52,15 @@ final class BodyMassIndexRecord extends InstantHealthRecord {
   ///
   /// ## Throws
   ///
-  /// - [ArgumentError] if [bmi] is negative.
+  /// - [ArgumentError] if [bmi] is outside the valid range of
+  ///   [minBmi]-[maxBmi] kg/m².
+  ///
+  /// ## Validation Rationale
+  ///
+  /// - **Minimum ([minBmi] kg/m²)**: Severe malnutrition threshold (life-threatening
+  ///   below ~10 kg/m²).
+  /// - **Maximum ([maxBmi] kg/m²)**: Extreme obesity (typical max ~85 kg/m²
+  ///   in medical literature).
   BodyMassIndexRecord({
     required super.time,
     required super.metadata,
@@ -50,13 +68,14 @@ final class BodyMassIndexRecord extends InstantHealthRecord {
     super.id = HealthRecordId.none,
     super.zoneOffsetSeconds,
   }) {
-    if (bmi < Number.zero) {
-      throw ArgumentError.value(
-        bmi,
-        'bmi',
-        'Body mass index must be non-negative',
-      );
-    }
+    require(
+      condition: bmi >= minBmi && bmi <= maxBmi,
+      value: bmi,
+      name: 'bmi',
+      message:
+          'BMI must be between ${minBmi.value}-${maxBmi.value} kg/m². Got '
+          '${bmi.value.toStringAsFixed(1)} kg/m².',
+    );
   }
 
   /// Internal factory for creating [BodyMassIndexRecord] instances

--- a/packages/health_connector_core/lib/src/models/health_records/body_water_mass_record.dart
+++ b/packages/health_connector_core/lib/src/models/health_records/body_water_mass_record.dart
@@ -29,6 +29,20 @@ part of 'health_record.dart';
 @supportedOnHealthConnect
 @immutable
 final class BodyWaterMassRecord extends InstantHealthRecord {
+  /// Minimum valid body water mass in kilograms (0.3 kg).
+  ///
+  /// Premature infant (~0.5 kg total weight × 60% water).
+  /// Minimum valid body water mass (0.3 kg).
+  ///
+  /// Premature infant (~0.5 kg total weight × 60% water).
+  static const Mass minMass = Mass.kilograms(0.3);
+
+  /// Maximum valid body water mass (500.0 kg).
+  ///
+  /// Water typically 45-75% of body weight; max for very large individuals
+  /// (700 kg × 70%).
+  static const Mass maxMass = Mass.kilograms(500.0);
+
   /// Creates a body water mass record.
   ///
   /// ## Parameters
@@ -38,13 +52,37 @@ final class BodyWaterMassRecord extends InstantHealthRecord {
   /// - [metadata]: Metadata about the origin and recording method.
   /// - [id]: The unique identifier for this record.
   /// - [zoneOffsetSeconds]: Optional timezone offset for the measurement time.
-  const BodyWaterMassRecord({
+  ///
+  /// ## Throws
+  ///
+  /// - [ArgumentError] if [mass] is outside the valid range of
+  /// - [ArgumentError] if [mass] is outside the valid range of
+  ///   [minMass]-[maxMass] kg.
+  ///
+  /// ## Validation Rationale
+  ///
+  /// - **Minimum ([minMass] kg)**: Premature infant (~0.5 kg total
+  ///   weight × 60% water).
+  /// - **Maximum ([maxMass] kg)**: Water typically 45-75% of body weight;
+  ///   max for very large individuals (700 kg × 70%).
+  BodyWaterMassRecord({
     required super.time,
     required super.metadata,
     required this.mass,
     super.id,
     super.zoneOffsetSeconds,
-  });
+  }) {
+    require(
+      condition: mass >= minMass && mass <= maxMass,
+      value: mass,
+      name: 'mass',
+      message:
+          'Body water mass must be between '
+          '${minMass.inKilograms.toStringAsFixed(1)}-'
+          '${maxMass.inKilograms.toStringAsFixed(0)} kg. '
+          'Got ${mass.inKilograms.toStringAsFixed(1)} kg.',
+    );
+  }
 
   /// Internal factory for creating [BodyWaterMassRecord] instances
   /// without validation.

--- a/packages/health_connector_core/lib/src/models/health_records/bone_mass_record.dart
+++ b/packages/health_connector_core/lib/src/models/health_records/bone_mass_record.dart
@@ -28,6 +28,20 @@ part of 'health_record.dart';
 @supportedOnHealthConnect
 @immutable
 final class BoneMassRecord extends InstantHealthRecord {
+  /// Minimum valid bone mass in kilograms (0.1 kg).
+  ///
+  /// Very young infants; typical newborn skeleton ~300-400g.
+  /// Minimum valid bone mass (0.1 kg).
+  ///
+  /// Very young infants; typical newborn skeleton ~300-400g.
+  static const Mass minMass = Mass.kilograms(0.1);
+
+  /// Maximum valid bone mass (15.0 kg).
+  ///
+  /// Extreme upper limit; typical adult bone mass 2-6 kg depending on body
+  /// size.
+  static const Mass maxMass = Mass.kilograms(15.0);
+
   /// Creates a bone mass record.
   ///
   /// ## Parameters
@@ -37,13 +51,37 @@ final class BoneMassRecord extends InstantHealthRecord {
   /// - [metadata]: Metadata about the origin and recording method.
   /// - [id]: The unique identifier for this record.
   /// - [zoneOffsetSeconds]: Optional timezone offset for the measurement time.
-  const BoneMassRecord({
+  ///
+  /// ## Throws
+  ///
+  /// - [ArgumentError] if [mass] is outside the valid range of
+  /// - [ArgumentError] if [mass] is outside the valid range of
+  ///   [minMass]-[maxMass] kg.
+  ///
+  /// ## Validation Rationale
+  ///
+  /// - **Minimum ([minMass] kg)**: Very young infants; typical newborn
+  ///   skeleton ~300-400g.
+  /// - **Maximum ([maxMass] kg)**: Extreme upper limit; typical adult bone
+  ///   mass 2-6 kg depending on body size.
+  BoneMassRecord({
     required super.time,
     required super.metadata,
     required this.mass,
     super.id,
     super.zoneOffsetSeconds,
-  });
+  }) {
+    require(
+      condition: mass >= minMass && mass <= maxMass,
+      value: mass,
+      name: 'mass',
+      message:
+          'Bone mass must be between '
+          '${minMass.inKilograms.toStringAsFixed(1)}-'
+          '${maxMass.inKilograms.toStringAsFixed(0)} kg. '
+          'Got ${mass.inKilograms.toStringAsFixed(1)} kg.',
+    );
+  }
 
   /// Internal factory for creating [BoneMassRecord] instances
   /// without validation.

--- a/packages/health_connector_core/lib/src/models/health_records/cycling_pedaling_cadence/cycling_pedaling_cadence_record.dart
+++ b/packages/health_connector_core/lib/src/models/health_records/cycling_pedaling_cadence/cycling_pedaling_cadence_record.dart
@@ -7,7 +7,8 @@ part of '../health_record.dart';
 ///
 /// ## Platform Mapping
 ///
-/// - **Android Health Connect**: Not supported  (Use [CyclingPedalingCadenceSeriesRecord])
+/// - **Android Health Connect**: Not supported. Use
+///   [CyclingPedalingCadenceSeriesRecord] instead.
 /// - **iOS HealthKit**:  [`HKQuantityTypeIdentifier.cyclingCadence`](https://developer.apple.com/documentation/healthkit/hkquantitytypeidentifier/cyclingcadence)
 ///
 /// ## Example
@@ -32,15 +33,48 @@ part of '../health_record.dart';
 @supportedOnAppleHealth
 @immutable
 final class CyclingPedalingCadenceRecord extends InstantHealthRecord {
+  /// Minimum valid cycling cadence (0.0 RPM).
+  ///
+  /// Not pedaling (coasting).
+  static final Frequency minCadence = Frequency.perMinute(0.0);
+
+  /// Maximum valid cycling cadence (200.0 RPM).
+  ///
+  /// Typical cadence 60-100 RPM; elite cyclists ~120 RPM; 200 RPM allows for
+  /// brief sprint peaks.
+  static final Frequency maxCadence = Frequency.perMinute(200.0);
+
   /// Creates a cycling pedaling cadence measurement record.
-  /// Creates a cycling pedaling cadence measurement record.
-  const CyclingPedalingCadenceRecord({
+  ///
+  /// ## Throws
+  ///
+  /// - [ArgumentError] if [cadence] is outside the valid range of
+  /// - [ArgumentError] if [cadence] is outside the valid range of
+  ///   [minCadence]-[maxCadence] RPM.
+  ///
+  /// ## Validation Rationale
+  ///
+  /// - **Minimum ([minCadence] RPM)**: Not pedaling (coasting).
+  /// - **Maximum ([maxCadence] RPM)**: Typical cadence 60-100 RPM; elite
+  ///   cyclists ~120 RPM; 200 RPM allows for brief sprint peaks.
+  CyclingPedalingCadenceRecord({
     required super.id,
     required this.cadence,
     required super.time,
     required super.metadata,
     super.zoneOffsetSeconds,
-  });
+  }) {
+    require(
+      condition: cadence >= minCadence && cadence <= maxCadence,
+      value: cadence,
+      name: 'cadence',
+      message:
+          'Cycling cadence must be between '
+          '${minCadence.inPerMinute.toStringAsFixed(0)}-'
+          '${maxCadence.inPerMinute.toStringAsFixed(0)} RPM. '
+          'Got ${cadence.inPerMinute.toStringAsFixed(0)} RPM.',
+    );
+  }
 
   /// Internal factory for creating [CyclingPedalingCadenceRecord] instances
   /// without validation.

--- a/packages/health_connector_core/lib/src/models/health_records/cycling_pedaling_cadence/cycling_pedaling_cadence_series_record.dart
+++ b/packages/health_connector_core/lib/src/models/health_records/cycling_pedaling_cadence/cycling_pedaling_cadence_series_record.dart
@@ -199,11 +199,39 @@ final class CyclingPedalingCadenceSeriesRecord
 /// {@category Health Records}
 @immutable
 final class CyclingPedalingCadenceSample {
+  /// Minimum valid cycling cadence.
+  static final Frequency minCadence = CyclingPedalingCadenceRecord.minCadence;
+
+  /// Maximum valid cycling cadence.
+  static final Frequency maxCadence = CyclingPedalingCadenceRecord.maxCadence;
+
   /// Creates a cycling pedaling cadence measurement.
-  const CyclingPedalingCadenceSample({
+  ///
+  /// ## Throws
+  ///
+  /// - [ArgumentError] if [cadence] is outside the valid range of
+  ///   [minCadence]-[maxCadence] RPM.
+  ///
+  /// ## Validation Rationale
+  ///
+  /// - **Minimum ([minCadence] RPM)**: Not pedaling (coasting).
+  /// - **Maximum ([maxCadence] RPM)**: Typical cadence 60-100 RPM; elite
+  ///   cyclists ~120 RPM; 200 RPM allows for brief sprint peaks.
+  CyclingPedalingCadenceSample({
     required this.time,
     required this.cadence,
-  });
+  }) {
+    require(
+      condition: cadence >= minCadence && cadence <= maxCadence,
+      value: cadence,
+      name: 'cadence',
+      message:
+          'Cycling cadence must be between '
+          '${minCadence.inPerMinute.toStringAsFixed(0)}-'
+          '${maxCadence.inPerMinute.toStringAsFixed(0)} RPM. '
+          'Got ${cadence.inPerMinute.toStringAsFixed(0)} RPM.',
+    );
+  }
 
   /// The timestamp when this cadence measurement was taken, stored as a
   /// UTC instant.

--- a/packages/health_connector_core/lib/src/models/health_records/distance/distance_activity_record.dart
+++ b/packages/health_connector_core/lib/src/models/health_records/distance/distance_activity_record.dart
@@ -32,6 +32,12 @@ part of '../health_record.dart';
 @internalUse
 @immutable
 sealed class DistanceActivityRecord extends IntervalHealthRecord {
+  /// Minimum valid distance.
+  static const Length minDistance = DistanceRecord.minDistance;
+
+  /// Maximum valid distance.
+  static const Length maxDistance = DistanceRecord.maxDistance;
+
   /// Creates a distance activity record.
   DistanceActivityRecord({
     required super.startTime,
@@ -41,7 +47,18 @@ sealed class DistanceActivityRecord extends IntervalHealthRecord {
     super.id = HealthRecordId.none,
     super.startZoneOffsetSeconds,
     super.endZoneOffsetSeconds,
-  });
+  }) {
+    require(
+      condition: distance >= minDistance && distance <= maxDistance,
+      value: distance,
+      name: 'distance',
+      message:
+          'Distance must be between '
+          '${minDistance.inKilometers.toStringAsFixed(0)}-'
+          '${maxDistance.inKilometers.toStringAsFixed(0)} km. '
+          'Got ${distance.inKilometers.toStringAsFixed(1)} km.',
+    );
+  }
 
   /// The distance measurement value.
   final Length distance;

--- a/packages/health_connector_core/lib/src/models/health_records/distance/distance_record.dart
+++ b/packages/health_connector_core/lib/src/models/health_records/distance/distance_record.dart
@@ -28,6 +28,15 @@ part of '../health_record.dart';
 @supportedOnHealthConnect
 @immutable
 final class DistanceRecord extends IntervalHealthRecord {
+  /// Minimum valid distance (0.0 km).
+  static const Length minDistance = Length.zero;
+
+  /// Maximum valid distance (1,000.0 km).
+  ///
+  /// Ultra-endurance events (e.g., multi-day races, cycling tours) can exceed
+  /// 500 km; 1,000 km allows for aggregated data.
+  static const Length maxDistance = Length.kilometers(1000.0);
+
   /// Creates a distance record.
   ///
   /// ## Parameters
@@ -43,6 +52,15 @@ final class DistanceRecord extends IntervalHealthRecord {
   /// ## Throws
   ///
   /// - [ArgumentError] if [endTime] is not after [startTime].
+  /// - [ArgumentError] if [distance] is outside the valid range of
+  ///   [minDistance]-[maxDistance] km.
+  ///
+  /// ## Validation Rationale
+  ///
+  /// - **Minimum ([minDistance] km)**: No distance during the interval.
+  /// - **Maximum ([maxDistance] km)**: Ultra-endurance events (e.g.,
+  ///   multi-day races, cycling tours) can exceed 500 km; 1,000 km allows for
+  ///   aggregated data.
   DistanceRecord({
     required super.startTime,
     required super.endTime,
@@ -51,7 +69,18 @@ final class DistanceRecord extends IntervalHealthRecord {
     super.id = HealthRecordId.none,
     super.startZoneOffsetSeconds,
     super.endZoneOffsetSeconds,
-  });
+  }) {
+    require(
+      condition: distance >= minDistance && distance <= maxDistance,
+      value: distance,
+      name: 'distance',
+      message:
+          'Distance must be between '
+          '${minDistance.inKilometers.toStringAsFixed(0)}-'
+          '${maxDistance.inKilometers.toStringAsFixed(0)} km. '
+          'Got ${distance.inKilometers.toStringAsFixed(1)} km.',
+    );
+  }
 
   /// Internal factory for creating [DistanceRecord] instances
   /// without validation.

--- a/packages/health_connector_core/lib/src/models/health_records/energy_burned/active_energy_burned_record.dart
+++ b/packages/health_connector_core/lib/src/models/health_records/energy_burned/active_energy_burned_record.dart
@@ -32,6 +32,17 @@ part of '../health_record.dart';
 @sinceV1_0_0
 @immutable
 final class ActiveEnergyBurnedRecord extends IntervalHealthRecord {
+  /// Minimum valid active energy burned (0.0 kcal).
+  ///
+  /// No active energy burned.
+  static const Energy minEnergy = Energy.zero;
+
+  /// Maximum valid active energy burned (15,000.0 kcal).
+  ///
+  /// Ultra-endurance events (e.g., multi-day races) can exceed 10,000 kcal/day;
+  /// 15,000 provides margin.
+  static const Energy maxEnergy = Energy.kilocalories(15000.0);
+
   /// Creates an active energy burned record.
   ///
   /// ## Parameters
@@ -47,6 +58,14 @@ final class ActiveEnergyBurnedRecord extends IntervalHealthRecord {
   /// ## Throws
   ///
   /// - [ArgumentError] if [endTime] is not after [startTime].
+  /// - [ArgumentError] if [energy] is outside the valid range of
+  ///   [minEnergy]-[maxEnergy] kcal.
+  ///
+  /// ## Validation Rationale
+  ///
+  /// - **Minimum ([minEnergy] kcal)**: No active energy burned.
+  /// - **Maximum ([maxEnergy] kcal)**: Ultra-endurance events (e.g.,
+  ///   multi-day races) can exceed 10,000 kcal/day; 15,000 provides margin.
   ActiveEnergyBurnedRecord({
     required super.startTime,
     required super.endTime,
@@ -55,7 +74,18 @@ final class ActiveEnergyBurnedRecord extends IntervalHealthRecord {
     super.id = HealthRecordId.none,
     super.startZoneOffsetSeconds,
     super.endZoneOffsetSeconds,
-  });
+  }) {
+    require(
+      condition: energy >= minEnergy && energy <= maxEnergy,
+      value: energy,
+      name: 'energy',
+      message:
+          'Active energy burned must be between '
+          '${minEnergy.inKilocalories.toStringAsFixed(0)}-'
+          '${maxEnergy.inKilocalories.toStringAsFixed(0)} kcal. '
+          'Got ${energy.inKilocalories.toStringAsFixed(0)} kcal.',
+    );
+  }
 
   /// Internal factory for creating [ActiveEnergyBurnedRecord] instances without
   /// validation.

--- a/packages/health_connector_core/lib/src/models/health_records/energy_burned/basal_energy_burned_record.dart
+++ b/packages/health_connector_core/lib/src/models/health_records/energy_burned/basal_energy_burned_record.dart
@@ -36,6 +36,17 @@ part of '../health_record.dart';
 @supportedOnAppleHealth
 @immutable
 final class BasalEnergyBurnedRecord extends IntervalHealthRecord {
+  /// Minimum valid basal energy burned (0.0 kcal).
+  ///
+  /// No basal energy during measurement period.
+  static const Energy minEnergy = Energy.zero;
+
+  /// Maximum valid basal energy burned (5,000.0 kcal).
+  ///
+  /// Typical BMR ~300-3,000 kcal/day; 5,000 allows for large individuals and
+  /// multi-day intervals.
+  static const Energy maxEnergy = Energy.kilocalories(5000.0);
+
   /// Creates a basal energy burned record.
   ///
   /// ## Parameters
@@ -51,6 +62,15 @@ final class BasalEnergyBurnedRecord extends IntervalHealthRecord {
   /// ## Throws
   ///
   /// - [ArgumentError] if [endTime] is not after [startTime].
+  /// - [ArgumentError] if [energy] is outside the valid range of
+  ///   [minEnergy]-[maxEnergy] kcal.
+  ///
+  /// ## Validation Rationale
+  ///
+  /// - **Minimum ([minEnergy] kcal)**: No basal energy during measurement
+  ///   period.
+  /// - **Maximum ([maxEnergy] kcal)**: Typical BMR ~300-3,000 kcal/day;
+  ///   5,000 allows for large individuals and multi-day intervals.
   BasalEnergyBurnedRecord({
     required super.startTime,
     required super.endTime,
@@ -59,7 +79,18 @@ final class BasalEnergyBurnedRecord extends IntervalHealthRecord {
     super.id = HealthRecordId.none,
     super.startZoneOffsetSeconds,
     super.endZoneOffsetSeconds,
-  });
+  }) {
+    require(
+      condition: energy >= minEnergy && energy <= maxEnergy,
+      value: energy,
+      name: 'energy',
+      message:
+          'Basal energy burned must be between '
+          '${minEnergy.inKilocalories.toStringAsFixed(0)}-'
+          '${maxEnergy.inKilocalories.toStringAsFixed(0)} kcal. '
+          'Got ${energy.inKilocalories.toStringAsFixed(0)} kcal.',
+    );
+  }
 
   /// Internal factory for creating [BasalEnergyBurnedRecord] instances without
   /// validation.

--- a/packages/health_connector_core/lib/src/models/health_records/energy_burned/total_energy_burned_record.dart
+++ b/packages/health_connector_core/lib/src/models/health_records/energy_burned/total_energy_burned_record.dart
@@ -37,13 +37,24 @@ part of '../health_record.dart';
 @supportedOnHealthConnect
 @immutable
 final class TotalEnergyBurnedRecord extends IntervalHealthRecord {
+  /// Minimum valid total energy burned (0.0 kcal).
+  ///
+  /// No energy burned during measurement period.
+  static const Energy minEnergy = Energy.zero;
+
+  /// Maximum valid total energy burned (20,000.0 kcal).
+  ///
+  /// Sum of active (max 15,000) + basal (max 5,000) energy with margin for
+  /// extreme multi-day events.
+  static const Energy maxEnergy = Energy.kilocalories(20000.0);
+
   /// Creates a total energy burned record.
   ///
   /// ## Parameters
   ///
   /// - [startTime]: The start of the time interval (inclusive).
   /// - [endTime]: The end of the time interval (exclusive).
-  /// - [energy]: The total amount of energy/energy burned during the interval.
+  /// - [energy]: The total amount of energy burned during the interval.
   /// - [metadata]: Metadata about the origin and recording method.
   /// - [id]: The unique identifier for this record.
   /// - [startZoneOffsetSeconds]: Optional timezone offset for start time.
@@ -52,6 +63,15 @@ final class TotalEnergyBurnedRecord extends IntervalHealthRecord {
   /// ## Throws
   ///
   /// - [ArgumentError] if [endTime] is not after [startTime].
+  /// - [ArgumentError] if [energy] is outside the valid range of
+  ///   [minEnergy]-[maxEnergy] kcal.
+  ///
+  /// ## Validation Rationale
+  ///
+  /// - **Minimum ([minEnergy] kcal)**: No energy burned during measurement
+  ///   period.
+  /// - **Maximum ([maxEnergy] kcal)**: Sum of active (max 15,000) +
+  ///   basal (max 5,000) energy with margin for extreme multi-day events.
   TotalEnergyBurnedRecord({
     required super.startTime,
     required super.endTime,
@@ -60,18 +80,30 @@ final class TotalEnergyBurnedRecord extends IntervalHealthRecord {
     super.id = HealthRecordId.none,
     super.startZoneOffsetSeconds,
     super.endZoneOffsetSeconds,
-  });
+  }) {
+    require(
+      condition: energy >= minEnergy && energy <= maxEnergy,
+      value: energy,
+      name: 'energy',
+      message:
+          'Total energy burned must be between '
+          '${minEnergy.inKilocalories.toStringAsFixed(0)}-'
+          '${maxEnergy.inKilocalories.toStringAsFixed(0)} kcal. '
+          'Got ${energy.inKilocalories.toStringAsFixed(0)} kcal.',
+    );
+  }
 
-  /// Internal factory for creating [BloodPressureRecord] instances without
+  /// Internal factory for creating [TotalEnergyBurnedRecord] instances without
   /// validation.
   ///
-  /// Creates a [BloodPressureRecord] by directly mapping platform data to
+  /// Creates a [TotalEnergyBurnedRecord] by directly mapping platform data to
   /// fields, bypassing the normal validation and business rules applied by the
   /// public constructor.
   ///
   /// **⚠️ Warning**: Not for public use. SDK users should use the public
-  /// [BloodPressureRecord] constructor, which enforces validation and business
-  /// rules. This factory is restricted to the SDK developers and contributors.
+  /// [TotalEnergyBurnedRecord] constructor, which enforces validation and
+  /// business rules. This factory is restricted to the SDK developers and
+  /// contributors.
   @internalUse
   factory TotalEnergyBurnedRecord.internal({
     required HealthRecordId id,

--- a/packages/health_connector_core/lib/src/models/health_records/exercise/exercise_session_record.dart
+++ b/packages/health_connector_core/lib/src/models/health_records/exercise/exercise_session_record.dart
@@ -59,16 +59,17 @@ final class ExerciseSessionRecord extends IntervalHealthRecord {
     this.notes,
   });
 
-  /// Internal factory for creating [BloodPressureRecord] instances without
+  /// Internal factory for creating [ExerciseSessionRecord] instances without
   /// validation.
   ///
-  /// Creates a [BloodPressureRecord] by directly mapping platform data to
+  /// Creates a [ExerciseSessionRecord] by directly mapping platform data to
   /// fields, bypassing the normal validation and business rules applied by the
   /// public constructor.
   ///
   /// **⚠️ Warning**: Not for public use. SDK users should use the public
-  /// [BloodPressureRecord] constructor, which enforces validation and business
-  /// rules. This factory is restricted to the SDK developers and contributors.
+  /// [ExerciseSessionRecord] constructor, which enforces validation and
+  /// business rules. This factory is restricted to the SDK developers and
+  /// contributors.
   @internalUse
   factory ExerciseSessionRecord.internal({
     required HealthRecordId id,

--- a/packages/health_connector_core/lib/src/models/health_records/exercise/exercise_type.dart
+++ b/packages/health_connector_core/lib/src/models/health_records/exercise/exercise_type.dart
@@ -7,7 +7,8 @@ part of '../health_record.dart';
 ///
 /// ## Platform Mapping
 ///
-/// - **Android Health Connect**: Maps to  `ExerciseSessionRecord.EXERCISE_TYPE_*` constants
+/// - **Android Health Connect**: Maps to
+///   `ExerciseSessionRecord.EXERCISE_TYPE_*` constants
 /// - **iOS HealthKit**: Maps to `HKWorkoutActivityType` enum values
 ///
 /// ## Cross-Platform Types
@@ -122,7 +123,8 @@ enum ExerciseType {
   ///
   /// **Platform Mappings:**
   /// - **iOS HealthKit**: `HKWorkoutActivityType.swimming`
-  /// - **Android Health Connect**: Not supported  (Use `swimmingPool` or `swimmingOpenWater`)
+  /// - **Android Health Connect**: Not supported  (Use `swimmingPool` or
+  /// `swimmingOpenWater`)
   ///
   /// Throws [UnsupportedOperationException] on Android Health Connect.
   @supportedOnAppleHealth
@@ -222,7 +224,7 @@ enum ExerciseType {
   /// General strength training activity.
   ///
   /// **Platform Mappings:**
-  /// - **iOS HealthKit**: `HKWorkoutActivityType.traditionalStrengthTraining`  or `.functionalStrengthTraining`
+  /// - **iOS HealthKit**: `HKWorkoutActivityType.traditionalStrengthTraining`
   /// - **Android Health Connect**: `EXERCISE_TYPE_STRENGTH_TRAINING`
   strengthTraining,
 
@@ -436,7 +438,8 @@ enum ExerciseType {
   /// Skiing activity (downhill, cross-country).
   ///
   /// **Platform Mappings:**
-  /// - **iOS HealthKit**: Not supported  (See `crossCountrySkiing` or `downhillSkiing`)
+  /// - **iOS HealthKit**: Not supported. Use [crossCountrySkiing] or
+  ///   [downhillSkiing] instead.
   /// - **Android Health Connect**: `EXERCISE_TYPE_SKIING`
   ///
   /// Throws [UnsupportedOperationException] on iOS HealthKit.
@@ -640,7 +643,8 @@ enum ExerciseType {
   ///
   /// **Platform Mappings:**
   /// - **iOS HealthKit**: `HKWorkoutActivityType.highIntensityIntervalTraining`
-  /// - **Android Health Connect**:  `EXERCISE_TYPE_HIGH_INTENSITY_INTERVAL_TRAINING`
+  /// - **Android Health Connect**:
+  ///   `EXERCISE_TYPE_HIGH_INTENSITY_INTERVAL_TRAINING`
   highIntensityIntervalTraining,
 
   /// Elliptical trainer machine exercise.
@@ -673,7 +677,7 @@ enum ExerciseType {
   /// Guided breathing session.
   ///
   /// **Platform Mappings:**
-  /// - **iOS HealthKit**: `HKCategoryTypeIdentifier.mindfulSession`  (Not workout)
+  /// - **iOS HealthKit**: `HKCategoryTypeIdentifier.mindfulSession`
   /// - **Android Health Connect**: `EXERCISE_TYPE_GUIDED_BREATHING`
   ///
   /// Throws [UnsupportedOperationException] on iOS HealthKit.
@@ -685,8 +689,9 @@ enum ExerciseType {
   /// Includes climbing real stairs, stair stepper machines, and stair climbers.
   ///
   /// **Platform Mappings:**
-  /// - **iOS HealthKit**: `HKWorkoutActivityType.stairs` or `.stairClimbing`
-  /// - **Android Health Connect**:  `ExerciseSessionRecord.EXERCISE_TYPE_STAIR_CLIMBING`
+  /// - **iOS HealthKit**: `HKWorkoutActivityType.stairClimbing`
+  /// - **Android Health Connect**:
+  ///   `ExerciseSessionRecord.EXERCISE_TYPE_STAIR_CLIMBING`
   ///
   /// **Note:** This unified type covers both real stairs and stair climbing
   /// machines.

--- a/packages/health_connector_core/lib/src/models/health_records/floors_climbed_record.dart
+++ b/packages/health_connector_core/lib/src/models/health_records/floors_climbed_record.dart
@@ -32,6 +32,20 @@ part of 'health_record.dart';
 @sinceV1_0_0
 @immutable
 final class FloorsClimbedRecord extends IntervalHealthRecord {
+  /// Minimum valid floors climbed (0.0).
+  ///
+  /// No floors climbed during the interval.
+  /// Minimum valid floors climbed (0).
+  ///
+  /// No floors climbed during the interval.
+  static const Number minFloors = Number.zero;
+
+  /// Maximum valid floors climbed (1,000).
+  ///
+  /// Typical max ~50 floors/day; 1,000 allows for multi-day intervals and
+  /// extreme cases.
+  static const Number maxFloors = Number(1000);
+
   /// Creates a floors climbed record.
   ///
   /// ## Parameters
@@ -47,6 +61,14 @@ final class FloorsClimbedRecord extends IntervalHealthRecord {
   /// ## Throws
   ///
   /// - [ArgumentError] if [endTime] is not after [startTime].
+  /// - [ArgumentError] if [count] is outside the valid range of
+  ///   [minFloors]-[maxFloors].
+  ///
+  /// ## Validation Rationale
+  ///
+  /// - **Minimum ([minFloors])**: No floors climbed during the interval.
+  /// - **Maximum ([maxFloors])**: Typical max ~50 floors/day; 1,000 allows for
+  ///   multi-day intervals and extreme cases.
   FloorsClimbedRecord({
     required super.startTime,
     required super.endTime,
@@ -55,7 +77,17 @@ final class FloorsClimbedRecord extends IntervalHealthRecord {
     super.id = HealthRecordId.none,
     super.startZoneOffsetSeconds,
     super.endZoneOffsetSeconds,
-  });
+  }) {
+    require(
+      condition: count >= minFloors && count <= maxFloors,
+      value: count,
+      name: 'count',
+      message:
+          'Floors climbed must be between '
+          '${minFloors.value.toInt()}-${maxFloors.value.toInt()}. '
+          'Got ${count.value.toInt()} floors.',
+    );
+  }
 
   /// Internal factory for creating [BloodPressureRecord] instances without
   /// validation.

--- a/packages/health_connector_core/lib/src/models/health_records/heart_rate/heart_rate_record.dart
+++ b/packages/health_connector_core/lib/src/models/health_records/heart_rate/heart_rate_record.dart
@@ -34,6 +34,26 @@ part of '../health_record.dart';
 @supportedOnAppleHealth
 @immutable
 final class HeartRateRecord extends InstantHealthRecord {
+  /// Minimum valid heart rate in beats per minute.
+  ///
+  /// Valid range: 1-300 bpm, as enforced by Android Health Connect.
+  ///
+  /// ## Platform Compatibility
+  ///
+  /// - **Android Health Connect**: [HeartRateRecord.kt](https://cs.android.com/androidx/platform/frameworks/support/+/androidx-main:health/connect/connect-client/src/main/java/androidx/health/connect/client/records/HeartRateRecord.kt)
+  /// - **Apple HealthKit**: No platform limits (application-defined)
+  static final Frequency minRate = Frequency.perMinute(1.0);
+
+  /// Maximum valid heart rate in beats per minute.
+  ///
+  /// Valid range: 1-300 bpm, as enforced by Android Health Connect.
+  ///
+  /// ## Platform Compatibility
+  ///
+  /// - **Android Health Connect**: [HeartRateRecord.kt](https://cs.android.com/androidx/platform/frameworks/support/+/androidx-main:health/connect/connect-client/src/main/java/androidx/health/connect/client/records/HeartRateRecord.kt)
+  /// - **Apple HealthKit**: No platform limits (application-defined)
+  static final Frequency maxRate = Frequency.perMinute(300.0);
+
   /// Creates a heart rate measurement record.
   ///
   /// ## Parameters
@@ -43,13 +63,36 @@ final class HeartRateRecord extends InstantHealthRecord {
   /// - [zoneOffsetSeconds]: Optional timezone offset for the measurement time.
   /// - [metadata]: Metadata about the origin and recording method.
   /// - [rate]: The heart rate value in beats per minute (BPM).
-  const HeartRateRecord({
+  ///
+  /// ## Throws
+  ///
+  /// - [ArgumentError] if [rate] is outside the valid range of
+  ///   [minRate]-[maxRate].
+  ///
+  /// ## Validation Rationale
+  ///
+  /// - **Minimum ([minRate])**: 1 bpm allows for extreme bradycardia and
+  ///   ensures all Health Connect data can be processed.
+  /// - **Maximum ([maxRate])**: 300 bpm accommodates extreme tachycardia,
+  ///   stress test conditions, and sensor artifacts.
+  HeartRateRecord({
     required super.id,
     required super.time,
     required super.metadata,
     required this.rate,
     super.zoneOffsetSeconds,
-  });
+  }) {
+    require(
+      condition: rate >= minRate && rate <= maxRate,
+      value: rate,
+      name: 'rate',
+      message:
+          'Heart rate must be between '
+          '${minRate.inPerMinute.toStringAsFixed(0)}-'
+          '${maxRate.inPerMinute.toStringAsFixed(0)} bpm. '
+          'Got ${rate.inPerMinute.toStringAsFixed(1)} bpm.',
+    );
+  }
 
   /// Internal factory for creating [HeartRateRecord] instances
   /// without validation.

--- a/packages/health_connector_core/lib/src/models/health_records/heart_rate/heart_rate_series_record.dart
+++ b/packages/health_connector_core/lib/src/models/health_records/heart_rate/heart_rate_series_record.dart
@@ -199,11 +199,45 @@ final class HeartRateSeriesRecord extends SeriesHealthRecord<HeartRateSample> {
 /// {@category Health Records}
 @immutable
 final class HeartRateSample {
+  /// Minimum valid heart rate in beats per minute.
+  static final Frequency minRate = HeartRateRecord.minRate;
+
+  /// Maximum valid heart rate in beats per minute.
+  static final Frequency maxRate = HeartRateRecord.maxRate;
+
   /// Creates a heart rate measurement.
-  const HeartRateSample({
+  ///
+  /// ## Parameters
+  ///
+  /// - [time]: The timestamp when the heart rate was measured.
+  /// - [rate]: The heart rate value in beats per minute (BPM).
+  ///
+  /// ## Throws
+  ///
+  /// - [ArgumentError] if [rate] is outside the valid range of
+  ///   [minRate]-[maxRate].
+  ///
+  /// ## Validation Rationale
+  ///
+  /// - **Minimum ([minRate])**: Elite endurance athletes have
+  ///   documented resting heart rates as low as 27-32 bpm.
+  /// - **Maximum ([maxRate])**: Exceeds the theoretical maximum
+  ///   (220 - age) to accommodate young individuals and measurement artifacts.
+  HeartRateSample({
     required this.time,
     required this.rate,
-  });
+  }) {
+    require(
+      condition: rate >= minRate && rate <= maxRate,
+      value: rate,
+      name: 'rate',
+      message:
+          'Heart rate must be between '
+          '${minRate.inPerMinute.toStringAsFixed(0)}-'
+          '${maxRate.inPerMinute.toStringAsFixed(0)} bpm. '
+          'Got ${rate.inPerMinute.toStringAsFixed(1)} bpm.',
+    );
+  }
 
   /// The timestamp when this heart rate measurement was taken, stored as a
   /// UTC instant.

--- a/packages/health_connector_core/lib/src/models/health_records/heart_rate/heart_rate_variability_rmssd_record.dart
+++ b/packages/health_connector_core/lib/src/models/health_records/heart_rate/heart_rate_variability_rmssd_record.dart
@@ -30,6 +30,18 @@ part of '../health_record.dart';
 @supportedOnHealthConnect
 @immutable
 final class HeartRateVariabilityRMSSDRecord extends InstantHealthRecord {
+  /// Minimum valid HRV RMSSD in milliseconds (1.0 ms).
+  ///
+  /// Practical lower limit; values near zero indicate measurement error or
+  /// severe pathology.
+  static const double minRmssdMs = 1.0;
+
+  /// Maximum valid HRV RMSSD in milliseconds (250.0 ms).
+  ///
+  /// Research consensus indicates 5-200 ms typical range; 250 ms provides
+  /// margin for exceptional parasympathetic tone.
+  static const double maxRmssdMs = 250.0;
+
   /// Creates a heart rate variability (RMSSD) record.
   ///
   /// ## Parameters
@@ -42,7 +54,16 @@ final class HeartRateVariabilityRMSSDRecord extends InstantHealthRecord {
   ///
   /// ## Throws
   ///
-  /// - [ArgumentError] if [rmssd] is negative.
+  /// - [ArgumentError] if [rmssd] is outside the valid range of
+  ///   [minRmssdMs]-[maxRmssdMs] ms.
+  ///
+  /// ## Validation Rationale
+  ///
+  /// - **Minimum ([minRmssdMs] ms)**: Practical lower limit; values near zero
+  ///   indicate measurement error or severe pathology.
+  /// - **Maximum ([maxRmssdMs] ms)**: Research consensus indicates 5-200 ms
+  ///   typical range; 250 ms provides margin for exceptional parasympathetic
+  ///   tone.
   HeartRateVariabilityRMSSDRecord({
     required super.time,
     required super.metadata,
@@ -50,25 +71,29 @@ final class HeartRateVariabilityRMSSDRecord extends InstantHealthRecord {
     super.id = HealthRecordId.none,
     super.zoneOffsetSeconds,
   }) {
-    if (rmssd < TimeDuration.zero) {
-      throw ArgumentError.value(
-        rmssd,
-        'RMSSD',
-        'Heart rate variability RMSSD must be non-negative',
-      );
-    }
+    final ms = rmssd.inMilliseconds;
+    require(
+      condition: ms >= minRmssdMs && ms <= maxRmssdMs,
+      value: rmssd,
+      name: 'rmssd',
+      message:
+          'HRV RMSSD must be between '
+          '$minRmssdMs-${maxRmssdMs.toStringAsFixed(0)} ms. '
+          'Got ${ms.toStringAsFixed(1)} ms.',
+    );
   }
 
-  /// Internal factory for creating [BloodPressureRecord] instances without
-  /// validation.
+  /// Internal factory for creating [HeartRateVariabilityRMSSDRecord] instances
+  /// without validation.
   ///
-  /// Creates a [BloodPressureRecord] by directly mapping platform data to
-  /// fields, bypassing the normal validation and business rules applied by the
-  /// public constructor.
+  /// Creates a [HeartRateVariabilityRMSSDRecord] by directly mapping platform
+  /// data to fields, bypassing the normal validation and business rules
+  /// applied by the public constructor.
   ///
   /// **⚠️ Warning**: Not for public use. SDK users should use the public
-  /// [BloodPressureRecord] constructor, which enforces validation and business
-  /// rules. This factory is restricted to the SDK developers and contributors.
+  /// [HeartRateVariabilityRMSSDRecord] constructor, which enforces validation
+  /// and business rules. This factory is restricted to the SDK developers and
+  /// contributors.
   @internalUse
   factory HeartRateVariabilityRMSSDRecord.internal({
     required HealthRecordId id,

--- a/packages/health_connector_core/lib/src/models/health_records/heart_rate/heart_rate_variability_sdnn_record.dart
+++ b/packages/health_connector_core/lib/src/models/health_records/heart_rate/heart_rate_variability_sdnn_record.dart
@@ -33,6 +33,18 @@ part of '../health_record.dart';
 @supportedOnAppleHealth
 @immutable
 final class HeartRateVariabilitySDNNRecord extends InstantHealthRecord {
+  /// Minimum valid HRV SDNN in milliseconds (1.0 ms).
+  ///
+  /// Practical lower limit; values near zero indicate measurement error or
+  /// severe cardiac pathology.
+  static const double minSdnnMs = 1.0;
+
+  /// Maximum valid HRV SDNN in milliseconds (300.0 ms).
+  ///
+  /// Research indicates 30-250 ms typical; 300 ms provides margin for 24-hour
+  /// measurements with high variability.
+  static const double maxSdnnMs = 300.0;
+
   /// Creates a heart rate variability (SDNN) record.
   ///
   /// ## Parameters
@@ -45,7 +57,15 @@ final class HeartRateVariabilitySDNNRecord extends InstantHealthRecord {
   ///
   /// ## Throws
   ///
-  /// - [ArgumentError] if [sdnn] is negative.
+  /// - [ArgumentError] if [sdnn] is outside the valid range of
+  ///   [minSdnnMs]-[maxSdnnMs] ms.
+  ///
+  /// ## Validation Rationale
+  ///
+  /// - **Minimum ([minSdnnMs] ms)**: Practical lower limit; values near zero
+  ///   indicate measurement error or severe cardiac pathology.
+  /// - **Maximum ([maxSdnnMs] ms)**: Research indicates 30-250 ms typical; 300
+  ///   ms provides margin for 24-hour measurements with high variability.
   HeartRateVariabilitySDNNRecord({
     required super.time,
     required super.metadata,
@@ -53,25 +73,29 @@ final class HeartRateVariabilitySDNNRecord extends InstantHealthRecord {
     super.id = HealthRecordId.none,
     super.zoneOffsetSeconds,
   }) {
-    if (sdnn < TimeDuration.zero) {
-      throw ArgumentError.value(
-        sdnn,
-        'SDNN',
-        'Heart rate variability SDNN must be non-negative',
-      );
-    }
+    final ms = sdnn.inMilliseconds;
+    require(
+      condition: ms >= minSdnnMs && ms <= maxSdnnMs,
+      value: sdnn,
+      name: 'sdnn',
+      message:
+          'HRV SDNN must be between '
+          '$minSdnnMs-${maxSdnnMs.toStringAsFixed(0)} ms. '
+          'Got ${ms.toStringAsFixed(1)} ms.',
+    );
   }
 
-  /// Internal factory for creating [BloodPressureRecord] instances without
-  /// validation.
+  /// Internal factory for creating [HeartRateVariabilitySDNNRecord] instances
+  /// without validation.
   ///
-  /// Creates a [BloodPressureRecord] by directly mapping platform data to
-  /// fields, bypassing the normal validation and business rules applied by the
-  /// public constructor.
+  /// Creates a [HeartRateVariabilitySDNNRecord] by directly mapping platform
+  /// data to fields, bypassing the normal validation and business rules
+  /// applied by the public constructor.
   ///
   /// **⚠️ Warning**: Not for public use. SDK users should use the public
-  /// [BloodPressureRecord] constructor, which enforces validation and business
-  /// rules. This factory is restricted to the SDK developers and contributors.
+  /// [HeartRateVariabilitySDNNRecord] constructor, which enforces validation
+  /// and business rules. This factory is restricted to the SDK developers and
+  /// contributors.
   @internalUse
   factory HeartRateVariabilitySDNNRecord.internal({
     required HealthRecordId id,

--- a/packages/health_connector_core/lib/src/models/health_records/heart_rate/resting_heart_rate_record.dart
+++ b/packages/health_connector_core/lib/src/models/health_records/heart_rate/resting_heart_rate_record.dart
@@ -30,6 +30,26 @@ part of '../health_record.dart';
 @sinceV1_3_0
 @immutable
 final class RestingHeartRateRecord extends InstantHealthRecord {
+  /// Minimum valid resting heart rate in beats per minute.
+  ///
+  /// Valid range: 1-300 bpm, aligned with Android Health Connect.
+  ///
+  /// ## Platform Compatibility
+  ///
+  /// - **Android Health Connect**: [RestingHeartRateRecord.kt](https://cs.android.com/androidx/platform/frameworks/support/+/androidx-main:health/connect/connect-client/src/main/java/androidx/health/connect/client/records/RestingHeartRateRecord.kt)
+  /// - **Apple HealthKit**: No platform limits (application-defined)
+  static final Frequency minRate = Frequency.perMinute(1.0);
+
+  /// Maximum valid resting heart rate in beats per minute.
+  ///
+  /// Valid range: 1-300 bpm, aligned with Android Health Connect.
+  ///
+  /// ## Platform Compatibility
+  ///
+  /// - **Android Health Connect**: [RestingHeartRateRecord.kt](https://cs.android.com/androidx/platform/frameworks/support/+/androidx-main:health/connect/connect-client/src/main/java/androidx/health/connect/client/records/RestingHeartRateRecord.kt)
+  /// - **Apple HealthKit**: No platform limits (application-defined)
+  static final Frequency maxRate = Frequency.perMinute(300.0);
+
   /// Creates a resting heart rate record.
   ///
   /// ## Parameters
@@ -39,24 +59,48 @@ final class RestingHeartRateRecord extends InstantHealthRecord {
   /// - [zoneOffsetSeconds]: Optional timezone offset for the measurement time.
   /// - [metadata]: Metadata about the origin and recording method.
   /// - [rate]: The resting heart rate measurement in beats per minute.
-  const RestingHeartRateRecord({
+  ///
+  /// ## Throws
+  ///
+  /// - [ArgumentError] if [rate] is outside the valid range of
+  ///   [minRate]-[maxRate].
+  ///
+  /// ## Validation Rationale
+  ///
+  /// - **Minimum ([minRate])**: 1 bpm allows for extreme bradycardia and
+  ///   ensures all valid Health Connect data can be processed.
+  /// - **Maximum ([maxRate])**: 300 bpm maintains consistency with general
+  ///   heart rate validation and Health Connect requirements.
+  RestingHeartRateRecord({
     required super.time,
     required super.metadata,
     required this.rate,
     super.id,
     super.zoneOffsetSeconds,
-  });
+  }) {
+    require(
+      condition: rate >= minRate && rate <= maxRate,
+      value: rate,
+      name: 'rate',
+      message:
+          'Resting heart rate must be between '
+          '${minRate.inPerMinute.toStringAsFixed(0)}-'
+          '${maxRate.inPerMinute.toStringAsFixed(0)} bpm. '
+          'Got ${rate.inPerMinute.toStringAsFixed(1)} bpm.',
+    );
+  }
 
-  /// Internal factory for creating [BloodPressureRecord] instances without
+  /// Internal factory for creating [RestingHeartRateRecord] instances without
   /// validation.
   ///
-  /// Creates a [BloodPressureRecord] by directly mapping platform data to
+  /// Creates a [RestingHeartRateRecord] by directly mapping platform data to
   /// fields, bypassing the normal validation and business rules applied by the
   /// public constructor.
   ///
   /// **⚠️ Warning**: Not for public use. SDK users should use the public
-  /// [BloodPressureRecord] constructor, which enforces validation and business
-  /// rules. This factory is restricted to the SDK developers and contributors.
+  /// [RestingHeartRateRecord] constructor, which enforces validation and
+  /// business rules. This factory is restricted to the SDK developers and
+  /// contributors.
   @internalUse
   factory RestingHeartRateRecord.internal({
     required HealthRecordId id,

--- a/packages/health_connector_core/lib/src/models/health_records/height_record.dart
+++ b/packages/health_connector_core/lib/src/models/health_records/height_record.dart
@@ -28,6 +28,19 @@ part of 'health_record.dart';
 @sinceV1_0_0
 @immutable
 final class HeightRecord extends InstantHealthRecord {
+  /// Minimum valid height in centimeters (30 cm).
+  ///
+  /// Premature newborn lower bound.
+  /// Minimum valid height (30 cm).
+  ///
+  /// Premature newborn lower bound.
+  static const Length minHeight = Length.centimeters(30.0);
+
+  /// Maximum valid height (280 cm).
+  ///
+  /// Exceeds the tallest recorded person (272 cm, Robert Wadlow) with margin.
+  static const Length maxHeight = Length.centimeters(280.0);
+
   /// Creates a body height record.
   ///
   /// ## Parameters
@@ -40,14 +53,33 @@ final class HeightRecord extends InstantHealthRecord {
   ///
   /// ## Throws
   ///
-  /// - [ArgumentError] if [height] is less than or equal to 0 meters.
-  const HeightRecord({
+  /// - [ArgumentError] if [height] is outside the valid range of
+  /// - [ArgumentError] if [height] is outside the valid range of
+  ///   [minHeight]-[maxHeight] cm.
+  ///
+  /// ## Validation Rationale
+  ///
+  /// - **Minimum ([minHeight] cm)**: Premature newborn lower bound.
+  /// - **Maximum ([maxHeight] cm)**: Exceeds the tallest recorded person
+  ///   (272 cm, Robert Wadlow) with margin.
+  HeightRecord({
     required super.time,
     required super.metadata,
     required this.height,
     super.id,
     super.zoneOffsetSeconds,
-  });
+  }) {
+    require(
+      condition: height >= minHeight && height <= maxHeight,
+      value: height,
+      name: 'height',
+      message:
+          'Height must be between '
+          '${minHeight.inCentimeters.toStringAsFixed(1)}-'
+          '${maxHeight.inCentimeters.toStringAsFixed(0)} cm. '
+          'Got ${height.inCentimeters.toStringAsFixed(1)} cm.',
+    );
+  }
 
   /// Internal factory for creating [HeightRecord] instances
   /// without validation.

--- a/packages/health_connector_core/lib/src/models/health_records/hydration_record.dart
+++ b/packages/health_connector_core/lib/src/models/health_records/hydration_record.dart
@@ -31,13 +31,19 @@ part of 'health_record.dart';
 @sinceV1_0_0
 @immutable
 final class HydrationRecord extends IntervalHealthRecord {
+  /// Minimum valid hydration volume (0.0 L).
+  static const Volume minVolume = Volume.zero;
+
+  /// Maximum valid hydration volume (20.0 L).
+  static const Volume maxVolume = Volume.liters(20.0);
+
   /// Creates a hydration record.
   ///
   /// ## Parameters
   ///
-  /// - [startTime]: The start of the time interval (inclusive).
-  /// - [endTime]: The end of the time interval (exclusive).
-  /// - [volume]: The volume of water consumed during the interval.
+  /// - [volume]: The volume of water consumed.
+  /// - [startTime]: The start of the drinking interval.
+  /// - [endTime]: The end of the drinking interval.
   /// - [metadata]: Metadata about the origin and recording method.
   /// - [id]: The unique identifier for this record.
   /// - [startZoneOffsetSeconds]: Optional timezone offset for start time.
@@ -45,6 +51,8 @@ final class HydrationRecord extends IntervalHealthRecord {
   ///
   /// ## Throws
   ///
+  /// - [ArgumentError] if [volume] is outside the valid range of
+  ///   [minVolume]-[maxVolume].
   /// - [ArgumentError] if [endTime] is not after [startTime].
   HydrationRecord({
     required super.startTime,
@@ -54,7 +62,18 @@ final class HydrationRecord extends IntervalHealthRecord {
     super.id = HealthRecordId.none,
     super.startZoneOffsetSeconds,
     super.endZoneOffsetSeconds,
-  });
+  }) {
+    require(
+      condition: volume >= minVolume && volume <= maxVolume,
+      value: volume,
+      name: 'volume',
+      message:
+          'Hydration volume must be between '
+          '${minVolume.inLiters.toStringAsFixed(0)}-'
+          '${maxVolume.inLiters.toStringAsFixed(0)} L. '
+          'Got ${volume.inLiters.toStringAsFixed(2)} L.',
+    );
+  }
 
   /// Internal factory for creating [HydrationRecord] instances
   /// without validation.

--- a/packages/health_connector_core/lib/src/models/health_records/lean_body_mass_record.dart
+++ b/packages/health_connector_core/lib/src/models/health_records/lean_body_mass_record.dart
@@ -31,6 +31,21 @@ part of 'health_record.dart';
 @sinceV1_0_0
 @immutable
 final class LeanBodyMassRecord extends InstantHealthRecord {
+  /// Minimum valid lean body mass in kilograms (0.5 kg).
+  ///
+  /// Premature infant lower bound (excluding fat).
+  /// Minimum valid lean body mass (0.5 kg).
+  ///
+  /// Premature infant lower bound (excluding fat).
+  static const Mass minMass = Mass.kilograms(0.5);
+
+  /// Maximum valid lean body mass (200.0 kg).
+  ///
+  /// Extreme upper limit for very large/muscular individuals; lean mass
+  /// typically 40-100 kg.
+  static const Mass maxMass = Mass.kilograms(200.0);
+
+  /// Creates a lean body mass record.
   ///
   /// ## Parameters
   ///
@@ -39,13 +54,36 @@ final class LeanBodyMassRecord extends InstantHealthRecord {
   /// - [zoneOffsetSeconds]: Optional timezone offset for the measurement time.
   /// - [metadata]: Metadata about the origin and recording method.
   /// - [mass]: The lean body mass measurement.
-  const LeanBodyMassRecord({
+  ///
+  /// ## Throws
+  ///
+  /// - [ArgumentError] if [mass] is outside the valid range of
+  /// - [ArgumentError] if [mass] is outside the valid range of
+  ///   [minMass]-[maxMass] kg.
+  ///
+  /// ## Validation Rationale
+  ///
+  /// - **Minimum ([minMass] kg)**: Premature infant lower bound.
+  /// - **Maximum ([maxMass] kg)**: Extreme upper limit for very large/muscular
+  ///   individuals; lean mass typically 40-100 kg.
+  LeanBodyMassRecord({
     required super.time,
     required super.metadata,
     required this.mass,
     super.id,
     super.zoneOffsetSeconds,
-  });
+  }) {
+    require(
+      condition: mass >= minMass && mass <= maxMass,
+      value: mass,
+      name: 'mass',
+      message:
+          'Lean body mass must be between '
+          '${minMass.inKilograms.toStringAsFixed(1)}-'
+          '${maxMass.inKilograms.toStringAsFixed(0)} kg. '
+          'Got ${mass.inKilograms.toStringAsFixed(1)} kg.',
+    );
+  }
 
   /// Internal factory for creating [LeanBodyMassRecord] instances
   /// without validation.

--- a/packages/health_connector_core/lib/src/models/health_records/menstruation/cervical_mucus/cervical_mucus_appearance.dart
+++ b/packages/health_connector_core/lib/src/models/health_records/menstruation/cervical_mucus/cervical_mucus_appearance.dart
@@ -3,8 +3,11 @@ part of '../../health_record.dart';
 /// Cervical mucus appearance types.
 ///
 /// ## Platform Mapping
-/// - **Android Health Connect**: Full 1:1 mapping via  `CervicalMucusRecord.APPEARANCE_*`
-/// - **iOS HealthKit**:  - Natively supports: `dry`, `sticky`, `creamy`, `watery`, `eggWhite`  - `unusual` and `unknown` are stored in custom metadata key and handled by    the SKK
+/// - **Android Health Connect**: Full 1:1 mapping via
+///   `CervicalMucusRecord.APPEARANCE_*`
+/// - **iOS HealthKit**:
+///   - Natively supports: `dry`, `sticky`, `creamy`, `watery`, `eggWhite`.
+///   - `unusual` and `unknown` are stored in custom metadata key.
 ///
 /// {@category Health Records}
 @sinceV2_1_0

--- a/packages/health_connector_core/lib/src/models/health_records/menstruation/intermenstrual_bleeding_record.dart
+++ b/packages/health_connector_core/lib/src/models/health_records/menstruation/intermenstrual_bleeding_record.dart
@@ -45,16 +45,17 @@ final class IntermenstrualBleedingRecord extends InstantHealthRecord {
     super.zoneOffsetSeconds,
   });
 
-  /// Internal factory for creating [BloodPressureRecord] instances without
-  /// validation.
+  /// Internal factory for creating [IntermenstrualBleedingRecord] instances
+  /// without validation.
   ///
-  /// Creates a [BloodPressureRecord] by directly mapping platform data to
-  /// fields, bypassing the normal validation and business rules applied by the
-  /// public constructor.
+  /// Creates a [IntermenstrualBleedingRecord] by directly mapping platform
+  /// data to fields, bypassing the normal validation and business rules
+  /// applied by the public constructor.
   ///
   /// **⚠️ Warning**: Not for public use. SDK users should use the public
-  /// [BloodPressureRecord] constructor, which enforces validation and business
-  /// rules. This factory is restricted to the SDK developers and contributors.
+  /// [IntermenstrualBleedingRecord] constructor, which enforces validation and
+  /// business rules. This factory is restricted to the SDK developers and
+  /// contributors.
   @internalUse
   factory IntermenstrualBleedingRecord.internal({
     required HealthRecordId id,

--- a/packages/health_connector_core/lib/src/models/health_records/menstruation/menstrual_flow/menstrual_flow.dart
+++ b/packages/health_connector_core/lib/src/models/health_records/menstruation/menstrual_flow/menstrual_flow.dart
@@ -7,8 +7,10 @@ part of '../../health_record.dart';
 ///
 /// ## Platform Mapping
 ///
-/// - **Android Health Connect**: Maps to `MenstruationFlowRecord.FLOW_*`  constants
-/// - **iOS HealthKit**: Maps to `HKCategoryValueMenstrualFlow` (iOS ≤17) or  `HKCategoryValueVaginalBleeding` (iOS ≥18) enum values
+/// - **Android Health Connect**: Maps to `MenstruationFlowRecord.FLOW_*`
+///   constants
+/// - **iOS HealthKit**: Maps to `HKCategoryValueMenstrualFlow` (iOS ≤17) or
+///   `HKCategoryValueVaginalBleeding` (iOS ≥18) enum values
 ///
 /// {@category Health Records}
 @sinceV2_2_0

--- a/packages/health_connector_core/lib/src/models/health_records/menstruation/menstrual_flow/menstrual_flow_instant_record.dart
+++ b/packages/health_connector_core/lib/src/models/health_records/menstruation/menstrual_flow/menstrual_flow_instant_record.dart
@@ -45,16 +45,17 @@ final class MenstrualFlowInstantRecord extends InstantHealthRecord {
     super.zoneOffsetSeconds,
   });
 
-  /// Internal factory for creating [BloodPressureRecord] instances without
-  /// validation.
+  /// Internal factory for creating [MenstrualFlowInstantRecord] instances
+  /// without validation.
   ///
-  /// Creates a [BloodPressureRecord] by directly mapping platform data to
-  /// fields, bypassing the normal validation and business rules applied by the
-  /// public constructor.
+  /// Creates a [MenstrualFlowInstantRecord] by directly mapping platform data
+  /// to fields, bypassing the normal validation and business rules applied by
+  /// the public constructor.
   ///
   /// **⚠️ Warning**: Not for public use. SDK users should use the public
-  /// [BloodPressureRecord] constructor, which enforces validation and business
-  /// rules. This factory is restricted to the SDK developers and contributors.
+  /// [MenstrualFlowInstantRecord] constructor, which enforces validation and
+  /// business rules. This factory is restricted to the SDK developers and
+  /// contributors.
   @internalUse
   factory MenstrualFlowInstantRecord.internal({
     required HealthRecordId id,

--- a/packages/health_connector_core/lib/src/models/health_records/menstruation/menstrual_flow/menstrual_flow_record.dart
+++ b/packages/health_connector_core/lib/src/models/health_records/menstruation/menstrual_flow/menstrual_flow_record.dart
@@ -8,7 +8,8 @@ part of '../../health_record.dart';
 ///
 /// ## Platform Support
 ///
-/// - **Android Health Connect**: Not supported. Use  [MenstrualFlowInstantRecord] instead.
+/// - **Android Health Connect**: Not supported. [MenstrualFlowInstantRecord]
+///   should be used instead.
 /// - **iOS HealthKit**: [`HKCategoryTypeIdentifier.menstrualFlow`](https://developer.apple.com/documentation/healthkit/hkcategorytypeidentifier/menstrualflow)
 ///
 /// ## Example
@@ -73,15 +74,15 @@ final class MenstrualFlowRecord extends IntervalHealthRecord {
     super.endZoneOffsetSeconds,
   });
 
-  /// Internal factory for creating [BloodPressureRecord] instances without
+  /// Internal factory for creating [MenstrualFlowRecord] instances without
   /// validation.
   ///
-  /// Creates a [BloodPressureRecord] by directly mapping platform data to
+  /// Creates a [MenstrualFlowRecord] by directly mapping platform data to
   /// fields, bypassing the normal validation and business rules applied by the
   /// public constructor.
   ///
   /// **⚠️ Warning**: Not for public use. SDK users should use the public
-  /// [BloodPressureRecord] constructor, which enforces validation and business
+  /// [MenstrualFlowRecord] constructor, which enforces validation and business
   /// rules. This factory is restricted to the SDK developers and contributors.
   @internalUse
   factory MenstrualFlowRecord.internal({

--- a/packages/health_connector_core/lib/src/models/health_records/menstruation/ovulation_test/ovulation_test_record.dart
+++ b/packages/health_connector_core/lib/src/models/health_records/menstruation/ovulation_test/ovulation_test_record.dart
@@ -49,15 +49,15 @@ final class OvulationTestRecord extends InstantHealthRecord {
     super.zoneOffsetSeconds,
   });
 
-  /// Internal factory for creating [BloodPressureRecord] instances without
+  /// Internal factory for creating [OvulationTestRecord] instances without
   /// validation.
   ///
-  /// Creates a [BloodPressureRecord] by directly mapping platform data to
+  /// Creates a [OvulationTestRecord] by directly mapping platform data to
   /// fields, bypassing the normal validation and business rules applied by the
   /// public constructor.
   ///
   /// **⚠️ Warning**: Not for public use. SDK users should use the public
-  /// [BloodPressureRecord] constructor, which enforces validation and business
+  /// [OvulationTestRecord] constructor, which enforces validation and business
   /// rules. This factory is restricted to the SDK developers and contributors.
   @internalUse
   factory OvulationTestRecord.internal({

--- a/packages/health_connector_core/lib/src/models/health_records/menstruation/ovulation_test/ovulation_test_result.dart
+++ b/packages/health_connector_core/lib/src/models/health_records/menstruation/ovulation_test/ovulation_test_result.dart
@@ -7,8 +7,10 @@ part of '../../health_record.dart';
 ///
 /// ## Platform Mapping
 ///
-/// - **Android Health Connect**: Maps to  `OvulationTestRecord.RESULT_*` constants
-/// - **iOS HealthKit**: Maps to  `HKCategoryValueOvulationTestResult` enum values
+/// - **Android Health Connect**: Maps to `OvulationTestRecord.RESULT_*`
+///   constants
+/// - **iOS HealthKit**: Maps to `HKCategoryValueOvulationTestResult` enum
+///   values
 ///
 /// {@category Health Records}
 @sinceV2_2_0

--- a/packages/health_connector_core/lib/src/models/health_records/mindfulness/mindfulness_session_record.dart
+++ b/packages/health_connector_core/lib/src/models/health_records/mindfulness/mindfulness_session_record.dart
@@ -51,16 +51,17 @@ final class MindfulnessSessionRecord extends IntervalHealthRecord {
     this.notes,
   });
 
-  /// Internal factory for creating [BloodPressureRecord] instances without
+  /// Internal factory for creating [MindfulnessSessionRecord] instances without
   /// validation.
   ///
-  /// Creates a [BloodPressureRecord] by directly mapping platform data to
+  /// Creates a [MindfulnessSessionRecord] by directly mapping platform data to
   /// fields, bypassing the normal validation and business rules applied by the
   /// public constructor.
   ///
   /// **⚠️ Warning**: Not for public use. SDK users should use the public
-  /// [BloodPressureRecord] constructor, which enforces validation and business
-  /// rules. This factory is restricted to the SDK developers and contributors.
+  /// [MindfulnessSessionRecord] constructor, which enforces validation and
+  /// business rules. This factory is restricted to the SDK developers and
+  /// contributors.
   @internalUse
   factory MindfulnessSessionRecord.internal({
     required HealthRecordId id,
@@ -173,8 +174,10 @@ final class MindfulnessSessionRecord extends IntervalHealthRecord {
 ///
 /// ## Platform Mapping
 ///
-/// - **Android Health Connect**: Maps to  `MindfulnessSessionRecord.MINDFULNESS_SESSION_TYPE_***`
-/// - **iOS HealthKit**: Stored in custom metadata since iOS HealthKit only  supports generic `HKCategoryValue.notApplicable` type
+/// - **Android Health Connect**: Maps to
+///   `MindfulnessSessionRecord.MINDFULNESS_SESSION_TYPE_*` constants.
+/// - **iOS HealthKit**: Stored in custom metadata since iOS HealthKit only
+///   supports generic `HKCategoryValue.notApplicable` type.
 ///
 /// > [!NOTE]
 /// > **iOS HealthKit Limitation**: HealthKit only supports a single generic

--- a/packages/health_connector_core/lib/src/models/health_records/nutrition/dietary_biotin_record.dart
+++ b/packages/health_connector_core/lib/src/models/health_records/nutrition/dietary_biotin_record.dart
@@ -44,32 +44,44 @@ final class DietaryBiotinRecord extends DietaryVitaminRecord {
   /// - [zoneOffsetSeconds]: Optional timezone offset for the measurement time.
   /// - [foodName]: Optional name of the food containing this biotin.
   /// - [mealType]: The type of meal (breakfast, lunch, dinner, snack, unknown).
-  factory DietaryBiotinRecord({
-    required Mass mass,
-    required DateTime time,
-    required Metadata metadata,
-    HealthRecordId id = HealthRecordId.none,
-    int? zoneOffsetSeconds,
-    String? foodName,
-    MealType mealType = MealType.unknown,
+  ///
+  /// ## Throws
+  ///
+  /// - [ArgumentError] if [mass] is outside the valid range of
+  ///   [minMass]-[maxMass] g.
+  ///
+  /// ## Validation Rationale
+  ///
+  /// - **Minimum ([minMass] g)**: Valid mass must be non-negative.
+  /// - **Maximum ([maxMass] g)**: 10g is a reasonable upper bound for
+  ///   vitamin intake from a single food item.
+  DietaryBiotinRecord({
+    required super.mass,
+    required super.time,
+    required super.metadata,
+    super.id = HealthRecordId.none,
+    super.zoneOffsetSeconds,
+    super.foodName,
+    super.mealType,
   }) {
-    return DietaryBiotinRecord._(
-      mass: mass,
-      time: time,
-      metadata: metadata,
-      id: id,
-      zoneOffsetSeconds: zoneOffsetSeconds,
-      foodName: foodName,
-      mealType: mealType,
+    require(
+      condition: mass >= minMass && mass <= maxMass,
+      value: mass,
+      name: 'mass',
+      message:
+          'Biotin mass must be between '
+          '${minMass.inGrams.toStringAsFixed(0)}-'
+          '${maxMass.inGrams.toStringAsFixed(0)} g. '
+          'Got ${mass.inGrams.toStringAsFixed(4)} g.',
     );
   }
 
-  /// Internal factory for creating [DietaryBiotinRecord] instances without
-  /// validation.
-  ///
-  /// Creates a [DietaryBiotinRecord] by directly mapping platform data to
-  /// fields, bypassing the normal validation and business rules applied by the
-  /// public constructor.
+  /// Minimum valid biotin mass (0.0 g).
+  static const Mass minMass = Mass.zero;
+
+  /// Maximum valid biotin mass (10.0 g).
+  static const Mass maxMass = Mass.grams(10.0);
+
   ///
   /// **⚠️ Warning**: Not for public use. SDK users should use the public
   /// [DietaryBiotinRecord] constructor, which enforces validation and business
@@ -84,7 +96,7 @@ final class DietaryBiotinRecord extends DietaryVitaminRecord {
     String? foodName,
     MealType mealType = MealType.unknown,
   }) {
-    return DietaryBiotinRecord._(
+    return DietaryBiotinRecord(
       mass: mass,
       time: time,
       metadata: metadata,
@@ -115,14 +127,4 @@ final class DietaryBiotinRecord extends DietaryVitaminRecord {
       mealType: mealType ?? this.mealType,
     );
   }
-
-  const DietaryBiotinRecord._({
-    required super.mass,
-    required super.time,
-    required super.metadata,
-    super.id = HealthRecordId.none,
-    super.zoneOffsetSeconds,
-    super.foodName,
-    super.mealType,
-  });
 }

--- a/packages/health_connector_core/lib/src/models/health_records/nutrition/dietary_caffeine_record.dart
+++ b/packages/health_connector_core/lib/src/models/health_records/nutrition/dietary_caffeine_record.dart
@@ -7,9 +7,7 @@ part of '../health_record.dart';
 ///
 /// ## Platform Mapping
 ///
-/// - **iOS HealthKit Only**: [`HKQuantityTypeIdentifier.dietaryCaffeine`](https
-/// ://developer.apple.com/documentation/healthkit/hkquantitytypeidentifier/diet
-/// arycaffeine)
+/// - **iOS HealthKit Only**: [`HKQuantityTypeIdentifier.dietaryCaffeine`](https://developer.apple.com/documentation/healthkit/hkquantitytypeidentifier/dietarycaffeine)
 /// - **Android Health Connect**: Part of [`NutritionRecord`](https://developer.android.com/reference/kotlin/androidx/health/connect/client/records/NutritionRecord)
 ///
 /// ## Example
@@ -45,23 +43,35 @@ final class DietaryCaffeineRecord extends NutrientRecord<Mass> {
   /// - [zoneOffsetSeconds]: Optional timezone offset for the measurement time.
   /// - [foodName]: Optional name of the food containing this caffeine.
   /// - [mealType]: The type of meal (breakfast, lunch, dinner, snack, unknown).
-  factory DietaryCaffeineRecord({
-    required Mass mass,
-    required DateTime time,
-    required Metadata metadata,
-    HealthRecordId id = HealthRecordId.none,
-    int? zoneOffsetSeconds,
-    String? foodName,
-    MealType mealType = MealType.unknown,
+  ///
+  /// ## Throws
+  ///
+  /// - [ArgumentError] if [mass] is outside the valid range of
+  ///   [minMass]-[maxMass].
+  ///
+  /// ## Validation Rationale
+  ///
+  /// - **Minimum ([minMass])**: Valid mass must be non-negative.
+  /// - **Maximum ([maxMass])**: 10g is a reasonable upper bound for
+  ///   caffeine intake from a single food item.
+  DietaryCaffeineRecord({
+    required this.mass,
+    required super.time,
+    required super.metadata,
+    super.id = HealthRecordId.none,
+    super.zoneOffsetSeconds,
+    super.foodName,
+    super.mealType,
   }) {
-    return DietaryCaffeineRecord._(
-      mass: mass,
-      time: time,
-      metadata: metadata,
-      id: id,
-      zoneOffsetSeconds: zoneOffsetSeconds,
-      foodName: foodName,
-      mealType: mealType,
+    require(
+      condition: mass >= minMass && mass <= maxMass,
+      value: mass,
+      name: 'mass',
+      message:
+          'Caffeine mass must be between '
+          '${minMass.inGrams.toStringAsFixed(0)}-'
+          '${maxMass.inGrams.toStringAsFixed(0)} g. '
+          'Got ${mass.inGrams.toStringAsFixed(4)} g.',
     );
   }
 
@@ -86,7 +96,7 @@ final class DietaryCaffeineRecord extends NutrientRecord<Mass> {
     String? foodName,
     MealType mealType = MealType.unknown,
   }) {
-    return DietaryCaffeineRecord._(
+    return DietaryCaffeineRecord(
       mass: mass,
       time: time,
       metadata: metadata,
@@ -118,16 +128,22 @@ final class DietaryCaffeineRecord extends NutrientRecord<Mass> {
     );
   }
 
-  const DietaryCaffeineRecord._({
-    required this.mass,
-    required super.time,
-    required super.metadata,
-    super.id = HealthRecordId.none,
-    super.zoneOffsetSeconds,
-    super.foodName,
-    super.mealType,
-  });
-
   /// The caffeine measurement.
   final Mass mass;
+
+  /// Minimum valid caffeine mass (0.0 g).
+  static const Mass minMass = Mass.zero;
+
+  /// Maximum valid caffeine mass (10.0 g).
+  static const Mass maxMass = Mass.grams(10.0);
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      super == other &&
+          other is DietaryCaffeineRecord &&
+          (mass.inGrams - other.mass.inGrams).abs() < 1e-6;
+
+  @override
+  int get hashCode => super.hashCode ^ mass.hashCode;
 }

--- a/packages/health_connector_core/lib/src/models/health_records/nutrition/dietary_calcium_record.dart
+++ b/packages/health_connector_core/lib/src/models/health_records/nutrition/dietary_calcium_record.dart
@@ -7,9 +7,7 @@ part of '../health_record.dart';
 ///
 /// ## Platform Mapping
 ///
-/// - **iOS HealthKit Only**: [`HKQuantityTypeIdentifier.dietaryCalcium`](https:
-/// //developer.apple.com/documentation/healthkit/hkquantitytypeidentifier/dieta
-/// rycalcium)
+/// - **iOS HealthKit Only**: [`HKQuantityTypeIdentifier.dietaryCalcium`](https://developer.apple.com/documentation/healthkit/hkquantitytypeidentifier/dietarycalcium)
 /// - **Android Health Connect**: Part of [`NutritionRecord`](https://developer.android.com/reference/kotlin/androidx/health/connect/client/records/NutritionRecord)
 ///
 /// ## Example
@@ -33,6 +31,12 @@ part of '../health_record.dart';
 @supportedOnAppleHealth
 @immutable
 final class DietaryCalciumRecord extends DietaryMineralRecord {
+  /// Minimum valid calcium mass (0.0 g).
+  static const Mass minMass = Mass.zero;
+
+  /// Maximum valid calcium mass (100.0 g).
+  static const Mass maxMass = Mass.grams(100.0);
+
   /// Creates a calcium nutrient record.
   ///
   /// ## Parameters
@@ -45,32 +49,38 @@ final class DietaryCalciumRecord extends DietaryMineralRecord {
   /// - [zoneOffsetSeconds]: Optional timezone offset for the measurement time.
   /// - [foodName]: Optional name of the food containing this calcium.
   /// - [mealType]: The type of meal (breakfast, lunch, dinner, snack, unknown).
-  factory DietaryCalciumRecord({
-    required Mass mass,
-    required DateTime time,
-    required Metadata metadata,
-    HealthRecordId id = HealthRecordId.none,
-    int? zoneOffsetSeconds,
-    String? foodName,
-    MealType mealType = MealType.unknown,
+  ///
+  /// ## Throws
+  ///
+  /// - [ArgumentError] if [mass] is outside the valid range of
+  ///   [minMass]-[maxMass].
+  ///
+  /// ## Validation Rationale
+  ///
+  /// - **Minimum ([minMass])**: Valid mass must be non-negative.
+  /// - **Maximum ([maxMass])**: 100g is a reasonable upper bound for
+  ///   mineral intake from a single food item.
+  DietaryCalciumRecord({
+    required super.mass,
+    required super.time,
+    required super.metadata,
+    super.id = HealthRecordId.none,
+    super.zoneOffsetSeconds,
+    super.foodName,
+    super.mealType,
   }) {
-    return DietaryCalciumRecord._(
-      mass: mass,
-      time: time,
-      metadata: metadata,
-      id: id,
-      zoneOffsetSeconds: zoneOffsetSeconds,
-      foodName: foodName,
-      mealType: mealType,
+    require(
+      condition: mass >= minMass && mass <= maxMass,
+      value: mass,
+      name: 'mass',
+      message:
+          'Calcium mass must be between '
+          '${minMass.inGrams.toStringAsFixed(0)}-'
+          '${maxMass.inGrams.toStringAsFixed(0)} g. '
+          'Got ${mass.inGrams.toStringAsFixed(3)} g.',
     );
   }
 
-  /// Internal factory for creating [DietaryCalciumRecord] instances without
-  /// validation.
-  ///
-  /// Creates a [DietaryCalciumRecord] by directly mapping platform data to
-  /// fields, bypassing the normal validation and business rules applied by the
-  /// public constructor.
   ///
   /// **⚠️ Warning**: Not for public use. SDK users should use the public
   /// [DietaryCalciumRecord] constructor, which enforces validation and business
@@ -85,7 +95,7 @@ final class DietaryCalciumRecord extends DietaryMineralRecord {
     String? foodName,
     MealType mealType = MealType.unknown,
   }) {
-    return DietaryCalciumRecord._(
+    return DietaryCalciumRecord(
       mass: mass,
       time: time,
       metadata: metadata,
@@ -116,14 +126,4 @@ final class DietaryCalciumRecord extends DietaryMineralRecord {
       mealType: mealType ?? this.mealType,
     );
   }
-
-  const DietaryCalciumRecord._({
-    required super.mass,
-    required super.time,
-    required super.metadata,
-    super.id = HealthRecordId.none,
-    super.zoneOffsetSeconds,
-    super.foodName,
-    super.mealType,
-  });
 }

--- a/packages/health_connector_core/lib/src/models/health_records/nutrition/dietary_cholesterol_record.dart
+++ b/packages/health_connector_core/lib/src/models/health_records/nutrition/dietary_cholesterol_record.dart
@@ -8,9 +8,7 @@ part of '../health_record.dart';
 ///
 /// ## Platform Mapping
 ///
-/// - **iOS HealthKit Only**: [`HKQuantityTypeIdentifier.dietaryCholesterol`](ht
-/// tps://developer.apple.com/documentation/healthkit/hkquantitytypeidentifier/d
-/// ietarycholesterol)
+/// - **iOS HealthKit Only**: [`HKQuantityTypeIdentifier.dietaryCholesterol`](https://developer.apple.com/documentation/healthkit/hkquantitytypeidentifier/dietarycholesterol)
 /// - **Android Health Connect**: Part of [`NutritionRecord`](https://developer.android.com/reference/kotlin/androidx/health/connect/client/records/NutritionRecord)
 ///
 /// ## Example
@@ -46,32 +44,44 @@ final class DietaryCholesterolRecord extends DietaryMacronutrientRecord {
   /// - [zoneOffsetSeconds]: Optional timezone offset for the measurement time.
   /// - [foodName]: Optional name of the food containing this cholesterol.
   /// - [mealType]: The type of meal (breakfast, lunch, dinner, snack, unknown).
-  factory DietaryCholesterolRecord({
-    required Mass mass,
-    required DateTime time,
-    required Metadata metadata,
-    HealthRecordId id = HealthRecordId.none,
-    int? zoneOffsetSeconds,
-    String? foodName,
-    MealType mealType = MealType.unknown,
+  ///
+  /// ## Throws
+  ///
+  /// - [ArgumentError] if [mass] is outside the valid range of
+  ///   [minMass]-[maxMass] g.
+  ///
+  /// ## Validation Rationale
+  ///
+  /// - **Minimum ([minMass] g)**: Valid mass must be non-negative.
+  /// - **Maximum ([maxMass] g)**: 1,000g is a reasonable upper bound for
+  ///   macronutrient intake from a single food item.
+  DietaryCholesterolRecord({
+    required super.mass,
+    required super.time,
+    required super.metadata,
+    super.id = HealthRecordId.none,
+    super.zoneOffsetSeconds,
+    super.foodName,
+    super.mealType,
   }) {
-    return DietaryCholesterolRecord._(
-      mass: mass,
-      time: time,
-      metadata: metadata,
-      id: id,
-      zoneOffsetSeconds: zoneOffsetSeconds,
-      foodName: foodName,
-      mealType: mealType,
+    require(
+      condition: mass >= minMass && mass <= maxMass,
+      value: mass,
+      name: 'mass',
+      message:
+          'Cholesterol mass must be between '
+          '${minMass.inGrams.toStringAsFixed(0)}-'
+          '${maxMass.inGrams.toStringAsFixed(0)} g. '
+          'Got ${mass.inGrams.toStringAsFixed(1)} g.',
     );
   }
 
-  /// Internal factory for creating [DietaryCholesterolRecord] instances without
-  /// validation.
-  ///
-  /// Creates a [DietaryCholesterolRecord] by directly mapping platform data to
-  /// fields, bypassing the normal validation and business rules applied by the
-  /// public constructor.
+  /// Minimum valid cholesterol mass (0.0 g).
+  static const Mass minMass = Mass.zero;
+
+  /// Maximum valid cholesterol mass (1,000.0 g).
+  static const Mass maxMass = Mass.grams(1000.0);
+
   ///
   /// **⚠️ Warning**: Not for public use. SDK users should use the public
   /// [DietaryCholesterolRecord] constructor, which enforces validation and
@@ -87,7 +97,7 @@ final class DietaryCholesterolRecord extends DietaryMacronutrientRecord {
     String? foodName,
     MealType mealType = MealType.unknown,
   }) {
-    return DietaryCholesterolRecord._(
+    return DietaryCholesterolRecord(
       mass: mass,
       time: time,
       metadata: metadata,
@@ -97,6 +107,8 @@ final class DietaryCholesterolRecord extends DietaryMacronutrientRecord {
       mealType: mealType,
     );
   }
+
+  /// Private constructor without validation.
 
   /// Creates a copy with the given fields replaced with the new values.
   DietaryCholesterolRecord copyWith({
@@ -118,14 +130,4 @@ final class DietaryCholesterolRecord extends DietaryMacronutrientRecord {
       mealType: mealType ?? this.mealType,
     );
   }
-
-  const DietaryCholesterolRecord._({
-    required super.mass,
-    required super.time,
-    required super.metadata,
-    super.id = HealthRecordId.none,
-    super.zoneOffsetSeconds,
-    super.foodName,
-    super.mealType,
-  });
 }

--- a/packages/health_connector_core/lib/src/models/health_records/nutrition/dietary_energy_consumed_record.dart
+++ b/packages/health_connector_core/lib/src/models/health_records/nutrition/dietary_energy_consumed_record.dart
@@ -8,8 +8,7 @@ part of '../health_record.dart';
 ///
 /// ## Platform Mapping
 ///
-/// - **iOS HealthKit Only**: [`HKQuantityTypeIdentifier.dietaryEnergyConsumed`](https://developer.apple.com/documentation/healthkit/hkquantitytypeidentifie
-/// r/dietaryenergyconsumed)
+/// - **iOS HealthKit Only**: [`HKQuantityTypeIdentifier.dietaryEnergyConsumed`](https://developer.apple.com/documentation/healthkit/hkquantitytypeidentifier/dietaryenergyconsumed)
 /// - **Android Health Connect**: Part of [`NutritionRecord`](https://developer.android.com/reference/kotlin/androidx/health/connect/client/records/NutritionRecord)
 ///
 /// ## Example
@@ -33,6 +32,12 @@ part of '../health_record.dart';
 @supportedOnAppleHealth
 @immutable
 final class DietaryEnergyConsumedRecord extends NutrientRecord<Energy> {
+  /// Minimum valid energy (0.0 kcal).
+  static const Energy minEnergy = Energy.zero;
+
+  /// Maximum valid energy (10,000.0 kcal).
+  static const Energy maxEnergy = Energy.kilocalories(10000.0);
+
   /// Creates an energy nutrient record.
   ///
   /// ## Parameters
@@ -45,6 +50,11 @@ final class DietaryEnergyConsumedRecord extends NutrientRecord<Energy> {
   /// - [zoneOffsetSeconds]: Optional timezone offset for the measurement time.
   /// - [foodName]: Optional name of the food containing this energy.
   /// - [mealType]: The type of meal (breakfast, lunch, dinner, snack, unknown).
+  ///
+  /// ## Throws
+  ///
+  /// - [ArgumentError] if [energy] is outside the valid range of
+  ///   [minEnergy]-[maxEnergy].
   factory DietaryEnergyConsumedRecord({
     required Energy energy,
     required DateTime time,
@@ -54,6 +64,16 @@ final class DietaryEnergyConsumedRecord extends NutrientRecord<Energy> {
     String? foodName,
     MealType mealType = MealType.unknown,
   }) {
+    require(
+      condition: energy >= minEnergy && energy <= maxEnergy,
+      value: energy,
+      name: 'energy',
+      message:
+          'Dietary energy must be between '
+          '${minEnergy.inKilocalories.toInt()}-'
+          '${maxEnergy.inKilocalories.toInt()} kcal. '
+          'Got ${energy.inKilocalories.toStringAsFixed(0)} kcal.',
+    );
     return DietaryEnergyConsumedRecord._(
       energy: energy,
       time: time,
@@ -122,6 +142,16 @@ final class DietaryEnergyConsumedRecord extends NutrientRecord<Energy> {
       mealType: mealType ?? this.mealType,
     );
   }
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      super == other &&
+          other is DietaryEnergyConsumedRecord &&
+          energy == other.energy;
+
+  @override
+  int get hashCode => super.hashCode ^ energy.hashCode;
 
   const DietaryEnergyConsumedRecord._({
     required this.energy,

--- a/packages/health_connector_core/lib/src/models/health_records/nutrition/dietary_fiber_record.dart
+++ b/packages/health_connector_core/lib/src/models/health_records/nutrition/dietary_fiber_record.dart
@@ -9,8 +9,7 @@ part of '../health_record.dart';
 ///
 /// ## Platform Mapping
 ///
-/// - **iOS HealthKit Only**: [`HKQuantityTypeIdentifier.dietaryFiber`](https://developer.apple.com/documentation/healthkit/hkquantitytypeidentifier/dietary
-/// Fiber)
+/// - **iOS HealthKit Only**: [`HKQuantityTypeIdentifier.dietaryFiber`](https://developer.apple.com/documentation/healthkit/hkquantitytypeidentifier/dietaryFiber)
 /// - **Android Health Connect**: Part of [`NutritionRecord`](https://developer.android.com/reference/kotlin/androidx/health/connect/client/records/NutritionRecord)
 ///
 /// ## Example
@@ -46,32 +45,44 @@ final class DietaryFiberRecord extends DietaryMacronutrientRecord {
   /// - [zoneOffsetSeconds]: Optional timezone offset for the measurement time.
   /// - [foodName]: Optional name of the food containing this dietary fiber.
   /// - [mealType]: The type of meal (breakfast, lunch, dinner, snack, unknown).
-  factory DietaryFiberRecord({
-    required Mass mass,
-    required DateTime time,
-    required Metadata metadata,
-    HealthRecordId id = HealthRecordId.none,
-    int? zoneOffsetSeconds,
-    String? foodName,
-    MealType mealType = MealType.unknown,
+  ///
+  /// ## Throws
+  ///
+  /// - [ArgumentError] if [mass] is outside the valid range of
+  ///   [minMass]-[maxMass] g.
+  ///
+  /// ## Validation Rationale
+  ///
+  /// - **Minimum ([minMass] g)**: Valid mass must be non-negative.
+  /// - **Maximum ([maxMass] g)**: 1,000g is a reasonable upper bound for
+  ///   macronutrient intake from a single food item.
+  DietaryFiberRecord({
+    required super.mass,
+    required super.time,
+    required super.metadata,
+    super.id = HealthRecordId.none,
+    super.zoneOffsetSeconds,
+    super.foodName,
+    super.mealType,
   }) {
-    return DietaryFiberRecord._(
-      mass: mass,
-      time: time,
-      metadata: metadata,
-      id: id,
-      zoneOffsetSeconds: zoneOffsetSeconds,
-      foodName: foodName,
-      mealType: mealType,
+    require(
+      condition: mass >= minMass && mass <= maxMass,
+      value: mass,
+      name: 'mass',
+      message:
+          'Dietary fiber mass must be between '
+          '${minMass.inGrams.toStringAsFixed(0)}-'
+          '${maxMass.inGrams.toStringAsFixed(0)} g. '
+          'Got ${mass.inGrams.toStringAsFixed(1)} g.',
     );
   }
 
-  /// Internal factory for creating [DietaryFiberRecord] instances without
-  /// validation.
-  ///
-  /// Creates a [DietaryFiberRecord] by directly mapping platform data to
-  /// fields, bypassing the normal validation and business rules applied by the
-  /// public constructor.
+  /// Minimum valid dietary fiber mass (0.0 g).
+  static const Mass minMass = Mass.zero;
+
+  /// Maximum valid dietary fiber mass (1,000.0 g).
+  static const Mass maxMass = Mass.grams(1000.0);
+
   ///
   /// **⚠️ Warning**: Not for public use. SDK users should use the public
   /// [DietaryFiberRecord] constructor, which enforces validation and business
@@ -86,7 +97,7 @@ final class DietaryFiberRecord extends DietaryMacronutrientRecord {
     String? foodName,
     MealType mealType = MealType.unknown,
   }) {
-    return DietaryFiberRecord._(
+    return DietaryFiberRecord(
       mass: mass,
       time: time,
       metadata: metadata,
@@ -117,14 +128,4 @@ final class DietaryFiberRecord extends DietaryMacronutrientRecord {
       mealType: mealType ?? this.mealType,
     );
   }
-
-  const DietaryFiberRecord._({
-    required super.mass,
-    required super.time,
-    required super.metadata,
-    super.id = HealthRecordId.none,
-    super.zoneOffsetSeconds,
-    super.foodName,
-    super.mealType,
-  });
 }

--- a/packages/health_connector_core/lib/src/models/health_records/nutrition/dietary_folate_record.dart
+++ b/packages/health_connector_core/lib/src/models/health_records/nutrition/dietary_folate_record.dart
@@ -44,32 +44,44 @@ final class DietaryFolateRecord extends DietaryVitaminRecord {
   /// - [zoneOffsetSeconds]: Optional timezone offset for the measurement time.
   /// - [foodName]: Optional name of the food containing this folate.
   /// - [mealType]: The type of meal (breakfast, lunch, dinner, snack, unknown).
-  factory DietaryFolateRecord({
-    required Mass mass,
-    required DateTime time,
-    required Metadata metadata,
-    HealthRecordId id = HealthRecordId.none,
-    int? zoneOffsetSeconds,
-    String? foodName,
-    MealType mealType = MealType.unknown,
+  ///
+  /// ## Throws
+  ///
+  /// - [ArgumentError] if [mass] is outside the valid range of
+  ///   [minMass]-[maxMass].
+  ///
+  /// ## Validation Rationale
+  ///
+  /// - **Minimum ([minMass])**: Valid mass must be non-negative.
+  /// - **Maximum ([maxMass])**: 10g is a reasonable upper bound for
+  ///   vitamin intake from a single food item.
+  DietaryFolateRecord({
+    required super.mass,
+    required super.time,
+    required super.metadata,
+    super.id = HealthRecordId.none,
+    super.zoneOffsetSeconds,
+    super.foodName,
+    super.mealType,
   }) {
-    return DietaryFolateRecord._(
-      mass: mass,
-      time: time,
-      metadata: metadata,
-      id: id,
-      zoneOffsetSeconds: zoneOffsetSeconds,
-      foodName: foodName,
-      mealType: mealType,
+    require(
+      condition: mass >= minMass && mass <= maxMass,
+      value: mass,
+      name: 'mass',
+      message:
+          'Folate mass must be between '
+          '${minMass.inGrams.toStringAsFixed(0)}-'
+          '${maxMass.inGrams.toStringAsFixed(0)} g. '
+          'Got ${mass.inGrams.toStringAsFixed(4)} g.',
     );
   }
 
-  /// Internal factory for creating [DietaryFolateRecord] instances without
-  /// validation.
-  ///
-  /// Creates a [DietaryFolateRecord] by directly mapping platform data to
-  /// fields, bypassing the normal validation and business rules applied by the
-  /// public constructor.
+  /// Minimum valid folate mass (0.0 g).
+  static const Mass minMass = Mass.zero;
+
+  /// Maximum valid folate mass (10.0 g).
+  static const Mass maxMass = Mass.grams(10.0);
+
   ///
   /// **⚠️ Warning**: Not for public use. SDK users should use the public
   /// [DietaryFolateRecord] constructor, which enforces validation and business
@@ -84,7 +96,7 @@ final class DietaryFolateRecord extends DietaryVitaminRecord {
     String? foodName,
     MealType mealType = MealType.unknown,
   }) {
-    return DietaryFolateRecord._(
+    return DietaryFolateRecord(
       mass: mass,
       time: time,
       metadata: metadata,
@@ -115,14 +127,4 @@ final class DietaryFolateRecord extends DietaryVitaminRecord {
       mealType: mealType ?? this.mealType,
     );
   }
-
-  const DietaryFolateRecord._({
-    required super.mass,
-    required super.time,
-    required super.metadata,
-    super.id = HealthRecordId.none,
-    super.zoneOffsetSeconds,
-    super.foodName,
-    super.mealType,
-  });
 }

--- a/packages/health_connector_core/lib/src/models/health_records/nutrition/dietary_iron_record.dart
+++ b/packages/health_connector_core/lib/src/models/health_records/nutrition/dietary_iron_record.dart
@@ -7,8 +7,7 @@ part of '../health_record.dart';
 ///
 /// ## Platform Mapping
 ///
-/// - **iOS HealthKit Only**: [`HKQuantityTypeIdentifier.dietaryIron`](https://developer.apple.com/documentation/healthkit/hkquantitytypeidentifier/dietaryi
-/// ron)
+/// - **iOS HealthKit Only**: [`HKQuantityTypeIdentifier.dietaryIron`](https://developer.apple.com/documentation/healthkit/hkquantitytypeidentifier/dietaryiron)
 /// - **Android Health Connect**: Part of [`NutritionRecord`](https://developer.android.com/reference/kotlin/androidx/health/connect/client/records/NutritionRecord)
 ///
 /// ## Example
@@ -43,32 +42,44 @@ final class DietaryIronRecord extends DietaryMineralRecord {
   /// - [zoneOffsetSeconds]: Optional timezone offset for the measurement time.
   /// - [foodName]: Optional name of the food containing this iron.
   /// - [mealType]: The type of meal (breakfast, lunch, dinner, snack, unknown).
-  factory DietaryIronRecord({
-    required Mass mass,
-    required DateTime time,
-    required Metadata metadata,
-    HealthRecordId id = HealthRecordId.none,
-    int? zoneOffsetSeconds,
-    String? foodName,
-    MealType mealType = MealType.unknown,
+  ///
+  /// ## Throws
+  ///
+  /// - [ArgumentError] if [mass] is outside the valid range of
+  ///   [minMass]-[maxMass] g.
+  ///
+  /// ## Validation Rationale
+  ///
+  /// - **Minimum ([minMass] g)**: Valid mass must be non-negative.
+  /// - **Maximum ([maxMass] g)**: 100g is a reasonable upper bound for
+  ///   mineral intake from a single food item.
+  DietaryIronRecord({
+    required super.mass,
+    required super.time,
+    required super.metadata,
+    super.id = HealthRecordId.none,
+    super.zoneOffsetSeconds,
+    super.foodName,
+    super.mealType,
   }) {
-    return DietaryIronRecord._(
-      mass: mass,
-      time: time,
-      metadata: metadata,
-      id: id,
-      zoneOffsetSeconds: zoneOffsetSeconds,
-      foodName: foodName,
-      mealType: mealType,
+    require(
+      condition: mass >= minMass && mass <= maxMass,
+      value: mass,
+      name: 'mass',
+      message:
+          'Iron mass must be between '
+          '${minMass.inGrams.toStringAsFixed(0)}-'
+          '${maxMass.inGrams.toStringAsFixed(0)} g. '
+          'Got ${mass.inGrams.toStringAsFixed(3)} g.',
     );
   }
 
-  /// Internal factory for creating [DietaryIronRecord] instances without
-  /// validation.
-  ///
-  /// Creates a [DietaryIronRecord] by directly mapping platform data to
-  /// fields, bypassing the normal validation and business rules applied by the
-  /// public constructor.
+  /// Minimum valid iron mass (0.0 g).
+  static const Mass minMass = Mass.zero;
+
+  /// Maximum valid iron mass (100.0 g).
+  static const Mass maxMass = Mass.grams(100.0);
+
   ///
   /// **⚠️ Warning**: Not for public use. SDK users should use the public
   /// [DietaryIronRecord] constructor, which enforces validation and business
@@ -83,7 +94,7 @@ final class DietaryIronRecord extends DietaryMineralRecord {
     String? foodName,
     MealType mealType = MealType.unknown,
   }) {
-    return DietaryIronRecord._(
+    return DietaryIronRecord(
       mass: mass,
       time: time,
       metadata: metadata,
@@ -114,14 +125,4 @@ final class DietaryIronRecord extends DietaryMineralRecord {
       mealType: mealType ?? this.mealType,
     );
   }
-
-  const DietaryIronRecord._({
-    required super.mass,
-    required super.time,
-    required super.metadata,
-    super.id = HealthRecordId.none,
-    super.zoneOffsetSeconds,
-    super.foodName,
-    super.mealType,
-  });
 }

--- a/packages/health_connector_core/lib/src/models/health_records/nutrition/dietary_macronutrient_record.dart
+++ b/packages/health_connector_core/lib/src/models/health_records/nutrition/dietary_macronutrient_record.dart
@@ -8,7 +8,13 @@ part of '../health_record.dart';
 @internal
 @immutable
 sealed class DietaryMacronutrientRecord extends NutrientRecord<Mass> {
-  const DietaryMacronutrientRecord({
+  /// Minimum valid macronutrient mass (0.0 g).
+  static const Mass minMass = Mass.zero;
+
+  /// Maximum valid macronutrient mass (1,000.0 g).
+  static const Mass maxMass = Mass.grams(1000.0);
+
+  DietaryMacronutrientRecord({
     required this.mass,
     required super.time,
     required super.metadata,
@@ -16,8 +22,29 @@ sealed class DietaryMacronutrientRecord extends NutrientRecord<Mass> {
     super.zoneOffsetSeconds,
     super.foodName,
     super.mealType,
-  });
+  }) {
+    require(
+      condition: mass >= minMass && mass <= maxMass,
+      value: mass,
+      name: 'mass',
+      message:
+          'Macronutrient mass must be between '
+          '${minMass.inGrams.toStringAsFixed(0)}-'
+          '${maxMass.inGrams.toStringAsFixed(0)} g. '
+          'Got ${mass.inGrams.toStringAsFixed(1)} g.',
+    );
+  }
 
   /// The mass of the nutrient.
   final Mass mass;
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      super == other &&
+          other is DietaryMacronutrientRecord &&
+          (mass.inGrams - other.mass.inGrams).abs() < 1e-6;
+
+  @override
+  int get hashCode => super.hashCode ^ mass.hashCode;
 }

--- a/packages/health_connector_core/lib/src/models/health_records/nutrition/dietary_magnesium_record.dart
+++ b/packages/health_connector_core/lib/src/models/health_records/nutrition/dietary_magnesium_record.dart
@@ -42,32 +42,44 @@ final class DietaryMagnesiumRecord extends DietaryMineralRecord {
   /// - [zoneOffsetSeconds]: Optional timezone offset for the measurement time.
   /// - [foodName]: Optional name of the food containing this magnesium.
   /// - [mealType]: The type of meal (breakfast, lunch, dinner, snack, unknown).
-  factory DietaryMagnesiumRecord({
-    required Mass mass,
-    required DateTime time,
-    required Metadata metadata,
-    HealthRecordId id = HealthRecordId.none,
-    int? zoneOffsetSeconds,
-    String? foodName,
-    MealType mealType = MealType.unknown,
+  ///
+  /// ## Throws
+  ///
+  /// - [ArgumentError] if [mass] is outside the valid range of
+  ///   [minMass]-[maxMass] g.
+  ///
+  /// ## Validation Rationale
+  ///
+  /// - **Minimum ([minMass] g)**: Valid mass must be non-negative.
+  /// - **Maximum ([maxMass] g)**: 100g is a reasonable upper bound for
+  ///   mineral intake from a single food item.
+  DietaryMagnesiumRecord({
+    required super.mass,
+    required super.time,
+    required super.metadata,
+    super.id = HealthRecordId.none,
+    super.zoneOffsetSeconds,
+    super.foodName,
+    super.mealType,
   }) {
-    return DietaryMagnesiumRecord._(
-      mass: mass,
-      time: time,
-      metadata: metadata,
-      id: id,
-      zoneOffsetSeconds: zoneOffsetSeconds,
-      foodName: foodName,
-      mealType: mealType,
+    require(
+      condition: mass >= minMass && mass <= maxMass,
+      value: mass,
+      name: 'mass',
+      message:
+          'Magnesium mass must be between '
+          '${minMass.inGrams.toStringAsFixed(0)}-'
+          '${maxMass.inGrams.toStringAsFixed(0)} g. '
+          'Got ${mass.inGrams.toStringAsFixed(3)} g.',
     );
   }
 
-  /// Internal factory for creating [DietaryMagnesiumRecord] instances without
-  /// validation.
-  ///
-  /// Creates a [DietaryMagnesiumRecord] by directly mapping platform data to
-  /// fields, bypassing the normal validation and business rules applied by the
-  /// public constructor.
+  /// Minimum valid magnesium mass (0.0 g).
+  static const Mass minMass = Mass.zero;
+
+  /// Maximum valid magnesium mass (100.0 g).
+  static const Mass maxMass = Mass.grams(100.0);
+
   ///
   /// **⚠️ Warning**: Not for public use. SDK users should use the public
   /// [DietaryMagnesiumRecord] constructor, which enforces validation and
@@ -83,7 +95,7 @@ final class DietaryMagnesiumRecord extends DietaryMineralRecord {
     String? foodName,
     MealType mealType = MealType.unknown,
   }) {
-    return DietaryMagnesiumRecord._(
+    return DietaryMagnesiumRecord(
       mass: mass,
       time: time,
       metadata: metadata,
@@ -114,14 +126,4 @@ final class DietaryMagnesiumRecord extends DietaryMineralRecord {
       mealType: mealType ?? this.mealType,
     );
   }
-
-  const DietaryMagnesiumRecord._({
-    required super.mass,
-    required super.time,
-    required super.metadata,
-    super.id = HealthRecordId.none,
-    super.zoneOffsetSeconds,
-    super.foodName,
-    super.mealType,
-  });
 }

--- a/packages/health_connector_core/lib/src/models/health_records/nutrition/dietary_manganese_record.dart
+++ b/packages/health_connector_core/lib/src/models/health_records/nutrition/dietary_manganese_record.dart
@@ -42,32 +42,44 @@ final class DietaryManganeseRecord extends DietaryMineralRecord {
   /// - [zoneOffsetSeconds]: Optional timezone offset for the measurement time.
   /// - [foodName]: Optional name of the food containing this manganese.
   /// - [mealType]: The type of meal (breakfast, lunch, dinner, snack, unknown).
-  factory DietaryManganeseRecord({
-    required Mass mass,
-    required DateTime time,
-    required Metadata metadata,
-    HealthRecordId id = HealthRecordId.none,
-    int? zoneOffsetSeconds,
-    String? foodName,
-    MealType mealType = MealType.unknown,
+  ///
+  /// ## Throws
+  ///
+  /// - [ArgumentError] if [mass] is outside the valid range of
+  ///   [minMass]-[maxMass] g.
+  ///
+  /// ## Validation Rationale
+  ///
+  /// - **Minimum ([minMass] g)**: Valid mass must be non-negative.
+  /// - **Maximum ([maxMass] g)**: 100g is a reasonable upper bound for
+  ///   mineral intake from a single food item.
+  DietaryManganeseRecord({
+    required super.mass,
+    required super.time,
+    required super.metadata,
+    super.id = HealthRecordId.none,
+    super.zoneOffsetSeconds,
+    super.foodName,
+    super.mealType,
   }) {
-    return DietaryManganeseRecord._(
-      mass: mass,
-      time: time,
-      metadata: metadata,
-      id: id,
-      zoneOffsetSeconds: zoneOffsetSeconds,
-      foodName: foodName,
-      mealType: mealType,
+    require(
+      condition: mass >= minMass && mass <= maxMass,
+      value: mass,
+      name: 'mass',
+      message:
+          'Manganese mass must be between '
+          '${minMass.inGrams.toStringAsFixed(0)}-'
+          '${maxMass.inGrams.toStringAsFixed(0)} g. '
+          'Got ${mass.inGrams.toStringAsFixed(3)} g.',
     );
   }
 
-  /// Internal factory for creating [DietaryManganeseRecord] instances without
-  /// validation.
-  ///
-  /// Creates a [DietaryManganeseRecord] by directly mapping platform data to
-  /// fields, bypassing the normal validation and business rules applied by the
-  /// public constructor.
+  /// Minimum valid manganese mass (0.0 g).
+  static const Mass minMass = Mass.zero;
+
+  /// Maximum valid manganese mass (100.0 g).
+  static const Mass maxMass = Mass.grams(100.0);
+
   ///
   /// **⚠️ Warning**: Not for public use. SDK users should use the public
   /// [DietaryManganeseRecord] constructor, which enforces validation and
@@ -83,7 +95,7 @@ final class DietaryManganeseRecord extends DietaryMineralRecord {
     String? foodName,
     MealType mealType = MealType.unknown,
   }) {
-    return DietaryManganeseRecord._(
+    return DietaryManganeseRecord(
       mass: mass,
       time: time,
       metadata: metadata,
@@ -114,14 +126,4 @@ final class DietaryManganeseRecord extends DietaryMineralRecord {
       mealType: mealType ?? this.mealType,
     );
   }
-
-  const DietaryManganeseRecord._({
-    required super.mass,
-    required super.time,
-    required super.metadata,
-    super.id = HealthRecordId.none,
-    super.zoneOffsetSeconds,
-    super.foodName,
-    super.mealType,
-  });
 }

--- a/packages/health_connector_core/lib/src/models/health_records/nutrition/dietary_mineral_records.dart
+++ b/packages/health_connector_core/lib/src/models/health_records/nutrition/dietary_mineral_records.dart
@@ -8,7 +8,13 @@ part of '../health_record.dart';
 @internal
 @immutable
 sealed class DietaryMineralRecord extends NutrientRecord<Mass> {
-  const DietaryMineralRecord({
+  /// Minimum valid mineral mass (0.0 g).
+  static const Mass minMass = Mass.zero;
+
+  /// Maximum valid mineral mass (100.0 g).
+  static const Mass maxMass = Mass.grams(100.0);
+
+  DietaryMineralRecord({
     required this.mass,
     required super.time,
     required super.metadata,
@@ -16,8 +22,29 @@ sealed class DietaryMineralRecord extends NutrientRecord<Mass> {
     super.zoneOffsetSeconds,
     super.foodName,
     super.mealType,
-  });
+  }) {
+    require(
+      condition: mass >= minMass && mass <= maxMass,
+      value: mass,
+      name: 'mass',
+      message:
+          'Mineral mass must be between '
+          '${minMass.inGrams.toStringAsFixed(0)}-'
+          '${maxMass.inGrams.toStringAsFixed(0)} g. '
+          'Got ${mass.inGrams.toStringAsFixed(3)} g.',
+    );
+  }
 
   /// The mineral content of the nutrient.
   final Mass mass;
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      super == other &&
+          other is DietaryMineralRecord &&
+          (mass.inGrams - other.mass.inGrams).abs() < 1e-6;
+
+  @override
+  int get hashCode => super.hashCode ^ mass.hashCode;
 }

--- a/packages/health_connector_core/lib/src/models/health_records/nutrition/dietary_monounsaturated_fat_record.dart
+++ b/packages/health_connector_core/lib/src/models/health_records/nutrition/dietary_monounsaturated_fat_record.dart
@@ -11,8 +11,7 @@ part of '../health_record.dart';
 /// ## Platform Mapping
 ///
 /// - **iOS HealthKit Only**: [`HKQuantityTypeIdentifier.dietaryFatMonounsaturat
-/// ed`](https://developer.apple.com/documentation/healthkit/hkquantitytypeident
-/// ifier/dietaryFatMonounsaturated)
+/// ed`](https://developer.apple.com/documentation/healthkit/hkquantitytypeidentifier/dietaryFatMonounsaturated)
 /// - **Android Health Connect**: Part of [`NutritionRecord`](https://developer.android.com/reference/kotlin/androidx/health/connect/client/records/NutritionRecord)
 ///
 /// ## Example
@@ -48,25 +47,15 @@ final class DietaryMonounsaturatedFatRecord extends DietaryMacronutrientRecord {
   /// - [foodName]: Optional name of the food containing this monounsaturated
   /// fat.
   /// - [mealType]: The type of meal (breakfast, lunch, dinner, snack, unknown).
-  factory DietaryMonounsaturatedFatRecord({
-    required Mass mass,
-    required DateTime time,
-    required Metadata metadata,
-    HealthRecordId id = HealthRecordId.none,
-    int? zoneOffsetSeconds,
-    String? foodName,
-    MealType mealType = MealType.unknown,
-  }) {
-    return DietaryMonounsaturatedFatRecord._(
-      mass: mass,
-      time: time,
-      metadata: metadata,
-      id: id,
-      zoneOffsetSeconds: zoneOffsetSeconds,
-      foodName: foodName,
-      mealType: mealType,
-    );
-  }
+  DietaryMonounsaturatedFatRecord({
+    required super.mass,
+    required super.time,
+    required super.metadata,
+    super.id = HealthRecordId.none,
+    super.zoneOffsetSeconds,
+    super.foodName,
+    super.mealType,
+  });
 
   /// Internal factory for creating [DietaryMonounsaturatedFatRecord] instances
   /// without
@@ -91,7 +80,7 @@ final class DietaryMonounsaturatedFatRecord extends DietaryMacronutrientRecord {
     String? foodName,
     MealType mealType = MealType.unknown,
   }) {
-    return DietaryMonounsaturatedFatRecord._(
+    return DietaryMonounsaturatedFatRecord(
       mass: mass,
       time: time,
       metadata: metadata,
@@ -122,14 +111,4 @@ final class DietaryMonounsaturatedFatRecord extends DietaryMacronutrientRecord {
       mealType: mealType ?? this.mealType,
     );
   }
-
-  const DietaryMonounsaturatedFatRecord._({
-    required super.mass,
-    required super.time,
-    required super.metadata,
-    super.id = HealthRecordId.none,
-    super.zoneOffsetSeconds,
-    super.foodName,
-    super.mealType,
-  });
 }

--- a/packages/health_connector_core/lib/src/models/health_records/nutrition/dietary_niacin_record.dart
+++ b/packages/health_connector_core/lib/src/models/health_records/nutrition/dietary_niacin_record.dart
@@ -44,32 +44,44 @@ final class DietaryNiacinRecord extends DietaryVitaminRecord {
   /// - [zoneOffsetSeconds]: Optional timezone offset for the measurement time.
   /// - [foodName]: Optional name of the food containing this niacin.
   /// - [mealType]: The type of meal (breakfast, lunch, dinner, snack, unknown).
-  factory DietaryNiacinRecord({
-    required Mass mass,
-    required DateTime time,
-    required Metadata metadata,
-    HealthRecordId id = HealthRecordId.none,
-    int? zoneOffsetSeconds,
-    String? foodName,
-    MealType mealType = MealType.unknown,
+  ///
+  /// ## Throws
+  ///
+  /// - [ArgumentError] if [mass] is outside the valid range of
+  ///   [minMass]-[maxMass] g.
+  ///
+  /// ## Validation Rationale
+  ///
+  /// - **Minimum ([minMass] g)**: Valid mass must be non-negative.
+  /// - **Maximum ([maxMass] g)**: 10g is a reasonable upper bound for
+  ///   vitamin intake from a single food item.
+  DietaryNiacinRecord({
+    required super.mass,
+    required super.time,
+    required super.metadata,
+    super.id = HealthRecordId.none,
+    super.zoneOffsetSeconds,
+    super.foodName,
+    super.mealType,
   }) {
-    return DietaryNiacinRecord._(
-      mass: mass,
-      time: time,
-      metadata: metadata,
-      id: id,
-      zoneOffsetSeconds: zoneOffsetSeconds,
-      foodName: foodName,
-      mealType: mealType,
+    require(
+      condition: mass >= minMass && mass <= maxMass,
+      value: mass,
+      name: 'mass',
+      message:
+          'Niacin mass must be between '
+          '${minMass.inGrams.toStringAsFixed(0)}-'
+          '${maxMass.inGrams.toStringAsFixed(0)} g. '
+          'Got ${mass.inGrams.toStringAsFixed(4)} g.',
     );
   }
 
-  /// Internal factory for creating [DietaryNiacinRecord] instances without
-  /// validation.
-  ///
-  /// Creates a [DietaryNiacinRecord] by directly mapping platform data to
-  /// fields, bypassing the normal validation and business rules applied by the
-  /// public constructor.
+  /// Minimum valid niacin mass (0.0 g).
+  static const Mass minMass = Mass.zero;
+
+  /// Maximum valid niacin mass (10.0 g).
+  static const Mass maxMass = Mass.grams(10.0);
+
   ///
   /// **⚠️ Warning**: Not for public use. SDK users should use the public
   /// [DietaryNiacinRecord] constructor, which enforces validation and business
@@ -84,7 +96,7 @@ final class DietaryNiacinRecord extends DietaryVitaminRecord {
     String? foodName,
     MealType mealType = MealType.unknown,
   }) {
-    return DietaryNiacinRecord._(
+    return DietaryNiacinRecord(
       mass: mass,
       time: time,
       metadata: metadata,
@@ -115,14 +127,4 @@ final class DietaryNiacinRecord extends DietaryVitaminRecord {
       mealType: mealType ?? this.mealType,
     );
   }
-
-  const DietaryNiacinRecord._({
-    required super.mass,
-    required super.time,
-    required super.metadata,
-    super.id = HealthRecordId.none,
-    super.zoneOffsetSeconds,
-    super.foodName,
-    super.mealType,
-  });
 }

--- a/packages/health_connector_core/lib/src/models/health_records/nutrition/dietary_nutrient_record.dart
+++ b/packages/health_connector_core/lib/src/models/health_records/nutrition/dietary_nutrient_record.dart
@@ -48,4 +48,25 @@ sealed class NutrientRecord<U extends MeasurementUnit>
 
   /// The type of meal during which this nutrient was consumed.
   final MealType mealType;
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is NutrientRecord &&
+          runtimeType == other.runtimeType &&
+          id == other.id &&
+          metadata == other.metadata &&
+          time == other.time &&
+          zoneOffsetSeconds == other.zoneOffsetSeconds &&
+          foodName == other.foodName &&
+          mealType == other.mealType;
+
+  @override
+  int get hashCode =>
+      id.hashCode ^
+      metadata.hashCode ^
+      time.hashCode ^
+      zoneOffsetSeconds.hashCode ^
+      foodName.hashCode ^
+      mealType.hashCode;
 }

--- a/packages/health_connector_core/lib/src/models/health_records/nutrition/dietary_pantothenic_acid_record.dart
+++ b/packages/health_connector_core/lib/src/models/health_records/nutrition/dietary_pantothenic_acid_record.dart
@@ -11,8 +11,7 @@ part of '../health_record.dart';
 /// ## Platform Mapping
 ///
 /// - **iOS HealthKit Only**: [`HKQuantityTypeIdentifier.dietaryPantothenicAcid`
-/// ](https://developer.apple.com/documentation/healthkit/hkquantitytypeidentifi
-/// er/dietarypantothenicacid)
+/// ](https://developer.apple.com/documentation/healthkit/hkquantitytypeidentifier/dietarypantothenicacid)
 /// - **Android Health Connect**: Part of [`NutritionRecord`](https://developer.android.com/reference/kotlin/androidx/health/connect/client/records/NutritionRecord)
 ///
 /// ## Example
@@ -48,34 +47,44 @@ final class DietaryPantothenicAcidRecord extends DietaryVitaminRecord {
   /// - [zoneOffsetSeconds]: Optional timezone offset for the measurement time.
   /// - [foodName]: Optional name of the food containing this pantothenic acid.
   /// - [mealType]: The type of meal (breakfast, lunch, dinner, snack, unknown).
-  factory DietaryPantothenicAcidRecord({
-    required Mass mass,
-    required DateTime time,
-    required Metadata metadata,
-    HealthRecordId id = HealthRecordId.none,
-    int? zoneOffsetSeconds,
-    String? foodName,
-    MealType mealType = MealType.unknown,
+  ///
+  /// ## Throws
+  ///
+  /// - [ArgumentError] if [mass] is outside the valid range of
+  ///   [minMass]-[maxMass] g.
+  ///
+  /// ## Validation Rationale
+  ///
+  /// - **Minimum ([minMass] g)**: Valid mass must be non-negative.
+  /// - **Maximum ([maxMass] g)**: 10g is a reasonable upper bound for
+  ///   vitamin intake from a single food item.
+  DietaryPantothenicAcidRecord({
+    required super.mass,
+    required super.time,
+    required super.metadata,
+    super.id = HealthRecordId.none,
+    super.zoneOffsetSeconds,
+    super.foodName,
+    super.mealType,
   }) {
-    return DietaryPantothenicAcidRecord._(
-      mass: mass,
-      time: time,
-      metadata: metadata,
-      id: id,
-      zoneOffsetSeconds: zoneOffsetSeconds,
-      foodName: foodName,
-      mealType: mealType,
+    require(
+      condition: mass >= minMass && mass <= maxMass,
+      value: mass,
+      name: 'mass',
+      message:
+          'Pantothenic acid mass must be between '
+          '${minMass.inGrams.toStringAsFixed(0)}-'
+          '${maxMass.inGrams.toStringAsFixed(0)} g. '
+          'Got ${mass.inGrams.toStringAsFixed(4)} g.',
     );
   }
 
-  /// Internal factory for creating [DietaryPantothenicAcidRecord] instances
-  /// without
-  /// validation.
-  ///
-  /// Creates a [DietaryPantothenicAcidRecord] by directly mapping platform data
-  /// to
-  /// fields, bypassing the normal validation and business rules applied by the
-  /// public constructor.
+  /// Minimum valid pantothenic acid mass (0.0 g).
+  static const Mass minMass = Mass.zero;
+
+  /// Maximum valid pantothenic acid mass (10.0 g).
+  static const Mass maxMass = Mass.grams(10.0);
+
   ///
   /// **⚠️ Warning**: Not for public use. SDK users should use the public
   /// [DietaryPantothenicAcidRecord] constructor, which enforces validation and
@@ -91,7 +100,7 @@ final class DietaryPantothenicAcidRecord extends DietaryVitaminRecord {
     String? foodName,
     MealType mealType = MealType.unknown,
   }) {
-    return DietaryPantothenicAcidRecord._(
+    return DietaryPantothenicAcidRecord(
       mass: mass,
       time: time,
       metadata: metadata,
@@ -122,14 +131,4 @@ final class DietaryPantothenicAcidRecord extends DietaryVitaminRecord {
       mealType: mealType ?? this.mealType,
     );
   }
-
-  const DietaryPantothenicAcidRecord._({
-    required super.mass,
-    required super.time,
-    required super.metadata,
-    super.id = HealthRecordId.none,
-    super.zoneOffsetSeconds,
-    super.foodName,
-    super.mealType,
-  });
 }

--- a/packages/health_connector_core/lib/src/models/health_records/nutrition/dietary_phosphorus_record.dart
+++ b/packages/health_connector_core/lib/src/models/health_records/nutrition/dietary_phosphorus_record.dart
@@ -43,32 +43,44 @@ final class DietaryPhosphorusRecord extends DietaryMineralRecord {
   /// - [zoneOffsetSeconds]: Optional timezone offset for the measurement time.
   /// - [foodName]: Optional name of the food containing this phosphorus.
   /// - [mealType]: The type of meal (breakfast, lunch, dinner, snack, unknown).
-  factory DietaryPhosphorusRecord({
-    required Mass mass,
-    required DateTime time,
-    required Metadata metadata,
-    HealthRecordId id = HealthRecordId.none,
-    int? zoneOffsetSeconds,
-    String? foodName,
-    MealType mealType = MealType.unknown,
+  ///
+  /// ## Throws
+  ///
+  /// - [ArgumentError] if [mass] is outside the valid range of
+  ///   [minMass]-[maxMass].
+  ///
+  /// ## Validation Rationale
+  ///
+  /// - **Minimum ([minMass])**: Valid mass must be non-negative.
+  /// - **Maximum ([maxMass])**: 100g is a reasonable upper bound for
+  ///   mineral intake from a single food item.
+  DietaryPhosphorusRecord({
+    required super.mass,
+    required super.time,
+    required super.metadata,
+    super.id = HealthRecordId.none,
+    super.zoneOffsetSeconds,
+    super.foodName,
+    super.mealType,
   }) {
-    return DietaryPhosphorusRecord._(
-      mass: mass,
-      time: time,
-      metadata: metadata,
-      id: id,
-      zoneOffsetSeconds: zoneOffsetSeconds,
-      foodName: foodName,
-      mealType: mealType,
+    require(
+      condition: mass >= minMass && mass <= maxMass,
+      value: mass,
+      name: 'mass',
+      message:
+          'Phosphorus mass must be between '
+          '${minMass.inGrams.toStringAsFixed(0)}-'
+          '${maxMass.inGrams.toStringAsFixed(0)} g. '
+          'Got ${mass.inGrams.toStringAsFixed(3)} g.',
     );
   }
 
-  /// Internal factory for creating [DietaryPhosphorusRecord] instances without
-  /// validation.
-  ///
-  /// Creates a [DietaryPhosphorusRecord] by directly mapping platform data to
-  /// fields, bypassing the normal validation and business rules applied by the
-  /// public constructor.
+  /// Minimum valid phosphorus mass (0.0 g).
+  static const Mass minMass = Mass.zero;
+
+  /// Maximum valid phosphorus mass (100.0 g).
+  static const Mass maxMass = Mass.grams(100.0);
+
   ///
   /// **⚠️ Warning**: Not for public use. SDK users should use the public
   /// [DietaryPhosphorusRecord] constructor, which enforces validation and
@@ -84,7 +96,7 @@ final class DietaryPhosphorusRecord extends DietaryMineralRecord {
     String? foodName,
     MealType mealType = MealType.unknown,
   }) {
-    return DietaryPhosphorusRecord._(
+    return DietaryPhosphorusRecord(
       mass: mass,
       time: time,
       metadata: metadata,
@@ -115,14 +127,4 @@ final class DietaryPhosphorusRecord extends DietaryMineralRecord {
       mealType: mealType ?? this.mealType,
     );
   }
-
-  const DietaryPhosphorusRecord._({
-    required super.mass,
-    required super.time,
-    required super.metadata,
-    super.id = HealthRecordId.none,
-    super.zoneOffsetSeconds,
-    super.foodName,
-    super.mealType,
-  });
 }

--- a/packages/health_connector_core/lib/src/models/health_records/nutrition/dietary_polyunsaturated_fat_record.dart
+++ b/packages/health_connector_core/lib/src/models/health_records/nutrition/dietary_polyunsaturated_fat_record.dart
@@ -11,8 +11,7 @@ part of '../health_record.dart';
 /// ## Platform Mapping
 ///
 /// - **iOS HealthKit Only**: [`HKQuantityTypeIdentifier.dietaryFatPolyunsaturat
-/// ed`](https://developer.apple.com/documentation/healthkit/hkquantitytypeident
-/// ifier/dietaryfatpolyunsaturated)
+/// ed`](https://developer.apple.com/documentation/healthkit/hkquantitytypeidentifier/dietaryfatpolyunsaturated)
 /// - **Android Health Connect**: Part of [`NutritionRecord`](https://developer.android.com/reference/kotlin/androidx/health/connect/client/records/NutritionRecord)
 ///
 /// ## Example
@@ -46,36 +45,46 @@ final class DietaryPolyunsaturatedFatRecord extends DietaryMacronutrientRecord {
   /// - [id]: The unique identifier for this record.
   /// - [zoneOffsetSeconds]: Optional timezone offset for the measurement time.
   /// - [foodName]: Optional name of the food containing this polyunsaturated
-  /// fat.
+  ///   fat.
   /// - [mealType]: The type of meal (breakfast, lunch, dinner, snack, unknown).
-  factory DietaryPolyunsaturatedFatRecord({
-    required Mass mass,
-    required DateTime time,
-    required Metadata metadata,
-    HealthRecordId id = HealthRecordId.none,
-    int? zoneOffsetSeconds,
-    String? foodName,
-    MealType mealType = MealType.unknown,
+  ///
+  /// ## Throws
+  ///
+  /// - [ArgumentError] if [mass] is outside the valid range of
+  ///   [minMass]-[maxMass].
+  ///
+  /// ## Validation Rationale
+  ///
+  /// - **Minimum ([minMass])**: Valid mass must be non-negative.
+  /// - **Maximum ([maxMass])**: 1,000g is a reasonable upper bound for
+  ///   macronutrient intake from a single food item.
+  DietaryPolyunsaturatedFatRecord({
+    required super.mass,
+    required super.time,
+    required super.metadata,
+    super.id = HealthRecordId.none,
+    super.zoneOffsetSeconds,
+    super.foodName,
+    super.mealType,
   }) {
-    return DietaryPolyunsaturatedFatRecord._(
-      mass: mass,
-      time: time,
-      metadata: metadata,
-      id: id,
-      zoneOffsetSeconds: zoneOffsetSeconds,
-      foodName: foodName,
-      mealType: mealType,
+    require(
+      condition: mass >= minMass && mass <= maxMass,
+      value: mass,
+      name: 'mass',
+      message:
+          'Polyunsaturated fat mass must be between '
+          '${minMass.inGrams.toStringAsFixed(0)}-'
+          '${maxMass.inGrams.toStringAsFixed(0)} g. '
+          'Got ${mass.inGrams.toStringAsFixed(1)} g.',
     );
   }
 
-  /// Internal factory for creating [DietaryPolyunsaturatedFatRecord] instances
-  /// without
-  /// validation.
-  ///
-  /// Creates a [DietaryPolyunsaturatedFatRecord] by directly mapping platform
-  /// data to
-  /// fields, bypassing the normal validation and business rules applied by the
-  /// public constructor.
+  /// Minimum valid polyunsaturated fat mass (0.0 g).
+  static const Mass minMass = Mass.zero;
+
+  /// Maximum valid polyunsaturated fat mass (1,000.0 g).
+  static const Mass maxMass = Mass.grams(1000.0);
+
   ///
   /// **⚠️ Warning**: Not for public use. SDK users should use the public
   /// [DietaryPolyunsaturatedFatRecord] constructor, which enforces validation
@@ -91,7 +100,7 @@ final class DietaryPolyunsaturatedFatRecord extends DietaryMacronutrientRecord {
     String? foodName,
     MealType mealType = MealType.unknown,
   }) {
-    return DietaryPolyunsaturatedFatRecord._(
+    return DietaryPolyunsaturatedFatRecord(
       mass: mass,
       time: time,
       metadata: metadata,
@@ -122,14 +131,4 @@ final class DietaryPolyunsaturatedFatRecord extends DietaryMacronutrientRecord {
       mealType: mealType ?? this.mealType,
     );
   }
-
-  const DietaryPolyunsaturatedFatRecord._({
-    required super.mass,
-    required super.time,
-    required super.metadata,
-    super.id = HealthRecordId.none,
-    super.zoneOffsetSeconds,
-    super.foodName,
-    super.mealType,
-  });
 }

--- a/packages/health_connector_core/lib/src/models/health_records/nutrition/dietary_potassium_record.dart
+++ b/packages/health_connector_core/lib/src/models/health_records/nutrition/dietary_potassium_record.dart
@@ -42,32 +42,44 @@ final class DietaryPotassiumRecord extends DietaryMineralRecord {
   /// - [zoneOffsetSeconds]: Optional timezone offset for the measurement time.
   /// - [foodName]: Optional name of the food containing this potassium.
   /// - [mealType]: The type of meal (breakfast, lunch, dinner, snack, unknown).
-  factory DietaryPotassiumRecord({
-    required Mass mass,
-    required DateTime time,
-    required Metadata metadata,
-    HealthRecordId id = HealthRecordId.none,
-    int? zoneOffsetSeconds,
-    String? foodName,
-    MealType mealType = MealType.unknown,
+  ///
+  /// ## Throws
+  ///
+  /// - [ArgumentError] if [mass] is outside the valid range of
+  ///   [minMass]-[maxMass] g.
+  ///
+  /// ## Validation Rationale
+  ///
+  /// - **Minimum ([minMass] g)**: Valid mass must be non-negative.
+  /// - **Maximum ([maxMass] g)**: 100g is a reasonable upper bound for
+  ///   mineral intake from a single food item.
+  DietaryPotassiumRecord({
+    required super.mass,
+    required super.time,
+    required super.metadata,
+    super.id = HealthRecordId.none,
+    super.zoneOffsetSeconds,
+    super.foodName,
+    super.mealType,
   }) {
-    return DietaryPotassiumRecord._(
-      mass: mass,
-      time: time,
-      metadata: metadata,
-      id: id,
-      zoneOffsetSeconds: zoneOffsetSeconds,
-      foodName: foodName,
-      mealType: mealType,
+    require(
+      condition: mass >= minMass && mass <= maxMass,
+      value: mass,
+      name: 'mass',
+      message:
+          'Potassium mass must be between '
+          '${minMass.inGrams.toStringAsFixed(0)}-'
+          '${maxMass.inGrams.toStringAsFixed(0)} g. '
+          'Got ${mass.inGrams.toStringAsFixed(3)} g.',
     );
   }
 
-  /// Internal factory for creating [DietaryPotassiumRecord] instances without
-  /// validation.
-  ///
-  /// Creates a [DietaryPotassiumRecord] by directly mapping platform data to
-  /// fields, bypassing the normal validation and business rules applied by the
-  /// public constructor.
+  /// Minimum valid potassium mass (0.0 g).
+  static const Mass minMass = Mass.zero;
+
+  /// Maximum valid potassium mass (100.0 g).
+  static const Mass maxMass = Mass.grams(100.0);
+
   ///
   /// **⚠️ Warning**: Not for public use. SDK users should use the public
   /// [DietaryPotassiumRecord] constructor, which enforces validation and
@@ -83,7 +95,7 @@ final class DietaryPotassiumRecord extends DietaryMineralRecord {
     String? foodName,
     MealType mealType = MealType.unknown,
   }) {
-    return DietaryPotassiumRecord._(
+    return DietaryPotassiumRecord(
       mass: mass,
       time: time,
       metadata: metadata,
@@ -114,14 +126,4 @@ final class DietaryPotassiumRecord extends DietaryMineralRecord {
       mealType: mealType ?? this.mealType,
     );
   }
-
-  const DietaryPotassiumRecord._({
-    required super.mass,
-    required super.time,
-    required super.metadata,
-    super.id = HealthRecordId.none,
-    super.zoneOffsetSeconds,
-    super.foodName,
-    super.mealType,
-  });
 }

--- a/packages/health_connector_core/lib/src/models/health_records/nutrition/dietary_protein_record.dart
+++ b/packages/health_connector_core/lib/src/models/health_records/nutrition/dietary_protein_record.dart
@@ -7,9 +7,7 @@ part of '../health_record.dart';
 ///
 /// ## Platform Mapping
 ///
-/// - **iOS HealthKit Only**: [`HKQuantityTypeIdentifier.dietaryProtein`](https:
-/// //developer.apple.com/documentation/healthkit/hkquantitytypeidentifier/dieta
-/// ryprotein)
+/// - **iOS HealthKit Only**: [`HKQuantityTypeIdentifier.dietaryProtein`](https://developer.apple.com/documentation/healthkit/hkquantitytypeidentifier/dietaryprotein)
 /// - **Android Health Connect**: Part of [`NutritionRecord`](https://developer.android.com/reference/kotlin/androidx/health/connect/client/records/NutritionRecord)
 ///
 /// ## Example
@@ -44,32 +42,44 @@ final class DietaryProteinRecord extends DietaryMacronutrientRecord {
   /// - [zoneOffsetSeconds]: Optional timezone offset for the measurement time.
   /// - [foodName]: Optional name of the food containing this protein.
   /// - [mealType]: The type of meal (breakfast, lunch, dinner, snack, unknown).
-  factory DietaryProteinRecord({
-    required Mass mass,
-    required DateTime time,
-    required Metadata metadata,
-    HealthRecordId id = HealthRecordId.none,
-    int? zoneOffsetSeconds,
-    String? foodName,
-    MealType mealType = MealType.unknown,
+  ///
+  /// ## Throws
+  ///
+  /// - [ArgumentError] if [mass] is outside the valid range of
+  ///   [minMass]-[maxMass] g.
+  ///
+  /// ## Validation Rationale
+  ///
+  /// - **Minimum ([minMass] g)**: Valid mass must be non-negative.
+  /// - **Maximum ([maxMass] g)**: 1,000g is a reasonable upper bound for
+  ///   macronutrient intake from a single food item.
+  DietaryProteinRecord({
+    required super.mass,
+    required super.time,
+    required super.metadata,
+    super.id = HealthRecordId.none,
+    super.zoneOffsetSeconds,
+    super.foodName,
+    super.mealType,
   }) {
-    return DietaryProteinRecord._(
-      mass: mass,
-      time: time,
-      metadata: metadata,
-      id: id,
-      zoneOffsetSeconds: zoneOffsetSeconds,
-      foodName: foodName,
-      mealType: mealType,
+    require(
+      condition: mass >= minMass && mass <= maxMass,
+      value: mass,
+      name: 'mass',
+      message:
+          'Protein mass must be between '
+          '${minMass.inGrams.toStringAsFixed(0)}-'
+          '${maxMass.inGrams.toStringAsFixed(0)} g. '
+          'Got ${mass.inGrams.toStringAsFixed(1)} g.',
     );
   }
 
-  /// Internal factory for creating [DietaryProteinRecord] instances without
-  /// validation.
-  ///
-  /// Creates a [DietaryProteinRecord] by directly mapping platform data to
-  /// fields, bypassing the normal validation and business rules applied by the
-  /// public constructor.
+  /// Minimum valid protein mass (0.0 g).
+  static const Mass minMass = Mass.zero;
+
+  /// Maximum valid protein mass (1,000.0 g).
+  static const Mass maxMass = Mass.grams(1000.0);
+
   ///
   /// **⚠️ Warning**: Not for public use. SDK users should use the public
   /// [DietaryProteinRecord] constructor, which enforces validation and business
@@ -84,7 +94,7 @@ final class DietaryProteinRecord extends DietaryMacronutrientRecord {
     String? foodName,
     MealType mealType = MealType.unknown,
   }) {
-    return DietaryProteinRecord._(
+    return DietaryProteinRecord(
       mass: mass,
       time: time,
       metadata: metadata,
@@ -115,14 +125,4 @@ final class DietaryProteinRecord extends DietaryMacronutrientRecord {
       mealType: mealType ?? this.mealType,
     );
   }
-
-  const DietaryProteinRecord._({
-    required super.mass,
-    required super.time,
-    required super.metadata,
-    super.id = HealthRecordId.none,
-    super.zoneOffsetSeconds,
-    super.foodName,
-    super.mealType,
-  });
 }

--- a/packages/health_connector_core/lib/src/models/health_records/nutrition/dietary_riboflavin_record.dart
+++ b/packages/health_connector_core/lib/src/models/health_records/nutrition/dietary_riboflavin_record.dart
@@ -45,32 +45,44 @@ final class DietaryRiboflavinRecord extends DietaryVitaminRecord {
   /// - [zoneOffsetSeconds]: Optional timezone offset for the measurement time.
   /// - [foodName]: Optional name of the food containing this riboflavin.
   /// - [mealType]: The type of meal (breakfast, lunch, dinner, snack, unknown).
-  factory DietaryRiboflavinRecord({
-    required Mass mass,
-    required DateTime time,
-    required Metadata metadata,
-    HealthRecordId id = HealthRecordId.none,
-    int? zoneOffsetSeconds,
-    String? foodName,
-    MealType mealType = MealType.unknown,
+  ///
+  /// ## Throws
+  ///
+  /// - [ArgumentError] if [mass] is outside the valid range of
+  ///   [minMass]-[maxMass] g.
+  ///
+  /// ## Validation Rationale
+  ///
+  /// - **Minimum ([minMass] g)**: Valid mass must be non-negative.
+  /// - **Maximum ([maxMass] g)**: 10g is a reasonable upper bound for
+  ///   vitamin intake from a single food item.
+  DietaryRiboflavinRecord({
+    required super.mass,
+    required super.time,
+    required super.metadata,
+    super.id = HealthRecordId.none,
+    super.zoneOffsetSeconds,
+    super.foodName,
+    super.mealType,
   }) {
-    return DietaryRiboflavinRecord._(
-      mass: mass,
-      time: time,
-      metadata: metadata,
-      id: id,
-      zoneOffsetSeconds: zoneOffsetSeconds,
-      foodName: foodName,
-      mealType: mealType,
+    require(
+      condition: mass >= minMass && mass <= maxMass,
+      value: mass,
+      name: 'mass',
+      message:
+          'Riboflavin mass must be between '
+          '${minMass.inGrams.toStringAsFixed(0)}-'
+          '${maxMass.inGrams.toStringAsFixed(0)} g. '
+          'Got ${mass.inGrams.toStringAsFixed(4)} g.',
     );
   }
 
-  /// Internal factory for creating [DietaryRiboflavinRecord] instances without
-  /// validation.
-  ///
-  /// Creates a [DietaryRiboflavinRecord] by directly mapping platform data to
-  /// fields, bypassing the normal validation and business rules applied by the
-  /// public constructor.
+  /// Minimum valid riboflavin mass (0.0 g).
+  static const Mass minMass = Mass.zero;
+
+  /// Maximum valid riboflavin mass (10.0 g).
+  static const Mass maxMass = Mass.grams(10.0);
+
   ///
   /// **⚠️ Warning**: Not for public use. SDK users should use the public
   /// [DietaryRiboflavinRecord] constructor, which enforces validation and
@@ -86,7 +98,7 @@ final class DietaryRiboflavinRecord extends DietaryVitaminRecord {
     String? foodName,
     MealType mealType = MealType.unknown,
   }) {
-    return DietaryRiboflavinRecord._(
+    return DietaryRiboflavinRecord(
       mass: mass,
       time: time,
       metadata: metadata,
@@ -117,14 +129,4 @@ final class DietaryRiboflavinRecord extends DietaryVitaminRecord {
       mealType: mealType ?? this.mealType,
     );
   }
-
-  const DietaryRiboflavinRecord._({
-    required super.mass,
-    required super.time,
-    required super.metadata,
-    super.id = HealthRecordId.none,
-    super.zoneOffsetSeconds,
-    super.foodName,
-    super.mealType,
-  });
 }

--- a/packages/health_connector_core/lib/src/models/health_records/nutrition/dietary_saturated_fat_record.dart
+++ b/packages/health_connector_core/lib/src/models/health_records/nutrition/dietary_saturated_fat_record.dart
@@ -46,33 +46,44 @@ final class DietarySaturatedFatRecord extends DietaryMacronutrientRecord {
   /// - [zoneOffsetSeconds]: Optional timezone offset for the measurement time.
   /// - [foodName]: Optional name of the food containing this saturated fat.
   /// - [mealType]: The type of meal (breakfast, lunch, dinner, snack, unknown).
-  factory DietarySaturatedFatRecord({
-    required Mass mass,
-    required DateTime time,
-    required Metadata metadata,
-    HealthRecordId id = HealthRecordId.none,
-    int? zoneOffsetSeconds,
-    String? foodName,
-    MealType mealType = MealType.unknown,
+  ///
+  /// ## Throws
+  ///
+  /// - [ArgumentError] if [mass] is outside the valid range of
+  ///   [minMass]-[maxMass] g.
+  ///
+  /// ## Validation Rationale
+  ///
+  /// - **Minimum ([minMass] g)**: Valid mass must be non-negative.
+  /// - **Maximum ([maxMass] g)**: 1,000g is a reasonable upper bound for
+  ///   macronutrient intake from a single food item.
+  DietarySaturatedFatRecord({
+    required super.mass,
+    required super.time,
+    required super.metadata,
+    super.id = HealthRecordId.none,
+    super.zoneOffsetSeconds,
+    super.foodName,
+    super.mealType,
   }) {
-    return DietarySaturatedFatRecord._(
-      mass: mass,
-      time: time,
-      metadata: metadata,
-      id: id,
-      zoneOffsetSeconds: zoneOffsetSeconds,
-      foodName: foodName,
-      mealType: mealType,
+    require(
+      condition: mass >= minMass && mass <= maxMass,
+      value: mass,
+      name: 'mass',
+      message:
+          'Saturated fat mass must be between '
+          '${minMass.inGrams.toStringAsFixed(0)}-'
+          '${maxMass.inGrams.toStringAsFixed(0)} g. '
+          'Got ${mass.inGrams.toStringAsFixed(1)} g.',
     );
   }
 
-  /// Internal factory for creating [DietarySaturatedFatRecord] instances
-  /// without
-  /// validation.
-  ///
-  /// Creates a [DietarySaturatedFatRecord] by directly mapping platform data to
-  /// fields, bypassing the normal validation and business rules applied by the
-  /// public constructor.
+  /// Minimum valid saturated fat mass (0.0 g).
+  static const Mass minMass = Mass.zero;
+
+  /// Maximum valid saturated fat mass (1,000.0 g).
+  static const Mass maxMass = Mass.grams(1000.0);
+
   ///
   /// **⚠️ Warning**: Not for public use. SDK users should use the public
   /// [DietarySaturatedFatRecord] constructor, which enforces validation and
@@ -88,7 +99,7 @@ final class DietarySaturatedFatRecord extends DietaryMacronutrientRecord {
     String? foodName,
     MealType mealType = MealType.unknown,
   }) {
-    return DietarySaturatedFatRecord._(
+    return DietarySaturatedFatRecord(
       mass: mass,
       time: time,
       metadata: metadata,
@@ -119,14 +130,4 @@ final class DietarySaturatedFatRecord extends DietaryMacronutrientRecord {
       mealType: mealType ?? this.mealType,
     );
   }
-
-  const DietarySaturatedFatRecord._({
-    required super.mass,
-    required super.time,
-    required super.metadata,
-    super.id = HealthRecordId.none,
-    super.zoneOffsetSeconds,
-    super.foodName,
-    super.mealType,
-  });
 }

--- a/packages/health_connector_core/lib/src/models/health_records/nutrition/dietary_selenium_record.dart
+++ b/packages/health_connector_core/lib/src/models/health_records/nutrition/dietary_selenium_record.dart
@@ -7,9 +7,7 @@ part of '../health_record.dart';
 ///
 /// ## Platform Mapping
 ///
-/// - **iOS HealthKit Only**: [`HKQuantityTypeIdentifier.dietarySelenium`](https
-/// ://developer.apple.com/documentation/healthkit/hkquantitytypeidentifier/diet
-/// aryselenium)
+/// - **iOS HealthKit Only**: [`HKQuantityTypeIdentifier.dietarySelenium`](https://developer.apple.com/documentation/healthkit/hkquantitytypeidentifier/dietaryselenium)
 /// - **Android Health Connect**: Part of [`NutritionRecord`](https://developer.android.com/reference/kotlin/androidx/health/connect/client/records/NutritionRecord)
 ///
 /// ## Example
@@ -44,32 +42,44 @@ final class DietarySeleniumRecord extends DietaryMineralRecord {
   /// - [zoneOffsetSeconds]: Optional timezone offset for the measurement time.
   /// - [foodName]: Optional name of the food containing this selenium.
   /// - [mealType]: The type of meal (breakfast, lunch, dinner, snack, unknown).
-  factory DietarySeleniumRecord({
-    required Mass mass,
-    required DateTime time,
-    required Metadata metadata,
-    HealthRecordId id = HealthRecordId.none,
-    int? zoneOffsetSeconds,
-    String? foodName,
-    MealType mealType = MealType.unknown,
+  ///
+  /// ## Throws
+  ///
+  /// - [ArgumentError] if [mass] is outside the valid range of
+  ///   [minMass]-[maxMass] g.
+  ///
+  /// ## Validation Rationale
+  ///
+  /// - **Minimum ([minMass] g)**: Valid mass must be non-negative.
+  /// - **Maximum ([maxMass] g)**: 100g is a reasonable upper bound for
+  ///   mineral intake from a single food item.
+  DietarySeleniumRecord({
+    required super.mass,
+    required super.time,
+    required super.metadata,
+    super.id = HealthRecordId.none,
+    super.zoneOffsetSeconds,
+    super.foodName,
+    super.mealType,
   }) {
-    return DietarySeleniumRecord._(
-      mass: mass,
-      time: time,
-      metadata: metadata,
-      id: id,
-      zoneOffsetSeconds: zoneOffsetSeconds,
-      foodName: foodName,
-      mealType: mealType,
+    require(
+      condition: mass >= minMass && mass <= maxMass,
+      value: mass,
+      name: 'mass',
+      message:
+          'Selenium mass must be between '
+          '${minMass.inGrams.toStringAsFixed(0)}-'
+          '${maxMass.inGrams.toStringAsFixed(0)} g. '
+          'Got ${mass.inGrams.toStringAsFixed(3)} g.',
     );
   }
 
-  /// Internal factory for creating [DietarySeleniumRecord] instances without
-  /// validation.
-  ///
-  /// Creates a [DietarySeleniumRecord] by directly mapping platform data to
-  /// fields, bypassing the normal validation and business rules applied by the
-  /// public constructor.
+  /// Minimum valid selenium mass (0.0 g).
+  static const Mass minMass = Mass.zero;
+
+  /// Maximum valid selenium mass (100.0 g).
+  static const Mass maxMass = Mass.grams(100.0);
+
   ///
   /// **⚠️ Warning**: Not for public use. SDK users should use the public
   /// [DietarySeleniumRecord] constructor, which enforces validation and
@@ -85,7 +95,7 @@ final class DietarySeleniumRecord extends DietaryMineralRecord {
     String? foodName,
     MealType mealType = MealType.unknown,
   }) {
-    return DietarySeleniumRecord._(
+    return DietarySeleniumRecord(
       mass: mass,
       time: time,
       metadata: metadata,
@@ -116,14 +126,4 @@ final class DietarySeleniumRecord extends DietaryMineralRecord {
       mealType: mealType ?? this.mealType,
     );
   }
-
-  const DietarySeleniumRecord._({
-    required super.mass,
-    required super.time,
-    required super.metadata,
-    super.id = HealthRecordId.none,
-    super.zoneOffsetSeconds,
-    super.foodName,
-    super.mealType,
-  });
 }

--- a/packages/health_connector_core/lib/src/models/health_records/nutrition/dietary_sodium_record.dart
+++ b/packages/health_connector_core/lib/src/models/health_records/nutrition/dietary_sodium_record.dart
@@ -42,32 +42,44 @@ final class DietarySodiumRecord extends DietaryMineralRecord {
   /// - [zoneOffsetSeconds]: Optional timezone offset for the measurement time.
   /// - [foodName]: Optional name of the food containing this sodium.
   /// - [mealType]: The type of meal (breakfast, lunch, dinner, snack, unknown).
-  factory DietarySodiumRecord({
-    required Mass mass,
-    required DateTime time,
-    required Metadata metadata,
-    HealthRecordId id = HealthRecordId.none,
-    int? zoneOffsetSeconds,
-    String? foodName,
-    MealType mealType = MealType.unknown,
+  ///
+  /// ## Throws
+  ///
+  /// - [ArgumentError] if [mass] is outside the valid range of
+  ///   [minMass]-[maxMass] g.
+  ///
+  /// ## Validation Rationale
+  ///
+  /// - **Minimum ([minMass] g)**: Valid mass must be non-negative.
+  /// - **Maximum ([maxMass] g)**: 100g is a reasonable upper bound for
+  ///   mineral intake from a single food item.
+  DietarySodiumRecord({
+    required super.mass,
+    required super.time,
+    required super.metadata,
+    super.id = HealthRecordId.none,
+    super.zoneOffsetSeconds,
+    super.foodName,
+    super.mealType,
   }) {
-    return DietarySodiumRecord._(
-      mass: mass,
-      time: time,
-      metadata: metadata,
-      id: id,
-      zoneOffsetSeconds: zoneOffsetSeconds,
-      foodName: foodName,
-      mealType: mealType,
+    require(
+      condition: mass >= minMass && mass <= maxMass,
+      value: mass,
+      name: 'mass',
+      message:
+          'Sodium mass must be between '
+          '${minMass.inGrams.toStringAsFixed(0)}-'
+          '${maxMass.inGrams.toStringAsFixed(0)} g. '
+          'Got ${mass.inGrams.toStringAsFixed(3)} g.',
     );
   }
 
-  /// Internal factory for creating [DietarySodiumRecord] instances without
-  /// validation.
-  ///
-  /// Creates a [DietarySodiumRecord] by directly mapping platform data to
-  /// fields, bypassing the normal validation and business rules applied by the
-  /// public constructor.
+  /// Minimum valid sodium mass (0.0 g).
+  static const Mass minMass = Mass.zero;
+
+  /// Maximum valid sodium mass (100.0 g).
+  static const Mass maxMass = Mass.grams(100.0);
+
   ///
   /// **⚠️ Warning**: Not for public use. SDK users should use the public
   /// [DietarySodiumRecord] constructor, which enforces validation and business
@@ -82,7 +94,7 @@ final class DietarySodiumRecord extends DietaryMineralRecord {
     String? foodName,
     MealType mealType = MealType.unknown,
   }) {
-    return DietarySodiumRecord._(
+    return DietarySodiumRecord(
       mass: mass,
       time: time,
       metadata: metadata,
@@ -113,14 +125,4 @@ final class DietarySodiumRecord extends DietaryMineralRecord {
       mealType: mealType ?? this.mealType,
     );
   }
-
-  const DietarySodiumRecord._({
-    required super.mass,
-    required super.time,
-    required super.metadata,
-    super.id = HealthRecordId.none,
-    super.zoneOffsetSeconds,
-    super.foodName,
-    super.mealType,
-  });
 }

--- a/packages/health_connector_core/lib/src/models/health_records/nutrition/dietary_sugar_record.dart
+++ b/packages/health_connector_core/lib/src/models/health_records/nutrition/dietary_sugar_record.dart
@@ -7,8 +7,7 @@ part of '../health_record.dart';
 ///
 /// ## Platform Mapping
 ///
-/// - **iOS HealthKit Only**: [`HKQuantityTypeIdentifier.dietarySugar`](https://developer.apple.com/documentation/healthkit/hkquantitytypeidentifier/dietary
-/// Sugar)
+/// - **iOS HealthKit Only**: [`HKQuantityTypeIdentifier.dietarySugar`](https://developer.apple.com/documentation/healthkit/hkquantitytypeidentifier/dietarySugar)
 /// - **Android Health Connect**: Part of [`NutritionRecord`](https://developer.android.com/reference/kotlin/androidx/health/connect/client/records/NutritionRecord)
 ///
 /// ## Example
@@ -43,32 +42,44 @@ final class DietarySugarRecord extends DietaryMacronutrientRecord {
   /// - [zoneOffsetSeconds]: Optional timezone offset for the measurement time.
   /// - [foodName]: Optional name of the food containing this sugar.
   /// - [mealType]: The type of meal (breakfast, lunch, dinner, snack, unknown).
-  factory DietarySugarRecord({
-    required Mass mass,
-    required DateTime time,
-    required Metadata metadata,
-    HealthRecordId id = HealthRecordId.none,
-    int? zoneOffsetSeconds,
-    String? foodName,
-    MealType mealType = MealType.unknown,
+  ///
+  /// ## Throws
+  ///
+  /// - [ArgumentError] if [mass] is outside the valid range of
+  ///   [minMass]-[maxMass] g.
+  ///
+  /// ## Validation Rationale
+  ///
+  /// - **Minimum ([minMass] g)**: Valid mass must be non-negative.
+  /// - **Maximum ([maxMass] g)**: 1,000g is a reasonable upper bound for
+  ///   macronutrient intake from a single food item.
+  DietarySugarRecord({
+    required super.mass,
+    required super.time,
+    required super.metadata,
+    super.id = HealthRecordId.none,
+    super.zoneOffsetSeconds,
+    super.foodName,
+    super.mealType,
   }) {
-    return DietarySugarRecord._(
-      mass: mass,
-      time: time,
-      metadata: metadata,
-      id: id,
-      zoneOffsetSeconds: zoneOffsetSeconds,
-      foodName: foodName,
-      mealType: mealType,
+    require(
+      condition: mass >= minMass && mass <= maxMass,
+      value: mass,
+      name: 'mass',
+      message:
+          'Sugar mass must be between '
+          '${minMass.inGrams.toStringAsFixed(0)}-'
+          '${maxMass.inGrams.toStringAsFixed(0)} g. '
+          'Got ${mass.inGrams.toStringAsFixed(1)} g.',
     );
   }
 
-  /// Internal factory for creating [DietarySugarRecord] instances without
-  /// validation.
-  ///
-  /// Creates a [DietarySugarRecord] by directly mapping platform data to
-  /// fields, bypassing the normal validation and business rules applied by the
-  /// public constructor.
+  /// Minimum valid sugar mass (0.0 g).
+  static const Mass minMass = Mass.zero;
+
+  /// Maximum valid sugar mass (1,000.0 g).
+  static const Mass maxMass = Mass.grams(1000.0);
+
   ///
   /// **⚠️ Warning**: Not for public use. SDK users should use the public
   /// [DietarySugarRecord] constructor, which enforces validation and business
@@ -83,7 +94,7 @@ final class DietarySugarRecord extends DietaryMacronutrientRecord {
     String? foodName,
     MealType mealType = MealType.unknown,
   }) {
-    return DietarySugarRecord._(
+    return DietarySugarRecord(
       mass: mass,
       time: time,
       metadata: metadata,
@@ -114,14 +125,4 @@ final class DietarySugarRecord extends DietaryMacronutrientRecord {
       mealType: mealType ?? this.mealType,
     );
   }
-
-  const DietarySugarRecord._({
-    required super.mass,
-    required super.time,
-    required super.metadata,
-    super.id = HealthRecordId.none,
-    super.zoneOffsetSeconds,
-    super.foodName,
-    super.mealType,
-  });
 }

--- a/packages/health_connector_core/lib/src/models/health_records/nutrition/dietary_thiamin_record.dart
+++ b/packages/health_connector_core/lib/src/models/health_records/nutrition/dietary_thiamin_record.dart
@@ -8,9 +8,7 @@ part of '../health_record.dart';
 ///
 /// ## Platform Mapping
 ///
-/// - **iOS HealthKit Only**: [`HKQuantityTypeIdentifier.dietaryThiamin`](https:
-/// //developer.apple.com/documentation/healthkit/hkquantitytypeidentifier/dieta
-/// rythiamin)
+/// - **iOS HealthKit Only**: [`HKQuantityTypeIdentifier.dietaryThiamin`](https://developer.apple.com/documentation/healthkit/hkquantitytypeidentifier/dietarythiamin)
 /// - **Android Health Connect**: Part of [`NutritionRecord`](https://developer.android.com/reference/kotlin/androidx/health/connect/client/records/NutritionRecord)
 ///
 /// ## Example
@@ -46,32 +44,44 @@ final class DietaryThiaminRecord extends DietaryVitaminRecord {
   /// - [zoneOffsetSeconds]: Optional timezone offset for the measurement time.
   /// - [foodName]: Optional name of the food containing this thiamin.
   /// - [mealType]: The type of meal (breakfast, lunch, dinner, snack, unknown).
-  factory DietaryThiaminRecord({
-    required Mass mass,
-    required DateTime time,
-    required Metadata metadata,
-    HealthRecordId id = HealthRecordId.none,
-    int? zoneOffsetSeconds,
-    String? foodName,
-    MealType mealType = MealType.unknown,
+  ///
+  /// ## Throws
+  ///
+  /// - [ArgumentError] if [mass] is outside the valid range of
+  ///   [minMass]-[maxMass] g.
+  ///
+  /// ## Validation Rationale
+  ///
+  /// - **Minimum ([minMass] g)**: Valid mass must be non-negative.
+  /// - **Maximum ([maxMass] g)**: 10g is a reasonable upper bound for
+  ///   vitamin intake from a single food item.
+  DietaryThiaminRecord({
+    required super.mass,
+    required super.time,
+    required super.metadata,
+    super.id = HealthRecordId.none,
+    super.zoneOffsetSeconds,
+    super.foodName,
+    super.mealType,
   }) {
-    return DietaryThiaminRecord._(
-      mass: mass,
-      time: time,
-      metadata: metadata,
-      id: id,
-      zoneOffsetSeconds: zoneOffsetSeconds,
-      foodName: foodName,
-      mealType: mealType,
+    require(
+      condition: mass >= minMass && mass <= maxMass,
+      value: mass,
+      name: 'mass',
+      message:
+          'Thiamin mass must be between '
+          '${minMass.inGrams.toStringAsFixed(0)}-'
+          '${maxMass.inGrams.toStringAsFixed(0)} g. '
+          'Got ${mass.inGrams.toStringAsFixed(4)} g.',
     );
   }
 
-  /// Internal factory for creating [DietaryThiaminRecord] instances without
-  /// validation.
-  ///
-  /// Creates a [DietaryThiaminRecord] by directly mapping platform data to
-  /// fields, bypassing the normal validation and business rules applied by the
-  /// public constructor.
+  /// Minimum valid thiamin mass (0.0 g).
+  static const Mass minMass = Mass.zero;
+
+  /// Maximum valid thiamin mass (10.0 g).
+  static const Mass maxMass = Mass.grams(10.0);
+
   ///
   /// **⚠️ Warning**: Not for public use. SDK users should use the public
   /// [DietaryThiaminRecord] constructor, which enforces validation and business
@@ -86,7 +96,7 @@ final class DietaryThiaminRecord extends DietaryVitaminRecord {
     String? foodName,
     MealType mealType = MealType.unknown,
   }) {
-    return DietaryThiaminRecord._(
+    return DietaryThiaminRecord(
       mass: mass,
       time: time,
       metadata: metadata,
@@ -117,14 +127,4 @@ final class DietaryThiaminRecord extends DietaryVitaminRecord {
       mealType: mealType ?? this.mealType,
     );
   }
-
-  const DietaryThiaminRecord._({
-    required super.mass,
-    required super.time,
-    required super.metadata,
-    super.id = HealthRecordId.none,
-    super.zoneOffsetSeconds,
-    super.foodName,
-    super.mealType,
-  });
 }

--- a/packages/health_connector_core/lib/src/models/health_records/nutrition/dietary_total_carbohydrate_record.dart
+++ b/packages/health_connector_core/lib/src/models/health_records/nutrition/dietary_total_carbohydrate_record.dart
@@ -46,36 +46,46 @@ final class DietaryTotalCarbohydrateRecord extends DietaryMacronutrientRecord {
   /// - [id]: The unique identifier for this record.
   /// - [zoneOffsetSeconds]: Optional timezone offset for the measurement time.
   /// - [foodName]: Optional name of the food containing this total
-  /// carbohydrate.
+  ///   carbohydrate.
   /// - [mealType]: The type of meal (breakfast, lunch, dinner, snack, unknown).
-  factory DietaryTotalCarbohydrateRecord({
-    required Mass mass,
-    required DateTime time,
-    required Metadata metadata,
-    HealthRecordId id = HealthRecordId.none,
-    int? zoneOffsetSeconds,
-    String? foodName,
-    MealType mealType = MealType.unknown,
+  ///
+  /// ## Throws
+  ///
+  /// - [ArgumentError] if [mass] is outside the valid range of
+  ///   [minMass]-[maxMass] g.
+  ///
+  /// ## Validation Rationale
+  ///
+  /// - **Minimum ([minMass] g)**: Valid mass must be non-negative.
+  /// - **Maximum ([maxMass] g)**: 1,000g is a reasonable upper bound for
+  ///   macronutrient intake from a single food item.
+  DietaryTotalCarbohydrateRecord({
+    required super.mass,
+    required super.time,
+    required super.metadata,
+    super.id = HealthRecordId.none,
+    super.zoneOffsetSeconds,
+    super.foodName,
+    super.mealType,
   }) {
-    return DietaryTotalCarbohydrateRecord._(
-      mass: mass,
-      time: time,
-      metadata: metadata,
-      id: id,
-      zoneOffsetSeconds: zoneOffsetSeconds,
-      foodName: foodName,
-      mealType: mealType,
+    require(
+      condition: mass >= minMass && mass <= maxMass,
+      value: mass,
+      name: 'mass',
+      message:
+          'Total carbohydrate mass must be between '
+          '${minMass.inGrams.toStringAsFixed(0)}-'
+          '${maxMass.inGrams.toStringAsFixed(0)} g. '
+          'Got ${mass.inGrams.toStringAsFixed(1)} g.',
     );
   }
 
-  /// Internal factory for creating [DietaryTotalCarbohydrateRecord] instances
-  /// without
-  /// validation.
-  ///
-  /// Creates a [DietaryTotalCarbohydrateRecord] by directly mapping platform
-  /// data to
-  /// fields, bypassing the normal validation and business rules applied by the
-  /// public constructor.
+  /// Minimum valid total carbohydrate mass (0.0 g).
+  static const Mass minMass = Mass.zero;
+
+  /// Maximum valid total carbohydrate mass (1,000.0 g).
+  static const Mass maxMass = Mass.grams(1000.0);
+
   ///
   /// **⚠️ Warning**: Not for public use. SDK users should use the public
   /// [DietaryTotalCarbohydrateRecord] constructor, which enforces validation
@@ -91,7 +101,7 @@ final class DietaryTotalCarbohydrateRecord extends DietaryMacronutrientRecord {
     String? foodName,
     MealType mealType = MealType.unknown,
   }) {
-    return DietaryTotalCarbohydrateRecord._(
+    return DietaryTotalCarbohydrateRecord(
       mass: mass,
       time: time,
       metadata: metadata,
@@ -122,14 +132,4 @@ final class DietaryTotalCarbohydrateRecord extends DietaryMacronutrientRecord {
       mealType: mealType ?? this.mealType,
     );
   }
-
-  const DietaryTotalCarbohydrateRecord._({
-    required super.mass,
-    required super.time,
-    required super.metadata,
-    super.id = HealthRecordId.none,
-    super.zoneOffsetSeconds,
-    super.foodName,
-    super.mealType,
-  });
 }

--- a/packages/health_connector_core/lib/src/models/health_records/nutrition/dietary_total_fat_record.dart
+++ b/packages/health_connector_core/lib/src/models/health_records/nutrition/dietary_total_fat_record.dart
@@ -7,9 +7,7 @@ part of '../health_record.dart';
 ///
 /// ## Platform Mapping
 ///
-/// - **iOS HealthKit Only**: [`HKQuantityTypeIdentifier.dietaryFatTotal`](https
-/// ://developer.apple.com/documentation/healthkit/hkquantitytypeidentifier/diet
-/// aryfattotal)
+/// - **iOS HealthKit Only**: [`HKQuantityTypeIdentifier.dietaryFatTotal`](https://developer.apple.com/documentation/healthkit/hkquantitytypeidentifier/dietaryfattotal)
 /// - **Android Health Connect**: Part of [`NutritionRecord`](https://developer.android.com/reference/kotlin/androidx/health/connect/client/records/NutritionRecord)
 ///
 /// ## Example
@@ -44,32 +42,44 @@ final class DietaryTotalFatRecord extends DietaryMacronutrientRecord {
   /// - [zoneOffsetSeconds]: Optional timezone offset for the measurement time.
   /// - [foodName]: Optional name of the food containing this total fat.
   /// - [mealType]: The type of meal (breakfast, lunch, dinner, snack, unknown).
-  factory DietaryTotalFatRecord({
-    required Mass mass,
-    required DateTime time,
-    required Metadata metadata,
-    HealthRecordId id = HealthRecordId.none,
-    int? zoneOffsetSeconds,
-    String? foodName,
-    MealType mealType = MealType.unknown,
+  ///
+  /// ## Throws
+  ///
+  /// - [ArgumentError] if [mass] is outside the valid range of
+  ///   [minMass]-[maxMass] g.
+  ///
+  /// ## Validation Rationale
+  ///
+  /// - **Minimum ([minMass] g)**: Valid mass must be non-negative.
+  /// - **Maximum ([maxMass] g)**: 1,000g is a reasonable upper bound for
+  ///   macronutrient intake from a single food item.
+  DietaryTotalFatRecord({
+    required super.mass,
+    required super.time,
+    required super.metadata,
+    super.id = HealthRecordId.none,
+    super.zoneOffsetSeconds,
+    super.foodName,
+    super.mealType,
   }) {
-    return DietaryTotalFatRecord._(
-      mass: mass,
-      time: time,
-      metadata: metadata,
-      id: id,
-      zoneOffsetSeconds: zoneOffsetSeconds,
-      foodName: foodName,
-      mealType: mealType,
+    require(
+      condition: mass >= minMass && mass <= maxMass,
+      value: mass,
+      name: 'mass',
+      message:
+          'Total fat mass must be between '
+          '${minMass.inGrams.toStringAsFixed(0)}-'
+          '${maxMass.inGrams.toStringAsFixed(0)} g. '
+          'Got ${mass.inGrams.toStringAsFixed(1)} g.',
     );
   }
 
-  /// Internal factory for creating [DietaryTotalFatRecord] instances without
-  /// validation.
-  ///
-  /// Creates a [DietaryTotalFatRecord] by directly mapping platform data to
-  /// fields, bypassing the normal validation and business rules applied by the
-  /// public constructor.
+  /// Minimum valid total fat mass (0.0 g).
+  static const Mass minMass = Mass.zero;
+
+  /// Maximum valid total fat mass (1,000.0 g).
+  static const Mass maxMass = Mass.grams(1000.0);
+
   ///
   /// **⚠️ Warning**: Not for public use. SDK users should use the public
   /// [DietaryTotalFatRecord] constructor, which enforces validation and
@@ -85,7 +95,7 @@ final class DietaryTotalFatRecord extends DietaryMacronutrientRecord {
     String? foodName,
     MealType mealType = MealType.unknown,
   }) {
-    return DietaryTotalFatRecord._(
+    return DietaryTotalFatRecord(
       mass: mass,
       time: time,
       metadata: metadata,
@@ -116,14 +126,4 @@ final class DietaryTotalFatRecord extends DietaryMacronutrientRecord {
       mealType: mealType ?? this.mealType,
     );
   }
-
-  const DietaryTotalFatRecord._({
-    required super.mass,
-    required super.time,
-    required super.metadata,
-    super.id = HealthRecordId.none,
-    super.zoneOffsetSeconds,
-    super.foodName,
-    super.mealType,
-  });
 }

--- a/packages/health_connector_core/lib/src/models/health_records/nutrition/dietary_vitamin_a_record.dart
+++ b/packages/health_connector_core/lib/src/models/health_records/nutrition/dietary_vitamin_a_record.dart
@@ -7,9 +7,7 @@ part of '../health_record.dart';
 ///
 /// ## Platform Mapping
 ///
-/// - **iOS HealthKit Only**: [`HKQuantityTypeIdentifier.dietaryVitaminA`](https
-/// ://developer.apple.com/documentation/healthkit/hkquantitytypeidentifier/diet
-/// aryvitamina)
+/// - **iOS HealthKit Only**: [`HKQuantityTypeIdentifier.dietaryVitaminA`](https://developer.apple.com/documentation/healthkit/hkquantitytypeidentifier/dietaryvitamina)
 /// - **Android Health Connect**: Part of [`NutritionRecord`](https://developer.android.com/reference/kotlin/androidx/health/connect/client/records/NutritionRecord)
 ///
 /// ## Example
@@ -45,32 +43,44 @@ final class DietaryVitaminARecord extends DietaryVitaminRecord {
   /// - [zoneOffsetSeconds]: Optional timezone offset for the measurement time.
   /// - [foodName]: Optional name of the food containing this vitamin A.
   /// - [mealType]: The type of meal (breakfast, lunch, dinner, snack, unknown).
-  factory DietaryVitaminARecord({
-    required Mass mass,
-    required DateTime time,
-    required Metadata metadata,
-    HealthRecordId id = HealthRecordId.none,
-    int? zoneOffsetSeconds,
-    String? foodName,
-    MealType mealType = MealType.unknown,
+  ///
+  /// ## Throws
+  ///
+  /// - [ArgumentError] if [mass] is outside the valid range of
+  ///   [minMass]-[maxMass] g.
+  ///
+  /// ## Validation Rationale
+  ///
+  /// - **Minimum ([minMass] g)**: Valid mass must be non-negative.
+  /// - **Maximum ([maxMass] g)**: 10g is a reasonable upper bound for
+  ///   vitamin intake from a single food item.
+  DietaryVitaminARecord({
+    required super.mass,
+    required super.time,
+    required super.metadata,
+    super.id = HealthRecordId.none,
+    super.zoneOffsetSeconds,
+    super.foodName,
+    super.mealType,
   }) {
-    return DietaryVitaminARecord._(
-      mass: mass,
-      time: time,
-      metadata: metadata,
-      id: id,
-      zoneOffsetSeconds: zoneOffsetSeconds,
-      foodName: foodName,
-      mealType: mealType,
+    require(
+      condition: mass >= minMass && mass <= maxMass,
+      value: mass,
+      name: 'mass',
+      message:
+          'Vitamin A mass must be between '
+          '${minMass.inGrams.toStringAsFixed(0)}-'
+          '${maxMass.inGrams.toStringAsFixed(0)} g. '
+          'Got ${mass.inGrams.toStringAsFixed(4)} g.',
     );
   }
 
-  /// Internal factory for creating [DietaryVitaminARecord] instances without
-  /// validation.
-  ///
-  /// Creates a [DietaryVitaminARecord] by directly mapping platform data to
-  /// fields, bypassing the normal validation and business rules applied by the
-  /// public constructor.
+  /// Minimum valid vitamin A mass (0.0 g).
+  static const Mass minMass = Mass.zero;
+
+  /// Maximum valid vitamin A mass (10.0 g).
+  static const Mass maxMass = Mass.grams(10.0);
+
   ///
   /// **⚠️ Warning**: Not for public use. SDK users should use the public
   /// [DietaryVitaminARecord] constructor, which enforces validation and
@@ -86,7 +96,7 @@ final class DietaryVitaminARecord extends DietaryVitaminRecord {
     String? foodName,
     MealType mealType = MealType.unknown,
   }) {
-    return DietaryVitaminARecord._(
+    return DietaryVitaminARecord(
       mass: mass,
       time: time,
       metadata: metadata,
@@ -117,14 +127,4 @@ final class DietaryVitaminARecord extends DietaryVitaminRecord {
       mealType: mealType ?? this.mealType,
     );
   }
-
-  const DietaryVitaminARecord._({
-    required super.mass,
-    required super.time,
-    required super.metadata,
-    super.id = HealthRecordId.none,
-    super.zoneOffsetSeconds,
-    super.foodName,
-    super.mealType,
-  });
 }

--- a/packages/health_connector_core/lib/src/models/health_records/nutrition/dietary_vitamin_b12_record.dart
+++ b/packages/health_connector_core/lib/src/models/health_records/nutrition/dietary_vitamin_b12_record.dart
@@ -44,32 +44,44 @@ final class DietaryVitaminB12Record extends DietaryVitaminRecord {
   /// - [zoneOffsetSeconds]: Optional timezone offset for the measurement time.
   /// - [foodName]: Optional name of the food containing this vitamin B12.
   /// - [mealType]: The type of meal (breakfast, lunch, dinner, snack, unknown).
-  factory DietaryVitaminB12Record({
-    required Mass mass,
-    required DateTime time,
-    required Metadata metadata,
-    HealthRecordId id = HealthRecordId.none,
-    int? zoneOffsetSeconds,
-    String? foodName,
-    MealType mealType = MealType.unknown,
+  ///
+  /// ## Throws
+  ///
+  /// - [ArgumentError] if [mass] is outside the valid range of
+  ///   [minMass]-[maxMass] g.
+  ///
+  /// ## Validation Rationale
+  ///
+  /// - **Minimum ([minMass] g)**: Valid mass must be non-negative.
+  /// - **Maximum ([maxMass] g)**: 10g is a reasonable upper bound for
+  ///   vitamin intake from a single food item.
+  DietaryVitaminB12Record({
+    required super.mass,
+    required super.time,
+    required super.metadata,
+    super.id = HealthRecordId.none,
+    super.zoneOffsetSeconds,
+    super.foodName,
+    super.mealType,
   }) {
-    return DietaryVitaminB12Record._(
-      mass: mass,
-      time: time,
-      metadata: metadata,
-      id: id,
-      zoneOffsetSeconds: zoneOffsetSeconds,
-      foodName: foodName,
-      mealType: mealType,
+    require(
+      condition: mass >= minMass && mass <= maxMass,
+      value: mass,
+      name: 'mass',
+      message:
+          'Vitamin B12 mass must be between '
+          '${minMass.inGrams.toStringAsFixed(0)}-'
+          '${maxMass.inGrams.toStringAsFixed(0)} g. '
+          'Got ${mass.inGrams.toStringAsFixed(4)} g.',
     );
   }
 
-  /// Internal factory for creating [DietaryVitaminB12Record] instances without
-  /// validation.
-  ///
-  /// Creates a [DietaryVitaminB12Record] by directly mapping platform data to
-  /// fields, bypassing the normal validation and business rules applied by the
-  /// public constructor.
+  /// Minimum valid vitamin B12 mass (0.0 g).
+  static const Mass minMass = Mass.zero;
+
+  /// Maximum valid vitamin B12 mass (10.0 g).
+  static const Mass maxMass = Mass.grams(10.0);
+
   ///
   /// **⚠️ Warning**: Not for public use. SDK users should use the public
   /// [DietaryVitaminB12Record] constructor, which enforces validation and
@@ -85,7 +97,7 @@ final class DietaryVitaminB12Record extends DietaryVitaminRecord {
     String? foodName,
     MealType mealType = MealType.unknown,
   }) {
-    return DietaryVitaminB12Record._(
+    return DietaryVitaminB12Record(
       mass: mass,
       time: time,
       metadata: metadata,
@@ -116,14 +128,4 @@ final class DietaryVitaminB12Record extends DietaryVitaminRecord {
       mealType: mealType ?? this.mealType,
     );
   }
-
-  const DietaryVitaminB12Record._({
-    required super.mass,
-    required super.time,
-    required super.metadata,
-    super.id = HealthRecordId.none,
-    super.zoneOffsetSeconds,
-    super.foodName,
-    super.mealType,
-  });
 }

--- a/packages/health_connector_core/lib/src/models/health_records/nutrition/dietary_vitamin_b6_record.dart
+++ b/packages/health_connector_core/lib/src/models/health_records/nutrition/dietary_vitamin_b6_record.dart
@@ -44,32 +44,44 @@ final class DietaryVitaminB6Record extends DietaryVitaminRecord {
   /// - [zoneOffsetSeconds]: Optional timezone offset for the measurement time.
   /// - [foodName]: Optional name of the food containing this vitamin B6.
   /// - [mealType]: The type of meal (breakfast, lunch, dinner, snack, unknown).
-  factory DietaryVitaminB6Record({
-    required Mass mass,
-    required DateTime time,
-    required Metadata metadata,
-    HealthRecordId id = HealthRecordId.none,
-    int? zoneOffsetSeconds,
-    String? foodName,
-    MealType mealType = MealType.unknown,
+  ///
+  /// ## Throws
+  ///
+  /// - [ArgumentError] if [mass] is outside the valid range of
+  ///   [minMass]-[maxMass] g.
+  ///
+  /// ## Validation Rationale
+  ///
+  /// - **Minimum ([minMass] g)**: Valid mass must be non-negative.
+  /// - **Maximum ([maxMass] g)**: 10g is a reasonable upper bound for
+  ///   vitamin intake from a single food item.
+  DietaryVitaminB6Record({
+    required super.mass,
+    required super.time,
+    required super.metadata,
+    super.id = HealthRecordId.none,
+    super.zoneOffsetSeconds,
+    super.foodName,
+    super.mealType,
   }) {
-    return DietaryVitaminB6Record._(
-      mass: mass,
-      time: time,
-      metadata: metadata,
-      id: id,
-      zoneOffsetSeconds: zoneOffsetSeconds,
-      foodName: foodName,
-      mealType: mealType,
+    require(
+      condition: mass >= minMass && mass <= maxMass,
+      value: mass,
+      name: 'mass',
+      message:
+          'Vitamin B6 mass must be between '
+          '${minMass.inGrams.toStringAsFixed(0)}-'
+          '${maxMass.inGrams.toStringAsFixed(0)} g. '
+          'Got ${mass.inGrams.toStringAsFixed(4)} g.',
     );
   }
 
-  /// Internal factory for creating [DietaryVitaminB6Record] instances without
-  /// validation.
-  ///
-  /// Creates a [DietaryVitaminB6Record] by directly mapping platform data to
-  /// fields, bypassing the normal validation and business rules applied by the
-  /// public constructor.
+  /// Minimum valid vitamin B6 mass (0.0 g).
+  static const Mass minMass = Mass.zero;
+
+  /// Maximum valid vitamin B6 mass (10.0 g).
+  static const Mass maxMass = Mass.grams(10.0);
+
   ///
   /// **⚠️ Warning**: Not for public use. SDK users should use the public
   /// [DietaryVitaminB6Record] constructor, which enforces validation and
@@ -85,7 +97,7 @@ final class DietaryVitaminB6Record extends DietaryVitaminRecord {
     String? foodName,
     MealType mealType = MealType.unknown,
   }) {
-    return DietaryVitaminB6Record._(
+    return DietaryVitaminB6Record(
       mass: mass,
       time: time,
       metadata: metadata,
@@ -116,14 +128,4 @@ final class DietaryVitaminB6Record extends DietaryVitaminRecord {
       mealType: mealType ?? this.mealType,
     );
   }
-
-  const DietaryVitaminB6Record._({
-    required super.mass,
-    required super.time,
-    required super.metadata,
-    super.id = HealthRecordId.none,
-    super.zoneOffsetSeconds,
-    super.foodName,
-    super.mealType,
-  });
 }

--- a/packages/health_connector_core/lib/src/models/health_records/nutrition/dietary_vitamin_c_record.dart
+++ b/packages/health_connector_core/lib/src/models/health_records/nutrition/dietary_vitamin_c_record.dart
@@ -7,9 +7,7 @@ part of '../health_record.dart';
 ///
 /// ## Platform Mapping
 ///
-/// - **iOS HealthKit Only**: [`HKQuantityTypeIdentifier.dietaryVitaminC`](https
-/// ://developer.apple.com/documentation/healthkit/hkquantitytypeidentifier/diet
-/// aryvitaminc)
+/// - **iOS HealthKit Only**: [`HKQuantityTypeIdentifier.dietaryVitaminC`](https://developer.apple.com/documentation/healthkit/hkquantitytypeidentifier/dietaryvitaminc)
 /// - **Android Health Connect**: Part of [`NutritionRecord`](https://developer.android.com/reference/kotlin/androidx/health/connect/client/records/NutritionRecord)
 ///
 /// ## Example
@@ -45,32 +43,44 @@ final class DietaryVitaminCRecord extends DietaryVitaminRecord {
   /// - [zoneOffsetSeconds]: Optional timezone offset for the measurement time.
   /// - [foodName]: Optional name of the food containing this vitamin C.
   /// - [mealType]: The type of meal (breakfast, lunch, dinner, snack, unknown).
-  factory DietaryVitaminCRecord({
-    required Mass mass,
-    required DateTime time,
-    required Metadata metadata,
-    HealthRecordId id = HealthRecordId.none,
-    int? zoneOffsetSeconds,
-    String? foodName,
-    MealType mealType = MealType.unknown,
+  ///
+  /// ## Throws
+  ///
+  /// - [ArgumentError] if [mass] is outside the valid range of
+  ///   [minMass]-[maxMass] g.
+  ///
+  /// ## Validation Rationale
+  ///
+  /// - **Minimum ([minMass] g)**: Valid mass must be non-negative.
+  /// - **Maximum ([maxMass] g)**: 10g is a reasonable upper bound for
+  ///   vitamin intake from a single food item.
+  DietaryVitaminCRecord({
+    required super.mass,
+    required super.time,
+    required super.metadata,
+    super.id = HealthRecordId.none,
+    super.zoneOffsetSeconds,
+    super.foodName,
+    super.mealType,
   }) {
-    return DietaryVitaminCRecord._(
-      mass: mass,
-      time: time,
-      metadata: metadata,
-      id: id,
-      zoneOffsetSeconds: zoneOffsetSeconds,
-      foodName: foodName,
-      mealType: mealType,
+    require(
+      condition: mass >= minMass && mass <= maxMass,
+      value: mass,
+      name: 'mass',
+      message:
+          'Vitamin C mass must be between '
+          '${minMass.inGrams.toStringAsFixed(0)}-'
+          '${maxMass.inGrams.toStringAsFixed(0)} g. '
+          'Got ${mass.inGrams.toStringAsFixed(4)} g.',
     );
   }
 
-  /// Internal factory for creating [DietaryVitaminCRecord] instances without
-  /// validation.
-  ///
-  /// Creates a [DietaryVitaminCRecord] by directly mapping platform data to
-  /// fields, bypassing the normal validation and business rules applied by the
-  /// public constructor.
+  /// Minimum valid vitamin C mass (0.0 g).
+  static const Mass minMass = Mass.zero;
+
+  /// Maximum valid vitamin C mass (10.0 g).
+  static const Mass maxMass = Mass.grams(10.0);
+
   ///
   /// **⚠️ Warning**: Not for public use. SDK users should use the public
   /// [DietaryVitaminCRecord] constructor, which enforces validation and
@@ -86,7 +96,7 @@ final class DietaryVitaminCRecord extends DietaryVitaminRecord {
     String? foodName,
     MealType mealType = MealType.unknown,
   }) {
-    return DietaryVitaminCRecord._(
+    return DietaryVitaminCRecord(
       mass: mass,
       time: time,
       metadata: metadata,
@@ -117,14 +127,4 @@ final class DietaryVitaminCRecord extends DietaryVitaminRecord {
       mealType: mealType ?? this.mealType,
     );
   }
-
-  const DietaryVitaminCRecord._({
-    required super.mass,
-    required super.time,
-    required super.metadata,
-    super.id = HealthRecordId.none,
-    super.zoneOffsetSeconds,
-    super.foodName,
-    super.mealType,
-  });
 }

--- a/packages/health_connector_core/lib/src/models/health_records/nutrition/dietary_vitamin_d_record.dart
+++ b/packages/health_connector_core/lib/src/models/health_records/nutrition/dietary_vitamin_d_record.dart
@@ -7,9 +7,7 @@ part of '../health_record.dart';
 ///
 /// ## Platform Mapping
 ///
-/// - **iOS HealthKit Only**: [`HKQuantityTypeIdentifier.dietaryVitaminD`](https
-/// ://developer.apple.com/documentation/healthkit/hkquantitytypeidentifier/diet
-/// aryvitamind)
+/// - **iOS HealthKit Only**: [`HKQuantityTypeIdentifier.dietaryVitaminD`](https://developer.apple.com/documentation/healthkit/hkquantitytypeidentifier/dietaryvitamind)
 /// - **Android Health Connect**: Part of [`NutritionRecord`](https://developer.android.com/reference/kotlin/androidx/health/connect/client/records/NutritionRecord)
 ///
 /// ## Example
@@ -45,32 +43,44 @@ final class DietaryVitaminDRecord extends DietaryVitaminRecord {
   /// - [zoneOffsetSeconds]: Optional timezone offset for the measurement time.
   /// - [foodName]: Optional name of the food containing this vitamin D.
   /// - [mealType]: The type of meal (breakfast, lunch, dinner, snack, unknown).
-  factory DietaryVitaminDRecord({
-    required Mass mass,
-    required DateTime time,
-    required Metadata metadata,
-    HealthRecordId id = HealthRecordId.none,
-    int? zoneOffsetSeconds,
-    String? foodName,
-    MealType mealType = MealType.unknown,
+  ///
+  /// ## Throws
+  ///
+  /// - [ArgumentError] if [mass] is outside the valid range of
+  ///   [minMass]-[maxMass] g.
+  ///
+  /// ## Validation Rationale
+  ///
+  /// - **Minimum ([minMass] g)**: Valid mass must be non-negative.
+  /// - **Maximum ([maxMass] g)**: 10g is a reasonable upper bound for
+  ///   vitamin intake from a single food item.
+  DietaryVitaminDRecord({
+    required super.mass,
+    required super.time,
+    required super.metadata,
+    super.id = HealthRecordId.none,
+    super.zoneOffsetSeconds,
+    super.foodName,
+    super.mealType,
   }) {
-    return DietaryVitaminDRecord._(
-      mass: mass,
-      time: time,
-      metadata: metadata,
-      id: id,
-      zoneOffsetSeconds: zoneOffsetSeconds,
-      foodName: foodName,
-      mealType: mealType,
+    require(
+      condition: mass >= minMass && mass <= maxMass,
+      value: mass,
+      name: 'mass',
+      message:
+          'Vitamin D mass must be between '
+          '${minMass.inGrams.toStringAsFixed(0)}-'
+          '${maxMass.inGrams.toStringAsFixed(0)} g. '
+          'Got ${mass.inGrams.toStringAsFixed(4)} g.',
     );
   }
 
-  /// Internal factory for creating [DietaryVitaminDRecord] instances without
-  /// validation.
-  ///
-  /// Creates a [DietaryVitaminDRecord] by directly mapping platform data to
-  /// fields, bypassing the normal validation and business rules applied by the
-  /// public constructor.
+  /// Minimum valid vitamin D mass (0.0 g).
+  static const Mass minMass = Mass.zero;
+
+  /// Maximum valid vitamin D mass (10.0 g).
+  static const Mass maxMass = Mass.grams(10.0);
+
   ///
   /// **⚠️ Warning**: Not for public use. SDK users should use the public
   /// [DietaryVitaminDRecord] constructor, which enforces validation and
@@ -86,7 +96,7 @@ final class DietaryVitaminDRecord extends DietaryVitaminRecord {
     String? foodName,
     MealType mealType = MealType.unknown,
   }) {
-    return DietaryVitaminDRecord._(
+    return DietaryVitaminDRecord(
       mass: mass,
       time: time,
       metadata: metadata,
@@ -117,14 +127,4 @@ final class DietaryVitaminDRecord extends DietaryVitaminRecord {
       mealType: mealType ?? this.mealType,
     );
   }
-
-  const DietaryVitaminDRecord._({
-    required super.mass,
-    required super.time,
-    required super.metadata,
-    super.id = HealthRecordId.none,
-    super.zoneOffsetSeconds,
-    super.foodName,
-    super.mealType,
-  });
 }

--- a/packages/health_connector_core/lib/src/models/health_records/nutrition/dietary_vitamin_e_record.dart
+++ b/packages/health_connector_core/lib/src/models/health_records/nutrition/dietary_vitamin_e_record.dart
@@ -7,9 +7,7 @@ part of '../health_record.dart';
 ///
 /// ## Platform Mapping
 ///
-/// - **iOS HealthKit Only**: [`HKQuantityTypeIdentifier.dietaryVitaminE`](https
-/// ://developer.apple.com/documentation/healthkit/hkquantitytypeidentifier/diet
-/// aryvitamine)
+/// - **iOS HealthKit Only**: [`HKQuantityTypeIdentifier.dietaryVitaminE`](https://developer.apple.com/documentation/healthkit/hkquantitytypeidentifier/dietaryvitamine)
 /// - **Android Health Connect**: Part of [`NutritionRecord`](https://developer.android.com/reference/kotlin/androidx/health/connect/client/records/NutritionRecord)
 ///
 /// ## Example
@@ -45,32 +43,44 @@ final class DietaryVitaminERecord extends DietaryVitaminRecord {
   /// - [zoneOffsetSeconds]: Optional timezone offset for the measurement time.
   /// - [foodName]: Optional name of the food containing this vitamin E.
   /// - [mealType]: The type of meal (breakfast, lunch, dinner, snack, unknown).
-  factory DietaryVitaminERecord({
-    required Mass mass,
-    required DateTime time,
-    required Metadata metadata,
-    HealthRecordId id = HealthRecordId.none,
-    int? zoneOffsetSeconds,
-    String? foodName,
-    MealType mealType = MealType.unknown,
+  ///
+  /// ## Throws
+  ///
+  /// - [ArgumentError] if [mass] is outside the valid range of
+  ///   [minMass]-[maxMass] g.
+  ///
+  /// ## Validation Rationale
+  ///
+  /// - **Minimum ([minMass] g)**: Valid mass must be non-negative.
+  /// - **Maximum ([maxMass] g)**: 10g is a reasonable upper bound for
+  ///   vitamin intake from a single food item.
+  DietaryVitaminERecord({
+    required super.mass,
+    required super.time,
+    required super.metadata,
+    super.id = HealthRecordId.none,
+    super.zoneOffsetSeconds,
+    super.foodName,
+    super.mealType,
   }) {
-    return DietaryVitaminERecord._(
-      mass: mass,
-      time: time,
-      metadata: metadata,
-      id: id,
-      zoneOffsetSeconds: zoneOffsetSeconds,
-      foodName: foodName,
-      mealType: mealType,
+    require(
+      condition: mass >= minMass && mass <= maxMass,
+      value: mass,
+      name: 'mass',
+      message:
+          'Vitamin E mass must be between '
+          '${minMass.inGrams.toStringAsFixed(0)}-'
+          '${maxMass.inGrams.toStringAsFixed(0)} g. '
+          'Got ${mass.inGrams.toStringAsFixed(4)} g.',
     );
   }
 
-  /// Internal factory for creating [DietaryVitaminERecord] instances without
-  /// validation.
-  ///
-  /// Creates a [DietaryVitaminERecord] by directly mapping platform data to
-  /// fields, bypassing the normal validation and business rules applied by the
-  /// public constructor.
+  /// Minimum valid vitamin E mass (0.0 g).
+  static const Mass minMass = Mass.zero;
+
+  /// Maximum valid vitamin E mass (10.0 g).
+  static const Mass maxMass = Mass.grams(10.0);
+
   ///
   /// **⚠️ Warning**: Not for public use. SDK users should use the public
   /// [DietaryVitaminERecord] constructor, which enforces validation and
@@ -86,7 +96,7 @@ final class DietaryVitaminERecord extends DietaryVitaminRecord {
     String? foodName,
     MealType mealType = MealType.unknown,
   }) {
-    return DietaryVitaminERecord._(
+    return DietaryVitaminERecord(
       mass: mass,
       time: time,
       metadata: metadata,
@@ -117,14 +127,4 @@ final class DietaryVitaminERecord extends DietaryVitaminRecord {
       mealType: mealType ?? this.mealType,
     );
   }
-
-  const DietaryVitaminERecord._({
-    required super.mass,
-    required super.time,
-    required super.metadata,
-    super.id = HealthRecordId.none,
-    super.zoneOffsetSeconds,
-    super.foodName,
-    super.mealType,
-  });
 }

--- a/packages/health_connector_core/lib/src/models/health_records/nutrition/dietary_vitamin_k_record.dart
+++ b/packages/health_connector_core/lib/src/models/health_records/nutrition/dietary_vitamin_k_record.dart
@@ -7,9 +7,7 @@ part of '../health_record.dart';
 ///
 /// ## Platform Mapping
 ///
-/// - **iOS HealthKit Only**: [`HKQuantityTypeIdentifier.dietaryVitaminK`](https
-/// ://developer.apple.com/documentation/healthkit/hkquantitytypeidentifier/diet
-/// aryvitamink)
+/// - **iOS HealthKit Only**: [`HKQuantityTypeIdentifier.dietaryVitaminK`](https://developer.apple.com/documentation/healthkit/hkquantitytypeidentifier/dietaryvitamink)
 /// - **Android Health Connect**: Part of [`NutritionRecord`](https://developer.android.com/reference/kotlin/androidx/health/connect/client/records/NutritionRecord)
 ///
 /// ## Example
@@ -45,32 +43,44 @@ final class DietaryVitaminKRecord extends DietaryVitaminRecord {
   /// - [zoneOffsetSeconds]: Optional timezone offset for the measurement time.
   /// - [foodName]: Optional name of the food containing this vitamin K.
   /// - [mealType]: The type of meal (breakfast, lunch, dinner, snack, unknown).
-  factory DietaryVitaminKRecord({
-    required Mass mass,
-    required DateTime time,
-    required Metadata metadata,
-    HealthRecordId id = HealthRecordId.none,
-    int? zoneOffsetSeconds,
-    String? foodName,
-    MealType mealType = MealType.unknown,
+  ///
+  /// ## Throws
+  ///
+  /// - [ArgumentError] if [mass] is outside the valid range of
+  ///   [minMass]-[maxMass] g.
+  ///
+  /// ## Validation Rationale
+  ///
+  /// - **Minimum ([minMass] g)**: Valid mass must be non-negative.
+  /// - **Maximum ([maxMass] g)**: 10g is a reasonable upper bound for
+  ///   vitamin intake from a single food item.
+  DietaryVitaminKRecord({
+    required super.mass,
+    required super.time,
+    required super.metadata,
+    super.id = HealthRecordId.none,
+    super.zoneOffsetSeconds,
+    super.foodName,
+    super.mealType,
   }) {
-    return DietaryVitaminKRecord._(
-      mass: mass,
-      time: time,
-      metadata: metadata,
-      id: id,
-      zoneOffsetSeconds: zoneOffsetSeconds,
-      foodName: foodName,
-      mealType: mealType,
+    require(
+      condition: mass >= minMass && mass <= maxMass,
+      value: mass,
+      name: 'mass',
+      message:
+          'Vitamin K mass must be between '
+          '${minMass.inGrams.toStringAsFixed(0)}-'
+          '${maxMass.inGrams.toStringAsFixed(0)} g. '
+          'Got ${mass.inGrams.toStringAsFixed(4)} g.',
     );
   }
 
-  /// Internal factory for creating [DietaryVitaminKRecord] instances without
-  /// validation.
-  ///
-  /// Creates a [DietaryVitaminKRecord] by directly mapping platform data to
-  /// fields, bypassing the normal validation and business rules applied by the
-  /// public constructor.
+  /// Minimum valid vitamin K mass (0.0 g).
+  static const Mass minMass = Mass.zero;
+
+  /// Maximum valid vitamin K mass (10.0 g).
+  static const Mass maxMass = Mass.grams(10.0);
+
   ///
   /// **⚠️ Warning**: Not for public use. SDK users should use the public
   /// [DietaryVitaminKRecord] constructor, which enforces validation and
@@ -86,7 +96,7 @@ final class DietaryVitaminKRecord extends DietaryVitaminRecord {
     String? foodName,
     MealType mealType = MealType.unknown,
   }) {
-    return DietaryVitaminKRecord._(
+    return DietaryVitaminKRecord(
       mass: mass,
       time: time,
       metadata: metadata,
@@ -117,14 +127,4 @@ final class DietaryVitaminKRecord extends DietaryVitaminRecord {
       mealType: mealType ?? this.mealType,
     );
   }
-
-  const DietaryVitaminKRecord._({
-    required super.mass,
-    required super.time,
-    required super.metadata,
-    super.id = HealthRecordId.none,
-    super.zoneOffsetSeconds,
-    super.foodName,
-    super.mealType,
-  });
 }

--- a/packages/health_connector_core/lib/src/models/health_records/nutrition/dietary_vitamin_record.dart
+++ b/packages/health_connector_core/lib/src/models/health_records/nutrition/dietary_vitamin_record.dart
@@ -12,7 +12,13 @@ part of '../health_record.dart';
 @internal
 @immutable
 sealed class DietaryVitaminRecord extends NutrientRecord<Mass> {
-  const DietaryVitaminRecord({
+  /// Minimum valid vitamin mass (0.0 g).
+  static const Mass minMass = Mass.zero;
+
+  /// Maximum valid vitamin mass (10.0 g).
+  static const Mass maxMass = Mass.grams(10.0);
+
+  DietaryVitaminRecord({
     required this.mass,
     required super.time,
     required super.metadata,
@@ -20,8 +26,29 @@ sealed class DietaryVitaminRecord extends NutrientRecord<Mass> {
     super.zoneOffsetSeconds,
     super.foodName,
     super.mealType,
-  });
+  }) {
+    require(
+      condition: mass >= minMass && mass <= maxMass,
+      value: mass,
+      name: 'mass',
+      message:
+          'Vitamin mass must be between '
+          '${minMass.inGrams.toStringAsFixed(0)}-'
+          '${maxMass.inGrams.toStringAsFixed(0)} g. '
+          'Got ${mass.inGrams.toStringAsFixed(4)} g.',
+    );
+  }
 
   /// The mass of the nutrient.
   final Mass mass;
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      super == other &&
+          other is DietaryVitaminRecord &&
+          (mass.inGrams - other.mass.inGrams).abs() < 1e-6;
+
+  @override
+  int get hashCode => super.hashCode ^ mass.hashCode;
 }

--- a/packages/health_connector_core/lib/src/models/health_records/nutrition/dietary_zinc_record.dart
+++ b/packages/health_connector_core/lib/src/models/health_records/nutrition/dietary_zinc_record.dart
@@ -7,8 +7,7 @@ part of '../health_record.dart';
 ///
 /// ## Platform Mapping
 ///
-/// - **iOS HealthKit Only**: [`HKQuantityTypeIdentifier.dietaryZinc`](https://developer.apple.com/documentation/healthkit/hkquantitytypeidentifier/dietaryz
-/// inc)
+/// - **iOS HealthKit Only**: [`HKQuantityTypeIdentifier.dietaryZinc`](https://developer.apple.com/documentation/healthkit/hkquantitytypeidentifier/dietaryzinc)
 /// - **Android Health Connect**: Part of [`NutritionRecord`](https://developer.android.com/reference/kotlin/androidx/health/connect/client/records/NutritionRecord)
 ///
 /// ## Example
@@ -43,32 +42,44 @@ final class DietaryZincRecord extends DietaryMineralRecord {
   /// - [zoneOffsetSeconds]: Optional timezone offset for the measurement time.
   /// - [foodName]: Optional name of the food containing this zinc.
   /// - [mealType]: The type of meal (breakfast, lunch, dinner, snack, unknown).
-  factory DietaryZincRecord({
-    required Mass mass,
-    required DateTime time,
-    required Metadata metadata,
-    HealthRecordId id = HealthRecordId.none,
-    int? zoneOffsetSeconds,
-    String? foodName,
-    MealType mealType = MealType.unknown,
+  ///
+  /// ## Throws
+  ///
+  /// - [ArgumentError] if [mass] is outside the valid range of
+  ///   [minMass]-[maxMass] g.
+  ///
+  /// ## Validation Rationale
+  ///
+  /// - **Minimum ([minMass] g)**: Valid mass must be non-negative.
+  /// - **Maximum ([maxMass] g)**: 100g is a reasonable upper bound for
+  ///   mineral intake from a single food item.
+  DietaryZincRecord({
+    required super.mass,
+    required super.time,
+    required super.metadata,
+    super.id = HealthRecordId.none,
+    super.zoneOffsetSeconds,
+    super.foodName,
+    super.mealType,
   }) {
-    return DietaryZincRecord._(
-      mass: mass,
-      time: time,
-      metadata: metadata,
-      id: id,
-      zoneOffsetSeconds: zoneOffsetSeconds,
-      foodName: foodName,
-      mealType: mealType,
+    require(
+      condition: mass >= minMass && mass <= maxMass,
+      value: mass,
+      name: 'mass',
+      message:
+          'Zinc mass must be between '
+          '${minMass.inGrams.toStringAsFixed(0)}-'
+          '${maxMass.inGrams.toStringAsFixed(0)} g. '
+          'Got ${mass.inGrams.toStringAsFixed(3)} g.',
     );
   }
 
-  /// Internal factory for creating [DietaryZincRecord] instances without
-  /// validation.
-  ///
-  /// Creates a [DietaryZincRecord] by directly mapping platform data to
-  /// fields, bypassing the normal validation and business rules applied by the
-  /// public constructor.
+  /// Minimum valid zinc mass (0.0 g).
+  static const Mass minMass = Mass.zero;
+
+  /// Maximum valid zinc mass (100.0 g).
+  static const Mass maxMass = Mass.grams(100.0);
+
   ///
   /// **⚠️ Warning**: Not for public use. SDK users should use the public
   /// [DietaryZincRecord] constructor, which enforces validation and business
@@ -83,7 +94,7 @@ final class DietaryZincRecord extends DietaryMineralRecord {
     String? foodName,
     MealType mealType = MealType.unknown,
   }) {
-    return DietaryZincRecord._(
+    return DietaryZincRecord(
       mass: mass,
       time: time,
       metadata: metadata,
@@ -114,14 +125,4 @@ final class DietaryZincRecord extends DietaryMineralRecord {
       mealType: mealType ?? this.mealType,
     );
   }
-
-  const DietaryZincRecord._({
-    required super.mass,
-    required super.time,
-    required super.metadata,
-    super.id = HealthRecordId.none,
-    super.zoneOffsetSeconds,
-    super.foodName,
-    super.mealType,
-  });
 }

--- a/packages/health_connector_core/lib/src/models/health_records/nutrition/nutrition_record.dart
+++ b/packages/health_connector_core/lib/src/models/health_records/nutrition/nutrition_record.dart
@@ -11,7 +11,8 @@ part of '../health_record.dart';
 /// ## Platform Mapping
 ///
 /// - **Android Health Connect**: [`NutritionRecord`](https://developer.android.com/reference/kotlin/androidx/health/connect/client/records/NutritionRecord)
-/// - **iOS HealthKit**: Multiple `HKQuantityType` correlations for individual  nutrients
+/// - **iOS HealthKit**: Multiple `HKQuantityType` correlations for
+///   individual nutrients
 ///
 /// ## Example
 ///
@@ -33,6 +34,12 @@ part of '../health_record.dart';
 @sinceV1_1_0
 @immutable
 final class NutritionRecord extends IntervalHealthRecord {
+  /// Minimum valid energy (0.0 kcal).
+  static const Energy minEnergy = Energy.zero;
+
+  /// Maximum valid energy (10,000.0 kcal).
+  static const Energy maxEnergy = Energy.kilocalories(10000.0);
+
   /// Creates a nutrition record.
   ///
   /// ## Parameters
@@ -61,6 +68,18 @@ final class NutritionRecord extends IntervalHealthRecord {
   /// ## Throws
   ///
   /// - [ArgumentError] if [endTime] is not after [startTime].
+  /// - [ArgumentError] if any nutrient value is outside its valid range.
+  ///
+  /// ## Validation Rationale
+  ///
+  /// Each nutrient field is validated when present:
+  /// - **Energy**: [minEnergy]-[maxEnergy] kcal
+  /// - **Macronutrients** (protein, carbs, fats):
+  ///   [DietaryMacronutrientRecord.minMass]-
+  ///   [DietaryMacronutrientRecord.maxMass] g per nutrient
+  /// - **Minerals**: [DietaryMineralRecord.minMass]-[DietaryMineralRecord.maxMass] g (measured in mg/μg ranges)
+  /// - **Vitamins**: [DietaryVitaminRecord.minMass]-[DietaryVitaminRecord.maxMass] g (measured in mg/μg ranges)
+  /// - **Caffeine**: 0-10 g (typical serving 50-200mg)
   NutritionRecord({
     required super.startTime,
     required super.endTime,
@@ -103,7 +122,110 @@ final class NutritionRecord extends IntervalHealthRecord {
     this.sodium,
     this.zinc,
     this.caffeine,
-  });
+  }) {
+    // Validate energy if present
+    if (energy != null) {
+      require(
+        condition: energy! >= minEnergy && energy! <= maxEnergy,
+        value: energy,
+        name: 'energy',
+        message:
+            'Energy must be between '
+            '${minEnergy.inKilocalories.toInt()}-'
+            '${maxEnergy.inKilocalories.toInt()} kcal. '
+            'Got ${energy!.inKilocalories.toStringAsFixed(0)} kcal.',
+      );
+    }
+
+    // Validate macronutrients if present
+    void validateMacro(Mass? nutrient, String name) {
+      if (nutrient != null) {
+        const min = DietaryMacronutrientRecord.minMass;
+        const max = DietaryMacronutrientRecord.maxMass;
+        require(
+          condition: nutrient >= min && nutrient <= max,
+          value: nutrient,
+          name: name,
+          message:
+              '$name must be between '
+              '${min.inGrams.toStringAsFixed(0)}-'
+              '${max.inGrams.toStringAsFixed(0)} g. '
+              'Got ${nutrient.inGrams.toStringAsFixed(1)} g.',
+        );
+      }
+    }
+
+    validateMacro(protein, 'protein');
+    validateMacro(totalCarbohydrate, 'totalCarbohydrate');
+    validateMacro(totalFat, 'totalFat');
+    validateMacro(saturatedFat, 'saturatedFat');
+    validateMacro(monounsaturatedFat, 'monounsaturatedFat');
+    validateMacro(polyunsaturatedFat, 'polyunsaturatedFat');
+    validateMacro(cholesterol, 'cholesterol');
+    validateMacro(dietaryFiber, 'dietaryFiber');
+    validateMacro(sugar, 'sugar');
+    validateMacro(caffeine, 'caffeine');
+
+    // Validate minerals if present
+    void validateMineral(Mass? nutrient, String name) {
+      if (nutrient != null) {
+        const min = DietaryMineralRecord.minMass;
+        const max = DietaryMineralRecord.maxMass;
+        require(
+          condition: nutrient >= min && nutrient <= max,
+          value: nutrient,
+          name: name,
+          message:
+              '$name must be between '
+              '${min.inGrams.toStringAsFixed(0)}-'
+              '${max.inGrams.toStringAsFixed(0)} g. '
+              'Got ${nutrient.inGrams.toStringAsFixed(3)} g.',
+        );
+      }
+    }
+
+    validateMineral(calcium, 'calcium');
+    validateMineral(iron, 'iron');
+    validateMineral(magnesium, 'magnesium');
+    validateMineral(manganese, 'manganese');
+    validateMineral(phosphorus, 'phosphorus');
+    validateMineral(potassium, 'potassium');
+    validateMineral(selenium, 'selenium');
+    validateMineral(sodium, 'sodium');
+    validateMineral(zinc, 'zinc');
+
+    // Validate vitamins if present
+    void validateVitamin(Mass? nutrient, String name) {
+      if (nutrient != null) {
+        const min = DietaryVitaminRecord.minMass;
+        const max = DietaryVitaminRecord.maxMass;
+        require(
+          condition: nutrient >= min && nutrient <= max,
+          value: nutrient,
+          name: name,
+          message:
+              '$name must be between '
+              '${min.inGrams.toStringAsFixed(0)}-'
+              '${max.inGrams.toStringAsFixed(0)} g. '
+              'Got ${nutrient.inGrams.toStringAsFixed(4)} g.',
+        );
+      }
+    }
+
+    validateVitamin(vitaminA, 'vitaminA');
+    validateVitamin(vitaminB6, 'vitaminB6');
+    validateVitamin(vitaminB12, 'vitaminB12');
+    validateVitamin(vitaminC, 'vitaminC');
+    validateVitamin(vitaminD, 'vitaminD');
+    validateVitamin(vitaminE, 'vitaminE');
+    validateVitamin(vitaminK, 'vitaminK');
+    validateVitamin(thiamin, 'thiamin');
+    validateVitamin(riboflavin, 'riboflavin');
+    validateVitamin(niacin, 'niacin');
+    validateVitamin(folate, 'folate');
+    validateVitamin(biotin, 'biotin');
+    validateVitamin(pantothenicAcid, 'pantothenicAcid');
+  }
 
   /// Internal factory for creating [NutritionRecord] instances
   /// without validation.
@@ -444,4 +566,95 @@ final class NutritionRecord extends IntervalHealthRecord {
       caffeine: caffeine ?? this.caffeine,
     );
   }
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is NutritionRecord &&
+          runtimeType == other.runtimeType &&
+          id == other.id &&
+          metadata == other.metadata &&
+          startTime == other.startTime &&
+          endTime == other.endTime &&
+          startZoneOffsetSeconds == other.startZoneOffsetSeconds &&
+          endZoneOffsetSeconds == other.endZoneOffsetSeconds &&
+          foodName == other.foodName &&
+          mealType == other.mealType &&
+          energy == other.energy &&
+          protein == other.protein &&
+          totalCarbohydrate == other.totalCarbohydrate &&
+          totalFat == other.totalFat &&
+          saturatedFat == other.saturatedFat &&
+          monounsaturatedFat == other.monounsaturatedFat &&
+          polyunsaturatedFat == other.polyunsaturatedFat &&
+          cholesterol == other.cholesterol &&
+          dietaryFiber == other.dietaryFiber &&
+          sugar == other.sugar &&
+          vitaminA == other.vitaminA &&
+          vitaminB6 == other.vitaminB6 &&
+          vitaminB12 == other.vitaminB12 &&
+          vitaminC == other.vitaminC &&
+          vitaminD == other.vitaminD &&
+          vitaminE == other.vitaminE &&
+          vitaminK == other.vitaminK &&
+          thiamin == other.thiamin &&
+          riboflavin == other.riboflavin &&
+          niacin == other.niacin &&
+          folate == other.folate &&
+          biotin == other.biotin &&
+          pantothenicAcid == other.pantothenicAcid &&
+          calcium == other.calcium &&
+          iron == other.iron &&
+          magnesium == other.magnesium &&
+          manganese == other.manganese &&
+          phosphorus == other.phosphorus &&
+          potassium == other.potassium &&
+          selenium == other.selenium &&
+          sodium == other.sodium &&
+          zinc == other.zinc &&
+          caffeine == other.caffeine;
+
+  @override
+  int get hashCode =>
+      id.hashCode ^
+      metadata.hashCode ^
+      startTime.hashCode ^
+      endTime.hashCode ^
+      startZoneOffsetSeconds.hashCode ^
+      endZoneOffsetSeconds.hashCode ^
+      foodName.hashCode ^
+      mealType.hashCode ^
+      energy.hashCode ^
+      protein.hashCode ^
+      totalCarbohydrate.hashCode ^
+      totalFat.hashCode ^
+      saturatedFat.hashCode ^
+      monounsaturatedFat.hashCode ^
+      polyunsaturatedFat.hashCode ^
+      cholesterol.hashCode ^
+      dietaryFiber.hashCode ^
+      sugar.hashCode ^
+      vitaminA.hashCode ^
+      vitaminB6.hashCode ^
+      vitaminB12.hashCode ^
+      vitaminC.hashCode ^
+      vitaminD.hashCode ^
+      vitaminE.hashCode ^
+      vitaminK.hashCode ^
+      thiamin.hashCode ^
+      riboflavin.hashCode ^
+      niacin.hashCode ^
+      folate.hashCode ^
+      biotin.hashCode ^
+      pantothenicAcid.hashCode ^
+      calcium.hashCode ^
+      iron.hashCode ^
+      magnesium.hashCode ^
+      manganese.hashCode ^
+      phosphorus.hashCode ^
+      potassium.hashCode ^
+      selenium.hashCode ^
+      sodium.hashCode ^
+      zinc.hashCode ^
+      caffeine.hashCode;
 }

--- a/packages/health_connector_core/lib/src/models/health_records/oxygen_saturation_record.dart
+++ b/packages/health_connector_core/lib/src/models/health_records/oxygen_saturation_record.dart
@@ -34,6 +34,17 @@ part of 'health_record.dart';
 @sinceV1_3_0
 @immutable
 final class OxygenSaturationRecord extends InstantHealthRecord {
+  /// Minimum valid oxygen saturation (0%).
+  ///
+  /// Theoretical lower limit; values < 65% rarely survivable but allowed for
+  /// measurement artifacts.
+  static const Percentage minSaturation = Percentage.zero;
+
+  /// Maximum valid oxygen saturation (100%).
+  ///
+  /// Physical maximum for oxygen saturation.
+  static const Percentage maxSaturation = Percentage.full;
+
   /// Creates an oxygen saturation record.
   ///
   /// ## Parameters
@@ -43,13 +54,36 @@ final class OxygenSaturationRecord extends InstantHealthRecord {
   /// - [metadata]: Metadata about the origin and recording method.
   /// - [id]: The unique identifier for this record.
   /// - [zoneOffsetSeconds]: Optional timezone offset for the measurement time.
-  const OxygenSaturationRecord({
+  ///
+  /// ## Throws
+  ///
+  /// - [ArgumentError] if [saturation] is outside the valid range of
+  ///   [minSaturation]-[maxSaturation]%.
+  ///
+  /// ## Validation Rationale
+  ///
+  /// - **Minimum ([minSaturation]%)**: Theoretical lower limit;
+  ///   values < 65% rarely survivable but allowed for measurement artifacts.
+  /// - **Maximum ([maxSaturation]%)**: Physical maximum for oxygen
+  ///   saturation.
+  OxygenSaturationRecord({
     required super.time,
     required this.saturation,
     required super.metadata,
     super.id,
     super.zoneOffsetSeconds,
-  });
+  }) {
+    require(
+      condition: saturation >= minSaturation && saturation <= maxSaturation,
+      value: saturation,
+      name: 'saturation',
+      message:
+          'Oxygen saturation must be between '
+          '${minSaturation.asWhole.toStringAsFixed(0)}-'
+          '${maxSaturation.asWhole.toStringAsFixed(0)}%. '
+          'Got ${saturation.asWhole.toStringAsFixed(1)}%.',
+    );
+  }
 
   /// Internal factory for creating [OxygenSaturationRecord] instances
   /// without validation.
@@ -113,9 +147,18 @@ final class OxygenSaturationRecord extends InstantHealthRecord {
   bool operator ==(Object other) =>
       identical(this, other) ||
       other is OxygenSaturationRecord &&
-          super == other &&
+          runtimeType == other.runtimeType &&
+          id == other.id &&
+          time == other.time &&
+          zoneOffsetSeconds == other.zoneOffsetSeconds &&
+          metadata == other.metadata &&
           saturation == other.saturation;
 
   @override
-  int get hashCode => Object.hash(super.hashCode, saturation);
+  int get hashCode =>
+      id.hashCode ^
+      time.hashCode ^
+      (zoneOffsetSeconds?.hashCode ?? 0) ^
+      metadata.hashCode ^
+      saturation.hashCode;
 }

--- a/packages/health_connector_core/lib/src/models/health_records/power/cycling_power_record.dart
+++ b/packages/health_connector_core/lib/src/models/health_records/power/cycling_power_record.dart
@@ -23,14 +23,48 @@ part of '../health_record.dart';
 @supportedOnAppleHealth
 @immutable
 final class CyclingPowerRecord extends InstantHealthRecord {
+  /// Minimum valid cycling power (0.0 W).
+  ///
+  /// No power output (coasting).
+  static const Power minPower = Power.zero;
+
+  /// Maximum valid cycling power (3,000.0 W).
+  ///
+  /// Elite track sprinters can peak at ~2,500W; 3,000W provides margin for
+  /// brief maximal efforts.
+  static const Power maxPower = Power.watts(3000.0);
+
   /// Creates a cycling power record.
-  const CyclingPowerRecord({
+  ///
+  /// ## Throws
+  ///
+  /// - [ArgumentError] if [power] is outside the valid range of
+  /// - [ArgumentError] if [power] is outside the valid range of
+  ///   [minPower]-[maxPower] W.
+  ///
+  /// ## Validation Rationale
+  ///
+  /// - **Minimum ([minPower] W)**: No power output (coasting).
+  /// - **Maximum ([maxPower] W)**: Elite track sprinters can peak at
+  ///   ~2,500W; 3,000W provides margin for brief maximal efforts.
+  CyclingPowerRecord({
     required super.time,
     required super.metadata,
     required this.power,
     super.id = HealthRecordId.none,
     super.zoneOffsetSeconds,
-  });
+  }) {
+    require(
+      condition: power >= minPower && power <= maxPower,
+      value: power,
+      name: 'power',
+      message:
+          'Cycling power must be between '
+          '${minPower.inWatts.toStringAsFixed(0)}-'
+          '${maxPower.inWatts.toStringAsFixed(0)} W. '
+          'Got ${power.inWatts.toStringAsFixed(0)} W.',
+    );
+  }
 
   /// Internal factory for creating [CyclingPowerRecord] instances
   /// without validation.

--- a/packages/health_connector_core/lib/src/models/health_records/power/power_series_record.dart
+++ b/packages/health_connector_core/lib/src/models/health_records/power/power_series_record.dart
@@ -200,14 +200,42 @@ final class PowerSeriesRecord extends SeriesHealthRecord<PowerSample> {
 @supportedOnHealthConnect
 @immutable
 final class PowerSample {
+  /// Minimum valid power.
+  static const Power minPower = CyclingPowerRecord.minPower;
+
+  /// Maximum valid power.
+  static const Power maxPower = CyclingPowerRecord.maxPower;
+
   /// Creates a power measurement.
   ///
   /// The [time] parameter specifies when the measurement was taken. The [power]
   /// parameter indicates the power output.
-  const PowerSample({
+  ///
+  /// ## Throws
+  ///
+  /// - [ArgumentError] if [power] is outside the valid range of
+  ///   [minPower]-[maxPower] W.
+  ///
+  /// ## Validation Rationale
+  ///
+  /// - **Minimum ([minPower] W)**: No power output (coasting).
+  /// - **Maximum ([maxPower] W)**: Elite track sprinters can peak at
+  ///   ~2,500W; 3,000W provides margin for brief maximal efforts.
+  PowerSample({
     required this.time,
     required this.power,
-  });
+  }) {
+    require(
+      condition: power >= minPower && power <= maxPower,
+      value: power,
+      name: 'power',
+      message:
+          'Power must be between '
+          '${minPower.inWatts.toStringAsFixed(0)}-'
+          '${maxPower.inWatts.toStringAsFixed(0)} W. '
+          'Got ${power.inWatts.toStringAsFixed(0)} W.',
+    );
+  }
 
   /// The time at which the power was measured, stored as a UTC instant.
   ///

--- a/packages/health_connector_core/lib/src/models/health_records/respiratory_rate_record.dart
+++ b/packages/health_connector_core/lib/src/models/health_records/respiratory_rate_record.dart
@@ -32,6 +32,26 @@ part of 'health_record.dart';
 @sinceV1_3_0
 @immutable
 final class RespiratoryRateRecord extends InstantHealthRecord {
+  /// Minimum valid respiratory rate.
+  ///
+  /// Valid range: 0-1000 breaths/min, as enforced by Android Health Connect.
+  ///
+  /// ## Platform Compatibility
+  ///
+  /// - **Android Health Connect**: [RespiratoryRateRecord.kt](https://cs.android.com/androidx/platform/frameworks/support/+/androidx-main:health/connect/connect-client/src/main/java/androidx/health/connect/client/records/RespiratoryRateRecord.kt)
+  /// - **Apple HealthKit**: No platform limits (application-defined)
+  static final Frequency minRate = Frequency.perMinute(0.0);
+
+  /// Maximum valid respiratory rate.
+  ///
+  /// Valid range: 0-1000 breaths/min, as enforced by Android Health Connect.
+  ///
+  /// ## Platform Compatibility
+  ///
+  /// - **Android Health Connect**: [RespiratoryRateRecord.kt](https://cs.android.com/androidx/platform/frameworks/support/+/androidx-main:health/connect/connect-client/src/main/java/androidx/health/connect/client/records/RespiratoryRateRecord.kt)
+  /// - **Apple HealthKit**: No platform limits (application-defined)
+  static final Frequency maxRate = Frequency.perMinute(1000.0);
+
   /// Creates a respiratory rate record.
   ///
   /// ## Parameters
@@ -41,13 +61,36 @@ final class RespiratoryRateRecord extends InstantHealthRecord {
   /// - [metadata]: Metadata about the origin and recording method.
   /// - [id]: The unique identifier for this record.
   /// - [zoneOffsetSeconds]: Optional timezone offset for the measurement time.
-  const RespiratoryRateRecord({
+  ///
+  /// ## Throws
+  ///
+  /// - [ArgumentError] if [rate] is outside the valid range of
+  ///   [minRate]-[maxRate] breaths/min.
+  ///
+  /// ## Validation Rationale
+  ///
+  /// - **Minimum ([minRate])**: 0 breaths/min matches Health Connect, though
+  ///   physiologically significant bradypnea begins around 4 breaths/min.
+  /// - **Maximum ([maxRate])**: 1000 breaths/min ensures Health Connect
+  ///   compatibility. Normal severe tachypnea is ~80 breaths/min.
+  RespiratoryRateRecord({
     required super.time,
     required this.rate,
     required super.metadata,
     super.id,
     super.zoneOffsetSeconds,
-  });
+  }) {
+    require(
+      condition: rate >= minRate && rate <= maxRate,
+      value: rate,
+      name: 'rate',
+      message:
+          'Respiratory rate must be between '
+          '${minRate.inPerMinute.toStringAsFixed(0)}-'
+          '${maxRate.inPerMinute.toStringAsFixed(0)} breaths/min. '
+          'Got ${rate.inPerMinute.toStringAsFixed(1)} breaths/min.',
+    );
+  }
 
   /// Internal factory for creating [BloodPressureRecord] instances without
   /// validation.
@@ -107,8 +150,19 @@ final class RespiratoryRateRecord extends InstantHealthRecord {
   @override
   bool operator ==(Object other) =>
       identical(this, other) ||
-      other is RespiratoryRateRecord && super == other && rate == other.rate;
+      other is RespiratoryRateRecord &&
+          runtimeType == other.runtimeType &&
+          id == other.id &&
+          time == other.time &&
+          zoneOffsetSeconds == other.zoneOffsetSeconds &&
+          metadata == other.metadata &&
+          rate == other.rate;
 
   @override
-  int get hashCode => Object.hash(super.hashCode, rate);
+  int get hashCode =>
+      id.hashCode ^
+      time.hashCode ^
+      (zoneOffsetSeconds?.hashCode ?? 0) ^
+      metadata.hashCode ^
+      rate.hashCode;
 }

--- a/packages/health_connector_core/lib/src/models/health_records/sexual_activity/sexual_activity_protection_used.dart
+++ b/packages/health_connector_core/lib/src/models/health_records/sexual_activity/sexual_activity_protection_used.dart
@@ -7,8 +7,10 @@ part of '../health_record.dart';
 ///
 /// ## Platform Mapping
 ///
-/// - **Android Health Connect**: Maps to  `SexualActivityRecord.SexualActivityProtectionUsed.*` constants
-/// - **iOS HealthKit**: Maps to `HKMetadataKeySexualActivityProtectionUsed`  metadata key (boolean value)
+/// - **Android Health Connect**: Maps to
+///   `SexualActivityRecord.SexualActivityProtectionUsed.*` constants
+/// - **iOS HealthKit**: Maps to `HKMetadataKeySexualActivityProtectionUsed`
+///   metadata key (boolean value)
 ///
 /// ## Cross-Platform Support
 ///
@@ -35,7 +37,8 @@ enum SexualActivityProtectionUsed {
   /// Unknown whether protection was used.
   ///
   /// **Platform Mappings:**
-  /// - **iOS HealthKit**: Custom metadata key  `HCCustomMetadataKeySexualActivityProtectionUsed = "unknown"`
+  /// - **iOS HealthKit**: Custom metadata key
+  ///   `HCCustomMetadataKeySexualActivityProtectionUsed = "unknown"`
   /// - **Android Health Connect**: `PROTECTION_USED_UNKNOWN`
   ///
   /// > **Note:** On iOS, this value requires custom metadata handling as

--- a/packages/health_connector_core/lib/src/models/health_records/sleep/sleep_session_record.dart
+++ b/packages/health_connector_core/lib/src/models/health_records/sleep/sleep_session_record.dart
@@ -45,6 +45,17 @@ part of '../health_record.dart';
 @supportedOnHealthConnect
 @immutable
 final class SleepSessionRecord extends SeriesHealthRecord<SleepStageSample> {
+  /// Minimum valid sleep session duration (1 minute).
+  ///
+  /// Brief naps; shorter than 1 minute unlikely to be actual sleep.
+  static const Duration minDuration = Duration(minutes: 1);
+
+  /// Maximum valid sleep session duration (24 hours).
+  ///
+  /// Typical sleep duration 4-12 hours; 24 hours allows for extended sleep or
+  /// combined sessions.
+  static const Duration maxDuration = Duration(hours: 24);
+
   /// Creates a sleep session record.
   ///
   /// The session spans from [startTime] to [endTime] and contains a list of
@@ -53,6 +64,19 @@ final class SleepSessionRecord extends SeriesHealthRecord<SleepStageSample> {
   /// Optional [title] and [notes] can be provided. Use [metadata] to describe
   /// the data source. Timezone offsets can be provided via
   /// [startZoneOffsetSeconds] and [endZoneOffsetSeconds].
+  ///
+  /// ## Throws
+  ///
+  /// - [ArgumentError] if [endTime] is not after [startTime].
+  /// - [ArgumentError] if session duration is outside the valid range of
+  ///   [minDuration] to [maxDuration].
+  ///
+  /// ## Validation Rationale
+  ///
+  /// - **Minimum ([minDuration])**: Brief naps; shorter than 1 minute
+  ///   unlikely to be actual sleep.
+  /// - **Maximum ([maxDuration])**: Typical sleep duration 4-12 hours; 24
+  ///   hours allows for extended sleep or combined sessions.
   SleepSessionRecord({
     required super.id,
     required super.metadata,
@@ -63,7 +87,18 @@ final class SleepSessionRecord extends SeriesHealthRecord<SleepStageSample> {
     super.endZoneOffsetSeconds,
     this.title,
     this.notes,
-  });
+  }) {
+    final duration = endTime.difference(startTime);
+    require(
+      condition: duration >= minDuration && duration <= maxDuration,
+      value: duration,
+      name: 'sleep session duration',
+      message:
+          'Sleep session duration must be between ${minDuration.inMinutes} '
+          'minute(s) and ${maxDuration.inHours} hours. '
+          'Got ${duration.inMinutes} minutes.',
+    );
+  }
 
   /// Internal factory for creating [BloodPressureRecord] instances without
   /// validation.
@@ -207,11 +242,22 @@ final class SleepStageSample {
   /// Creates a sleep stage.
   ///
   /// The stage is defined by [startTime], [endTime], and the [stageType].
-  const SleepStageSample({
+  ///
+  /// ## Throws
+  ///
+  /// - [ArgumentError] if [endTime] is not after [startTime].
+  SleepStageSample({
     required this.startTime,
     required this.endTime,
     required this.stageType,
-  });
+  }) {
+    require(
+      condition: endTime.isAfter(startTime),
+      value: endTime,
+      name: 'endTime',
+      message: 'Sleep stage end time must be after start time.',
+    );
+  }
 
   /// The start time of this sleep stage, stored as a UTC instant.
   ///

--- a/packages/health_connector_core/lib/src/models/health_records/sleep/sleep_stage.dart
+++ b/packages/health_connector_core/lib/src/models/health_records/sleep/sleep_stage.dart
@@ -2,7 +2,8 @@
 ///
 /// ## Platform Mapping
 ///
-/// - **Android Health Connect**: Maps to `SleepSessionRecord.Stage.StageType`constants
+/// - **Android Health Connect**: Maps to `SleepSessionRecord.Stage.StageType`
+///   constants
 /// - **iOS HealthKit**: Maps to `HKCategoryValueSleepAnalysis` enum values
 ///
 /// {@category Health Records}

--- a/packages/health_connector_core/lib/src/models/health_records/speed/running_speed_record.dart
+++ b/packages/health_connector_core/lib/src/models/health_records/speed/running_speed_record.dart
@@ -23,14 +23,50 @@ part of '../health_record.dart';
 @supportedOnAppleHealth
 @immutable
 final class RunningSpeedRecord extends SpeedActivityRecord {
+  /// Minimum valid running speed in km/h (0.0 km/h).
+  ///
+  /// At rest.
+  /// Minimum valid running speed (0.0 km/h).
+  ///
+  /// At rest.
+  static const Velocity minSpeed = Velocity.zero;
+
+  /// Maximum valid running speed (50.0 km/h).
+  ///
+  /// World record sprint speed ~44.7 km/h (Usain Bolt); 50 km/h provides
+  /// margin.
+  static const Velocity maxSpeed = Velocity.kilometersPerHour(50.0);
+
   /// Creates a running speed record.
-  const RunningSpeedRecord({
+  ///
+  /// ## Throws
+  ///
+  /// - [ArgumentError] if [speed] is outside the valid range of
+  ///   [minSpeed]-[maxSpeed] km/h.
+  ///
+  /// ## Validation Rationale
+  ///
+  /// - **Minimum ([minSpeed] km/h)**: At rest.
+  /// - **Maximum ([maxSpeed] km/h / 31 mph)**: World record sprint speed
+  ///   ~44.7 km/h (Usain Bolt); 50 km/h provides margin.
+  RunningSpeedRecord({
     required super.time,
     required super.metadata,
     required super.speed,
     super.id,
     super.zoneOffsetSeconds,
-  });
+  }) {
+    require(
+      condition: speed >= minSpeed && speed <= maxSpeed,
+      value: speed,
+      name: 'speed',
+      message:
+          'Running speed must be between '
+          '${minSpeed.inKilometersPerHour.toStringAsFixed(1)}-'
+          '${maxSpeed.inKilometersPerHour.toStringAsFixed(0)} km/h (0-31 mph). '
+          'Got ${speed.inKilometersPerHour.toStringAsFixed(1)} km/h.',
+    );
+  }
 
   /// Internal factory for creating [RunningSpeedRecord] instances
   /// without validation.

--- a/packages/health_connector_core/lib/src/models/health_records/speed/speed_series_record.dart
+++ b/packages/health_connector_core/lib/src/models/health_records/speed/speed_series_record.dart
@@ -8,7 +8,11 @@ part of '../health_record.dart';
 /// ## Platform Mapping
 ///
 /// - **Android Health Connect**: [`SpeedRecord`](https://developer.android.com/reference/kotlin/androidx/health/connect/client/records/SpeedRecord)
-/// - **iOS HealthKit**: Not supported. Use the activity-specific speed records:  - [WalkingSpeedRecord]  - [RunningSpeedRecord]  - [StairAscentSpeedRecord]  - [StairDescentSpeedRecord]
+/// - **iOS HealthKit**: Not supported. Use the activity-specific speed records:
+///   - [WalkingSpeedRecord]
+///   - [RunningSpeedRecord]
+///   - [StairAscentSpeedRecord]
+///   - [StairDescentSpeedRecord]
 ///
 /// ## Example
 ///
@@ -200,14 +204,46 @@ final class SpeedSeriesRecord extends SeriesHealthRecord<SpeedSample> {
 @supportedOnHealthConnect
 @immutable
 final class SpeedSample {
+  /// Minimum valid speed in km/h (0.0 km/h).
+  ///
+  /// At rest.
+  static const double minSpeedKmh = 0.0;
+
+  /// Maximum valid speed in km/h (150.0 km/h).
+  ///
+  /// Extreme cycling speeds (e.g., downhill); allows for various sports
+  /// activities.
+  static const double maxSpeedKmh = 150.0;
+
   /// Creates a speed measurement.
   ///
   /// The [time] parameter specifies when the measurement was taken. The [speed]
   /// parameter indicates the velocity.
-  const SpeedSample({
+  ///
+  /// ## Throws
+  ///
+  /// - [ArgumentError] if [speed] is outside the valid range of
+  ///   [minSpeedKmh]-[maxSpeedKmh] km/h.
+  ///
+  /// ## Validation Rationale
+  ///
+  /// - **Minimum ([minSpeedKmh] km/h)**: At rest.
+  /// - **Maximum ([maxSpeedKmh] km/h / 93 mph)**: Extreme cycling speeds (e.g.,
+  ///   downhill); allows for various sports activities.
+  SpeedSample({
     required this.time,
     required this.speed,
-  });
+  }) {
+    final kmh = speed.inKilometersPerHour;
+    require(
+      condition: kmh >= minSpeedKmh && kmh <= maxSpeedKmh,
+      value: speed,
+      name: 'speed',
+      message:
+          'Speed must be between $minSpeedKmh-${maxSpeedKmh.toStringAsFixed(0)} km/h (0-93 mph). Got '
+          '${kmh.toStringAsFixed(1)} km/h.',
+    );
+  }
 
   /// The time at which the speed was measured, stored as a UTC instant.
   ///

--- a/packages/health_connector_core/lib/src/models/health_records/speed/stair_ascent_speed_record.dart
+++ b/packages/health_connector_core/lib/src/models/health_records/speed/stair_ascent_speed_record.dart
@@ -23,14 +23,50 @@ part of '../health_record.dart';
 @supportedOnAppleHealth
 @immutable
 final class StairAscentSpeedRecord extends SpeedActivityRecord {
+  /// Minimum valid stair ascent speed in km/h (0.0 km/h).
+  ///
+  /// At rest.
+  /// Minimum valid stair ascent speed (0.0 km/h).
+  ///
+  /// At rest.
+  static const Velocity minSpeed = Velocity.zero;
+
+  /// Maximum valid stair ascent speed (2.0 km/h).
+  ///
+  /// Typical stair climbing 0.4-0.8 km/h; 2 km/h allows for fast stair
+  /// climbing.
+  static const Velocity maxSpeed = Velocity.kilometersPerHour(2.0);
+
   /// Creates a stair ascent speed record.
-  const StairAscentSpeedRecord({
+  ///
+  /// ## Throws
+  ///
+  /// - [ArgumentError] if [speed] is outside the valid range of
+  ///   [minSpeed]-[maxSpeed] km/h.
+  ///
+  /// ## Validation Rationale
+  ///
+  /// - **Minimum ([minSpeed] km/h)**: At rest.
+  /// - **Maximum ([maxSpeed] km/h / 1.2 mph)**: Typical stair climbing
+  ///   0.4-0.8 km/h; 2 km/h allows for fast stair climbing.
+  StairAscentSpeedRecord({
     required super.time,
     required super.metadata,
     required super.speed,
     super.id,
     super.zoneOffsetSeconds,
-  });
+  }) {
+    require(
+      condition: speed >= minSpeed && speed <= maxSpeed,
+      value: speed,
+      name: 'speed',
+      message:
+          'Stair ascent speed must be between '
+          '${minSpeed.inKilometersPerHour.toStringAsFixed(1)}-'
+          '${maxSpeed.inKilometersPerHour.toStringAsFixed(0)} km/h (0-1.2 mph). '
+          'Got ${speed.inKilometersPerHour.toStringAsFixed(2)} km/h.',
+    );
+  }
 
   /// Internal factory for creating [StairAscentSpeedRecord] instances
   /// without validation.

--- a/packages/health_connector_core/lib/src/models/health_records/speed/stair_descent_speed_record.dart
+++ b/packages/health_connector_core/lib/src/models/health_records/speed/stair_descent_speed_record.dart
@@ -23,14 +23,50 @@ part of '../health_record.dart';
 @supportedOnAppleHealth
 @immutable
 final class StairDescentSpeedRecord extends SpeedActivityRecord {
+  /// Minimum valid stair descent speed in km/h (0.0 km/h).
+  ///
+  /// At rest.
+  /// Minimum valid stair descent speed (0.0 km/h).
+  ///
+  /// At rest.
+  static const Velocity minSpeed = Velocity.zero;
+
+  /// Maximum valid stair descent speed (3.0 km/h).
+  ///
+  /// Descent typically faster than ascent (~0.5-1 km/h); 3 km/h allows for fast
+  /// descent.
+  static const Velocity maxSpeed = Velocity.kilometersPerHour(3.0);
+
   /// Creates a stair descent speed record.
-  const StairDescentSpeedRecord({
+  ///
+  /// ## Throws
+  ///
+  /// - [ArgumentError] if [speed] is outside the valid range of
+  ///   [minSpeed]-[maxSpeed] km/h.
+  ///
+  /// ## Validation Rationale
+  ///
+  /// - **Minimum ([minSpeed] km/h)**: At rest.
+  /// - **Maximum ([maxSpeed] km/h / 1.9 mph)**: Descent typically faster than
+  ///   ascent (~0.5-1 km/h); 3 km/h allows for fast descent.
+  StairDescentSpeedRecord({
     required super.time,
     required super.metadata,
     required super.speed,
     super.id,
     super.zoneOffsetSeconds,
-  });
+  }) {
+    require(
+      condition: speed >= minSpeed && speed <= maxSpeed,
+      value: speed,
+      name: 'speed',
+      message:
+          'Stair descent speed must be between '
+          '${minSpeed.inKilometersPerHour.toStringAsFixed(1)}-'
+          '${maxSpeed.inKilometersPerHour.toStringAsFixed(0)} km/h (0-1.9 mph). '
+          'Got ${speed.inKilometersPerHour.toStringAsFixed(2)} km/h.',
+    );
+  }
 
   /// Internal factory for creating [StairDescentSpeedRecord] instances
   /// without validation.

--- a/packages/health_connector_core/lib/src/models/health_records/speed/walking_speed_record.dart
+++ b/packages/health_connector_core/lib/src/models/health_records/speed/walking_speed_record.dart
@@ -23,14 +23,49 @@ part of '../health_record.dart';
 @supportedOnAppleHealth
 @immutable
 final class WalkingSpeedRecord extends SpeedActivityRecord {
+  /// Minimum valid walking speed in km/h (0.0 km/h).
+  ///
+  /// At rest.
+  /// Minimum valid walking speed (0.0 km/h).
+  ///
+  /// At rest.
+  static const Velocity minSpeed = Velocity.zero;
+
+  /// Maximum valid walking speed (12.0 km/h).
+  ///
+  /// Fast power walking limit; faster speeds transition to running.
+  static const Velocity maxSpeed = Velocity.kilometersPerHour(12.0);
+
   /// Creates a walking speed record.
-  const WalkingSpeedRecord({
+  ///
+  /// ## Throws
+  ///
+  /// - [ArgumentError] if [speed] is outside the valid range of
+  ///   [minSpeed]-[maxSpeed] km/h.
+  ///
+  /// ## Validation Rationale
+  ///
+  /// - **Minimum ([minSpeed] km/h)**: At rest.
+  /// - **Maximum ([maxSpeed] km/h / 7.5 mph)**: Fast power walking limit;
+  ///   faster speeds transition to running.
+  WalkingSpeedRecord({
     required super.time,
     required super.metadata,
     required super.speed,
     super.id,
     super.zoneOffsetSeconds,
-  });
+  }) {
+    require(
+      condition: speed >= minSpeed && speed <= maxSpeed,
+      value: speed,
+      name: 'speed',
+      message:
+          'Walking speed must be between '
+          '${minSpeed.inKilometersPerHour.toStringAsFixed(1)}-'
+          '${maxSpeed.inKilometersPerHour.toStringAsFixed(0)} km/h (0-7.5 mph). '
+          'Got ${speed.inKilometersPerHour.toStringAsFixed(1)} km/h.',
+    );
+  }
 
   /// Internal factory for creating [WalkingSpeedRecord] instances
   /// without validation.

--- a/packages/health_connector_core/lib/src/models/health_records/steps_record.dart
+++ b/packages/health_connector_core/lib/src/models/health_records/steps_record.dart
@@ -32,6 +32,16 @@ part of 'health_record.dart';
 @sinceV1_0_0
 @immutable
 final class StepsRecord extends IntervalHealthRecord {
+  /// Minimum valid step count (0).
+  /// Minimum valid step count (0).
+  static const Number minSteps = Number.zero;
+
+  /// Maximum valid step count (1,000,000).
+  ///
+  /// Represents extreme endurance events (e.g., 200+ mile ultra-marathons)
+  /// with safety margin.
+  static const Number maxSteps = Number(1000000);
+
   /// Creates a step count record.
   ///
   /// ## Parameters
@@ -48,6 +58,8 @@ final class StepsRecord extends IntervalHealthRecord {
   ///
   /// - [ArgumentError] if [count] is negative.
   /// - [ArgumentError] if [endTime] is not after [startTime].
+  /// - [ArgumentError] if [count] is outside the valid range of
+  ///   [minSteps]-[maxSteps].
   StepsRecord({
     required super.startTime,
     required super.endTime,
@@ -58,10 +70,13 @@ final class StepsRecord extends IntervalHealthRecord {
     super.endZoneOffsetSeconds,
   }) {
     require(
-      condition: count.value >= 0,
+      condition: count >= minSteps && count <= maxSteps,
       value: count,
       name: 'count',
-      message: 'count must be non-negative. Got count=${count.value}',
+      message:
+          'Steps must be between ${minSteps.value.toInt()}-'
+          '${maxSteps.value.toInt()}. '
+          'Got ${count.value.toInt()} steps.',
     );
   }
 

--- a/packages/health_connector_core/lib/src/models/health_records/temperature/basal_body_temperature_record.dart
+++ b/packages/health_connector_core/lib/src/models/health_records/temperature/basal_body_temperature_record.dart
@@ -33,6 +33,18 @@ part of '../health_record.dart';
 @sinceV2_2_0
 @immutable
 final class BasalBodyTemperatureRecord extends InstantHealthRecord {
+  /// Minimum valid basal body temperature in Celsius (34.0°C).
+  ///
+  /// Mild hypothermia threshold; basal temp measured at rest should not be this
+  /// low.
+  static const double minTempCelsius = 34.0;
+
+  /// Maximum valid basal body temperature in Celsius (42.0°C).
+  ///
+  /// High fever threshold; basal temp typically < 37.5°C, but allowing up to
+  /// 42°C for illness cases.
+  static const double maxTempCelsius = 42.0;
+
   /// Creates a basal body temperature record.
   ///
   /// ## Parameters
@@ -44,14 +56,37 @@ final class BasalBodyTemperatureRecord extends InstantHealthRecord {
   /// - [temperature]: The basal body temperature measurement.
   /// - [measurementLocation]: The location on the body where the measurement
   ///   was taken.
-  const BasalBodyTemperatureRecord({
+  ///
+  /// ## Throws
+  ///
+  /// - [ArgumentError] if [temperature] is outside the valid range of
+  ///   [minTempCelsius]-[maxTempCelsius]°C (93.2-107.6°F).
+  ///
+  /// ## Validation Rationale
+  ///
+  /// - **Minimum ([minTempCelsius]°C / 93.2°F)**: Mild hypothermia threshold;
+  ///   basal temp measured at rest should not be this low.
+  /// - **Maximum ([maxTempCelsius]°C / 107.6°F)**: High fever threshold; basal
+  ///   temp typically < 37.5°C, but allowing up to 42°C for illness cases.
+  BasalBodyTemperatureRecord({
     required super.time,
     required super.metadata,
     required this.temperature,
     super.id,
     super.zoneOffsetSeconds,
     this.measurementLocation = BasalBodyTemperatureMeasurementLocation.unknown,
-  });
+  }) {
+    final celsius = temperature.inCelsius;
+    require(
+      condition: celsius >= minTempCelsius && celsius <= maxTempCelsius,
+      value: temperature,
+      name: 'temperature',
+      message:
+          'Basal body temperature must be between '
+          '$minTempCelsius-${maxTempCelsius.toStringAsFixed(0)}°C '
+          '(93.2-107.6°F). Got ${celsius.toStringAsFixed(1)}°C.',
+    );
+  }
 
   /// Internal factory for creating [BasalBodyTemperatureRecord] instances
   /// without validation.

--- a/packages/health_connector_core/lib/src/models/health_records/temperature/body_temperature_record.dart
+++ b/packages/health_connector_core/lib/src/models/health_records/temperature/body_temperature_record.dart
@@ -28,6 +28,18 @@ part of '../health_record.dart';
 @sinceV1_0_0
 @immutable
 final class BodyTemperatureRecord extends InstantHealthRecord {
+  /// Minimum valid body temperature (10°C).
+  ///
+  /// Below lowest survived core temperature (11.8°C) with margin for sensor
+  /// variance.
+  static const Temperature minTemperature = Temperature.celsius(10.0);
+
+  /// Maximum valid body temperature (47°C).
+  ///
+  /// Above typical lethal threshold (46.5°C); values above indicate
+  /// measurement error.
+  static const Temperature maxTemperature = Temperature.celsius(47.0);
+
   /// Creates a body temperature record.
   ///
   /// ## Parameters
@@ -37,13 +49,36 @@ final class BodyTemperatureRecord extends InstantHealthRecord {
   /// - [zoneOffsetSeconds]: Optional timezone offset for the measurement time.
   /// - [metadata]: Metadata about the origin and recording method.
   /// - [temperature]: The body temperature measurement.
-  const BodyTemperatureRecord({
+  ///
+  /// ## Throws
+  ///
+  /// - [ArgumentError] if [temperature] is outside the valid range of
+  ///   [minTemperature]-[maxTemperature]°C (50-117°F).
+  ///
+  /// ## Validation Rationale
+  ///
+  /// - **Minimum ([minTemperature]°C / 50°F)**: Below lowest survived core temperature
+  ///   (11.8°C) with margin for sensor variance.
+  /// - **Maximum ([maxTemperature]°C / 117°F)**: Above typical lethal threshold (46.5°C);
+  ///   values above indicate measurement error.
+  BodyTemperatureRecord({
     required super.time,
     required super.metadata,
     required this.temperature,
     super.id,
     super.zoneOffsetSeconds,
-  });
+  }) {
+    require(
+      condition: temperature >= minTemperature && temperature <= maxTemperature,
+      value: temperature,
+      name: 'temperature',
+      message:
+          'Body temperature must be between '
+          '${minTemperature.inCelsius.toStringAsFixed(0)}-'
+          '${maxTemperature.inCelsius.toStringAsFixed(0)}°C (50-117°F). '
+          'Got ${temperature.inCelsius.toStringAsFixed(1)}°C.',
+    );
+  }
 
   /// Internal factory for creating [BodyTemperatureRecord] instances
   /// without validation.

--- a/packages/health_connector_core/lib/src/models/health_records/vo2_max_record.dart
+++ b/packages/health_connector_core/lib/src/models/health_records/vo2_max_record.dart
@@ -38,6 +38,17 @@ part of 'health_record.dart';
 @sinceV1_3_0
 @immutable
 final class Vo2MaxRecord extends InstantHealthRecord {
+  /// Minimum valid VO₂ max (5.0 mL/kg/min).
+  ///
+  /// Very sedentary/severely ill lower limit.
+  static const Number minVo2MlPerMinPerKg = Number(5.0);
+
+  /// Maximum valid VO₂ max (100.0 mL/kg/min).
+  ///
+  /// Exceeds world record (97.5 mL/kg/min, Oskar Svendsen) with margin for
+  /// measurement variance.
+  static const Number maxVo2MlPerMinPerKg = Number(100.0);
+
   /// Creates a VO₂ max record.
   ///
   /// ## Parameters
@@ -48,14 +59,38 @@ final class Vo2MaxRecord extends InstantHealthRecord {
   /// - [metadata]: Metadata about the origin and recording method.
   /// - [vo2MlPerMinPerKg]: The VO₂ max measurement in mL/kg/min.
   /// - [testType]: Optional test type or measurement method used.
-  const Vo2MaxRecord({
+  ///
+  /// ## Throws
+  ///
+  /// - [ArgumentError] if [vo2MlPerMinPerKg] is outside the valid range of
+  ///   [minVo2MlPerMinPerKg]-[maxVo2MlPerMinPerKg] mL/kg/min.
+  ///
+  /// ## Validation Rationale
+  ///
+  /// - **Minimum ([minVo2MlPerMinPerKg] mL/kg/min)**: Very sedentary/severely ill lower limit.
+  /// - **Maximum ([maxVo2MlPerMinPerKg] mL/kg/min)**: Exceeds world record (97.5 mL/kg/min,
+  ///   Oskar Svendsen) with margin for measurement variance.
+  Vo2MaxRecord({
     required super.time,
     required super.metadata,
     required this.vo2MlPerMinPerKg,
     this.testType,
     super.id,
     super.zoneOffsetSeconds,
-  });
+  }) {
+    require(
+      condition:
+          vo2MlPerMinPerKg >= minVo2MlPerMinPerKg &&
+          vo2MlPerMinPerKg <= maxVo2MlPerMinPerKg,
+      value: vo2MlPerMinPerKg,
+      name: 'vo2MlPerMinPerKg',
+      message:
+          'VO₂ max must be between '
+          '${minVo2MlPerMinPerKg.value}-'
+          '${maxVo2MlPerMinPerKg.value} mL/kg/min. '
+          'Got ${vo2MlPerMinPerKg.value.toStringAsFixed(1)} mL/kg/min.',
+    );
+  }
 
   /// Internal factory for creating [Vo2MaxRecord] instances
   /// without validation.

--- a/packages/health_connector_core/lib/src/models/health_records/waist_circumference_record.dart
+++ b/packages/health_connector_core/lib/src/models/health_records/waist_circumference_record.dart
@@ -32,6 +32,16 @@ part of 'health_record.dart';
 @supportedOnAppleHealth
 @immutable
 final class WaistCircumferenceRecord extends InstantHealthRecord {
+  /// Minimum valid waist circumference (20.0 cm).
+  ///
+  /// Newborn/infant lower bound.
+  static const Length minCircumference = Length.centimeters(20.0);
+
+  /// Maximum valid waist circumference (200.0 cm).
+  ///
+  /// Severe obesity upper limit.
+  static const Length maxCircumference = Length.centimeters(200.0);
+
   /// Creates a waist circumference record.
   ///
   /// ## Parameters
@@ -44,7 +54,13 @@ final class WaistCircumferenceRecord extends InstantHealthRecord {
   ///
   /// ## Throws
   ///
-  /// - [ArgumentError] if [circumference] is negative.
+  /// - [ArgumentError] if [circumference] is outside the valid range of
+  ///   [minCircumference]-[maxCircumference] cm.
+  ///
+  /// ## Validation Rationale
+  ///
+  /// - **Minimum ([minCircumference] cm)**: Newborn/infant lower bound.
+  /// - **Maximum ([maxCircumference] cm)**: Severe obesity upper limit.
   WaistCircumferenceRecord({
     required super.time,
     required super.metadata,
@@ -52,13 +68,18 @@ final class WaistCircumferenceRecord extends InstantHealthRecord {
     super.id = HealthRecordId.none,
     super.zoneOffsetSeconds,
   }) {
-    if (circumference < Length.zero) {
-      throw ArgumentError.value(
-        circumference,
-        'circumference',
-        'Circumference must be non-negative',
-      );
-    }
+    require(
+      condition:
+          circumference >= minCircumference &&
+          circumference <= maxCircumference,
+      value: circumference,
+      name: 'circumference',
+      message:
+          'Waist circumference must be between '
+          '${minCircumference.inCentimeters.toStringAsFixed(1)}-'
+          '${maxCircumference.inCentimeters.toStringAsFixed(0)} cm. '
+          'Got ${circumference.inCentimeters.toStringAsFixed(1)} cm.',
+    );
   }
 
   /// Internal factory for creating [WaistCircumferenceRecord] instances

--- a/packages/health_connector_core/lib/src/models/health_records/weight_record.dart
+++ b/packages/health_connector_core/lib/src/models/health_records/weight_record.dart
@@ -28,6 +28,20 @@ part of 'health_record.dart';
 @sinceV1_0_0
 @immutable
 final class WeightRecord extends InstantHealthRecord {
+  /// Minimum valid weight in kilograms (0.5 kg).
+  ///
+  /// Extremely premature infants can weigh ~500g.
+  /// Minimum valid weight (0.5 kg).
+  ///
+  /// Extremely premature infants can weigh ~500g.
+  static const Mass minWeight = Mass.kilograms(0.5);
+
+  /// Maximum valid weight (700 kg).
+  ///
+  /// Exceeds the heaviest recorded person (635 kg) with margin for
+  /// medical edge cases.
+  static const Mass maxWeight = Mass.kilograms(700.0);
+
   /// Creates a body weight record.
   ///
   /// ## Parameters
@@ -37,13 +51,37 @@ final class WeightRecord extends InstantHealthRecord {
   /// - [zoneOffsetSeconds]: Optional timezone offset for the measurement time.
   /// - [metadata]: Metadata about the origin and recording method.
   /// - [weight]: The body mass measurement.
-  const WeightRecord({
+  ///
+  /// ## Throws
+  ///
+  /// - [ArgumentError] if [weight] is outside the valid range of
+  /// - [ArgumentError] if [weight] is outside the valid range of
+  ///   [minWeight]-[maxWeight] kg.
+  ///
+  /// ## Validation Rationale
+  ///
+  /// - **Minimum ([minWeight] kg)**: Extremely premature infants can
+  ///   weigh ~500g.
+  /// - **Maximum ([maxWeight] kg)**: Exceeds the heaviest recorded person
+  ///   (635 kg) with margin for medical edge cases.
+  WeightRecord({
     required super.time,
     required super.metadata,
     required this.weight,
     super.id,
     super.zoneOffsetSeconds,
-  });
+  }) {
+    require(
+      condition: weight >= minWeight && weight <= maxWeight,
+      value: weight,
+      name: 'weight',
+      message:
+          'Weight must be between '
+          '${minWeight.inKilograms.toStringAsFixed(1)}-'
+          '${maxWeight.inKilograms.toStringAsFixed(0)} kg. '
+          'Got ${weight.inKilograms.toStringAsFixed(1)} kg.',
+    );
+  }
 
   /// Internal factory for creating [WeightRecord] instances
   /// without validation.

--- a/packages/health_connector_core/lib/src/models/health_records/wheelchair_pushes_record.dart
+++ b/packages/health_connector_core/lib/src/models/health_records/wheelchair_pushes_record.dart
@@ -32,6 +32,20 @@ part of 'health_record.dart';
 @sinceV1_0_0
 @immutable
 final class WheelchairPushesRecord extends IntervalHealthRecord {
+  /// Minimum valid wheelchair pushes (0.0).
+  ///
+  /// No wheelchair activity during the interval.
+  /// Minimum valid wheelchair pushes (0).
+  ///
+  /// No wheelchair activity during the interval.
+  static const Number minPushes = Number.zero;
+
+  /// Maximum valid wheelchair pushes (100,000).
+  ///
+  /// Typical daily activity ~500-5,000 pushes; 100,000 allows for multi-day
+  /// intervals and high-activity users.
+  static const Number maxPushes = Number(100000);
+
   /// Creates a wheelchair pushes record.
   ///
   /// ## Parameters
@@ -47,6 +61,14 @@ final class WheelchairPushesRecord extends IntervalHealthRecord {
   /// ## Throws
   ///
   /// - [ArgumentError] if [endTime] is not after [startTime].
+  /// - [ArgumentError] if [count] is outside the valid range of
+  ///   [minPushes]-[maxPushes].
+  ///
+  /// ## Validation Rationale
+  ///
+  /// - **Minimum ([minPushes])**: No wheelchair activity during the interval.
+  /// - **Maximum ([maxPushes])**: Typical daily activity ~500-5,000 pushes;
+  ///   100,000 allows for multi-day intervals and high-activity users.
   WheelchairPushesRecord({
     required super.startTime,
     required super.endTime,
@@ -55,7 +77,17 @@ final class WheelchairPushesRecord extends IntervalHealthRecord {
     super.id = HealthRecordId.none,
     super.startZoneOffsetSeconds,
     super.endZoneOffsetSeconds,
-  });
+  }) {
+    require(
+      condition: count >= minPushes && count <= maxPushes,
+      value: count,
+      name: 'count',
+      message:
+          'Wheelchair pushes must be between '
+          '${minPushes.value.toInt()}-${maxPushes.value.toInt()}. '
+          'Got ${count.value.toInt()} pushes.',
+    );
+  }
 
   /// Internal factory for creating [WheelchairPushesRecord] instances
   /// without validation.

--- a/packages/health_connector_core/test/src/models/health_records/blood_glucose/blood_glucose_record_test.dart
+++ b/packages/health_connector_core/test/src/models/health_records/blood_glucose/blood_glucose_record_test.dart
@@ -1,0 +1,94 @@
+import 'package:health_connector_core/health_connector_core.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('BloodGlucoseRecord', () {
+    final now = DateTime(2026, 1, 11);
+    final metadata = Metadata.manualEntry();
+    const validValue = BloodGlucose.millimolesPerLiter(5.5);
+
+    test('can be instantiated with valid parameters', () {
+      final record = BloodGlucoseRecord(
+        time: now,
+        glucoseLevel: validValue,
+        metadata: metadata,
+      );
+
+      expect(record.time, now);
+      expect(
+        record.glucoseLevel,
+        equals(validValue),
+      );
+      expect(record.metadata, metadata);
+    });
+
+    test('throws ArgumentError when glucoseLevel is below '
+        'minBloodGlucose', () {
+      expect(
+        () => BloodGlucoseRecord(
+          time: now,
+          glucoseLevel: const BloodGlucose.milligramsPerDeciliter(19.0),
+          metadata: metadata,
+        ),
+        throwsArgumentError,
+      );
+    });
+
+    test('throws ArgumentError when glucoseLevel is above '
+        'maxBloodGlucose', () {
+      expect(
+        () => BloodGlucoseRecord(
+          time: now,
+          glucoseLevel: const BloodGlucose.milligramsPerDeciliter(701.0),
+          metadata: metadata,
+        ),
+        throwsArgumentError,
+      );
+    });
+
+    test('copyWith updates all fields correctly', () {
+      final record = BloodGlucoseRecord(
+        time: now,
+        glucoseLevel: validValue,
+        metadata: metadata,
+      );
+
+      final newTime = now.add(const Duration(minutes: 5));
+      const newGlucose = BloodGlucose.millimolesPerLiter(6.0);
+      final newMetadata = Metadata.manualEntry();
+      final updated = record.copyWith(
+        time: newTime,
+        glucoseLevel: newGlucose,
+        metadata: newMetadata,
+      );
+
+      expect(updated.time, newTime);
+      expect(updated.glucoseLevel, newGlucose);
+      expect(updated.metadata, newMetadata);
+    });
+
+    test('equality works correctly', () {
+      final record1 = BloodGlucoseRecord(
+        time: now,
+        glucoseLevel: validValue,
+        metadata: metadata,
+      );
+      final record2 = BloodGlucoseRecord(
+        time: now,
+        glucoseLevel: validValue,
+        metadata: metadata,
+      );
+
+      expect(record1, equals(record2));
+
+      final record3 = BloodGlucoseRecord(
+        time: now,
+        glucoseLevel: const BloodGlucose.millimolesPerLiter(6.0),
+        metadata: metadata,
+      );
+
+      expect(record1, isNot(equals(record3)));
+      expect(record1.hashCode, equals(record2.hashCode));
+    });
+  });
+}

--- a/packages/health_connector_core/test/src/models/health_records/blood_pressure/blood_pressure_record_test.dart
+++ b/packages/health_connector_core/test/src/models/health_records/blood_pressure/blood_pressure_record_test.dart
@@ -1,0 +1,111 @@
+import 'package:health_connector_core/health_connector_core.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('BloodPressureRecord', () {
+    final now = DateTime(2026, 1, 11);
+    final metadata = Metadata.manualEntry();
+    const validSystolic = Pressure.millimetersOfMercury(120);
+    const validDiastolic = Pressure.millimetersOfMercury(80);
+
+    test('can be instantiated with valid parameters', () {
+      final record = BloodPressureRecord(
+        time: now,
+        systolic: validSystolic,
+        diastolic: validDiastolic,
+        metadata: metadata,
+      );
+
+      expect(record.time, now);
+      expect(record.systolic, equals(validSystolic));
+      expect(record.diastolic, equals(validDiastolic));
+      expect(record.metadata, metadata);
+    });
+
+    test('throws ArgumentError when systolic is below minSystolic', () {
+      expect(
+        () => BloodPressureRecord(
+          time: now,
+          systolic: const Pressure.millimetersOfMercury(49.0),
+          diastolic: validDiastolic,
+          metadata: metadata,
+        ),
+        throwsArgumentError,
+      );
+    });
+
+    test('throws ArgumentError when systolic is above maxSystolic', () {
+      expect(
+        () => BloodPressureRecord(
+          time: now,
+          systolic: const Pressure.millimetersOfMercury(301.0),
+          diastolic: validDiastolic,
+          metadata: metadata,
+        ),
+        throwsArgumentError,
+      );
+    });
+
+    test('throws ArgumentError when diastolic is below minDiastolic', () {
+      expect(
+        () => BloodPressureRecord(
+          time: now,
+          systolic: validSystolic,
+          diastolic: const Pressure.millimetersOfMercury(29.0),
+          metadata: metadata,
+        ),
+        throwsArgumentError,
+      );
+    });
+
+    test('throws ArgumentError when diastolic is above maxDiastolic', () {
+      expect(
+        () => BloodPressureRecord(
+          time: now,
+          systolic: validSystolic,
+          diastolic: const Pressure.millimetersOfMercury(301.0), // Above 300
+          metadata: metadata,
+        ),
+        throwsArgumentError,
+      );
+    });
+
+    test('throws ArgumentError when systolic is less than diastolic', () {
+      expect(
+        () => BloodPressureRecord(
+          time: now,
+          systolic: const Pressure.millimetersOfMercury(80.0),
+          diastolic: const Pressure.millimetersOfMercury(90.0),
+          metadata: metadata,
+        ),
+        throwsArgumentError,
+      );
+    });
+
+    test('copyWith updates all fields correctly', () {
+      final record = BloodPressureRecord(
+        time: now,
+        systolic: validSystolic,
+        diastolic: validDiastolic,
+        metadata: metadata,
+      );
+
+      final newTime = now.add(const Duration(minutes: 5));
+      const newSystolic = Pressure.millimetersOfMercury(130);
+      const newDiastolic = Pressure.millimetersOfMercury(90);
+      final newMetadata = Metadata.manualEntry();
+
+      final updated = record.copyWith(
+        time: newTime,
+        systolic: newSystolic,
+        diastolic: newDiastolic,
+        metadata: newMetadata,
+      );
+
+      expect(updated.time, newTime);
+      expect(updated.systolic, newSystolic);
+      expect(updated.diastolic, newDiastolic);
+      expect(updated.metadata, newMetadata);
+    });
+  });
+}

--- a/packages/health_connector_core/test/src/models/health_records/blood_pressure/diastolic_blood_pressure_record_test.dart
+++ b/packages/health_connector_core/test/src/models/health_records/blood_pressure/diastolic_blood_pressure_record_test.dart
@@ -1,0 +1,76 @@
+import 'package:health_connector_core/health_connector_core.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('DiastolicBloodPressureRecord', () {
+    final now = DateTime(2026, 1, 11);
+    final metadata = Metadata.manualEntry();
+    const validValue = Pressure.millimetersOfMercury(80);
+
+    test('can be instantiated with valid parameters', () {
+      final record = DiastolicBloodPressureRecord(
+        time: now,
+        pressure: validValue,
+        metadata: metadata,
+      );
+
+      expect(record.time, now);
+      expect(record.pressure, equals(validValue));
+      expect(record.metadata, metadata);
+    });
+
+    test('throws ArgumentError when pressure is below minPressure', () {
+      expect(
+        () => DiastolicBloodPressureRecord(
+          time: now,
+          pressure: const Pressure.millimetersOfMercury(29.0),
+          metadata: metadata,
+        ),
+        throwsArgumentError,
+      );
+    });
+
+    test('accepts maximum valid pressure', () {
+      final record = DiastolicBloodPressureRecord(
+        time: now,
+        pressure: const Pressure.millimetersOfMercury(300.0), // New max
+        metadata: metadata,
+      );
+
+      expect(record.pressure.inMillimetersOfMercury, equals(300.0));
+    });
+
+    test('throws ArgumentError when pressure is above maxPressure', () {
+      expect(
+        () => DiastolicBloodPressureRecord(
+          time: now,
+          pressure: const Pressure.millimetersOfMercury(301.0), // Above 300
+          metadata: metadata,
+        ),
+        throwsArgumentError,
+      );
+    });
+
+    test('copyWith updates all fields correctly', () {
+      final record = DiastolicBloodPressureRecord(
+        time: now,
+        pressure: validValue,
+        metadata: metadata,
+      );
+
+      final newTime = now.add(const Duration(minutes: 5));
+      const newPressure = Pressure.millimetersOfMercury(90);
+      final newMetadata = Metadata.manualEntry();
+
+      final updated = record.copyWith(
+        time: newTime,
+        pressure: newPressure,
+        metadata: newMetadata,
+      );
+
+      expect(updated.time, newTime);
+      expect(updated.pressure, newPressure);
+      expect(updated.metadata, newMetadata);
+    });
+  });
+}

--- a/packages/health_connector_core/test/src/models/health_records/blood_pressure/systolic_blood_pressure_record_test.dart
+++ b/packages/health_connector_core/test/src/models/health_records/blood_pressure/systolic_blood_pressure_record_test.dart
@@ -1,0 +1,76 @@
+import 'package:health_connector_core/health_connector_core.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('SystolicBloodPressureRecord', () {
+    final now = DateTime(2026, 1, 11);
+    final metadata = Metadata.manualEntry();
+    const validValue = Pressure.millimetersOfMercury(120);
+
+    test('can be instantiated with valid parameters', () {
+      final record = SystolicBloodPressureRecord(
+        time: now,
+        pressure: validValue,
+        metadata: metadata,
+      );
+
+      expect(record.time, now);
+      expect(record.pressure, equals(validValue));
+      expect(record.metadata, metadata);
+    });
+
+    test('throws ArgumentError when pressure is below minPressure', () {
+      expect(
+        () => SystolicBloodPressureRecord(
+          time: now,
+          pressure: const Pressure.millimetersOfMercury(49.0),
+          metadata: metadata,
+        ),
+        throwsArgumentError,
+      );
+    });
+
+    test('accepts maximum valid pressure', () {
+      final record = SystolicBloodPressureRecord(
+        time: now,
+        pressure: const Pressure.millimetersOfMercury(300.0), // New max
+        metadata: metadata,
+      );
+
+      expect(record.pressure.inMillimetersOfMercury, equals(300.0));
+    });
+
+    test('throws ArgumentError when pressure is above maxPressure', () {
+      expect(
+        () => SystolicBloodPressureRecord(
+          time: now,
+          pressure: const Pressure.millimetersOfMercury(301.0), // Above 300
+          metadata: metadata,
+        ),
+        throwsArgumentError,
+      );
+    });
+
+    test('copyWith updates all fields correctly', () {
+      final record = SystolicBloodPressureRecord(
+        time: now,
+        pressure: validValue,
+        metadata: metadata,
+      );
+
+      final newTime = now.add(const Duration(minutes: 5));
+      const newPressure = Pressure.millimetersOfMercury(130);
+      final newMetadata = Metadata.manualEntry();
+
+      final updated = record.copyWith(
+        time: newTime,
+        pressure: newPressure,
+        metadata: newMetadata,
+      );
+
+      expect(updated.time, newTime);
+      expect(updated.pressure, newPressure);
+      expect(updated.metadata, newMetadata);
+    });
+  });
+}

--- a/packages/health_connector_core/test/src/models/health_records/body_fat_percentage_record_test.dart
+++ b/packages/health_connector_core/test/src/models/health_records/body_fat_percentage_record_test.dart
@@ -1,0 +1,90 @@
+import 'package:health_connector_core/health_connector_core.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('BodyFatPercentageRecord', () {
+    final now = DateTime(2026, 1, 11);
+    final metadata = Metadata.manualEntry();
+    const validPercentage = Percentage.fromWhole(20.0);
+
+    test('can be instantiated with valid parameters', () {
+      final record = BodyFatPercentageRecord(
+        time: now,
+        percentage: validPercentage,
+        metadata: metadata,
+      );
+
+      expect(record.time, now);
+      expect(record.percentage, validPercentage);
+      expect(record.metadata, metadata);
+    });
+
+    test('throws ArgumentError when percentage is below minPercentage', () {
+      expect(
+        () => BodyFatPercentageRecord(
+          time: now,
+          percentage: const Percentage.fromWhole(1.9),
+          metadata: metadata,
+        ),
+        throwsArgumentError,
+      );
+    });
+
+    test('throws ArgumentError when percentage is above maxPercentage', () {
+      expect(
+        () => BodyFatPercentageRecord(
+          time: now,
+          percentage: const Percentage.fromWhole(65.1),
+          metadata: metadata,
+        ),
+        throwsArgumentError,
+      );
+    });
+
+    test('copyWith updates all fields correctly', () {
+      final record = BodyFatPercentageRecord(
+        time: now,
+        percentage: validPercentage,
+        metadata: metadata,
+      );
+
+      final newTime = now.add(const Duration(minutes: 5));
+      const newPercentage = Percentage.fromWhole(22.0);
+      final newMetadata = Metadata.manualEntry();
+
+      final updated = record.copyWith(
+        time: newTime,
+        percentage: newPercentage,
+        metadata: newMetadata,
+      );
+
+      expect(updated.time, newTime);
+      expect(updated.percentage, newPercentage);
+      expect(updated.metadata, newMetadata);
+    });
+
+    test('equality works correctly', () {
+      final record1 = BodyFatPercentageRecord(
+        time: now,
+        percentage: validPercentage,
+        metadata: metadata,
+      );
+
+      final record2 = BodyFatPercentageRecord(
+        time: now,
+        percentage: validPercentage,
+        metadata: metadata,
+      );
+
+      final record3 = BodyFatPercentageRecord(
+        time: now,
+        percentage: const Percentage.fromWhole(21.0),
+        metadata: metadata,
+      );
+
+      expect(record1 == record2, isTrue);
+      expect(record1 == record3, isFalse);
+      expect(record1.hashCode == record2.hashCode, isTrue);
+    });
+  });
+}

--- a/packages/health_connector_core/test/src/models/health_records/body_mass_index_record_test.dart
+++ b/packages/health_connector_core/test/src/models/health_records/body_mass_index_record_test.dart
@@ -1,0 +1,90 @@
+import 'package:health_connector_core/health_connector_core.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('BodyMassIndexRecord', () {
+    final now = DateTime(2026, 1, 11);
+    final metadata = Metadata.manualEntry();
+    const validBmi = Number(22.5);
+
+    test('can be instantiated with valid parameters', () {
+      final record = BodyMassIndexRecord(
+        time: now,
+        bmi: validBmi,
+        metadata: metadata,
+      );
+
+      expect(record.time, now);
+      expect(record.bmi, equals(validBmi));
+      expect(record.metadata, metadata);
+    });
+
+    test('throws ArgumentError when bmi is below minBmi', () {
+      expect(
+        () => BodyMassIndexRecord(
+          time: now,
+          bmi: const Number(4.9),
+          metadata: metadata,
+        ),
+        throwsArgumentError,
+      );
+    });
+
+    test('throws ArgumentError when bmi is above maxBmi', () {
+      expect(
+        () => BodyMassIndexRecord(
+          time: now,
+          bmi: const Number(100.1),
+          metadata: metadata,
+        ),
+        throwsArgumentError,
+      );
+    });
+
+    test('copyWith updates all fields correctly', () {
+      final record = BodyMassIndexRecord(
+        time: now,
+        bmi: validBmi,
+        metadata: metadata,
+      );
+
+      final newTime = now.add(const Duration(minutes: 5));
+      const newBmi = Number(25.0);
+      final newMetadata = Metadata.manualEntry();
+
+      final updated = record.copyWith(
+        time: newTime,
+        bmi: newBmi,
+        metadata: newMetadata,
+      );
+
+      expect(updated.time, newTime);
+      expect(updated.bmi, newBmi);
+      expect(updated.metadata, newMetadata);
+    });
+
+    test('equality works correctly', () {
+      final record1 = BodyMassIndexRecord(
+        time: now,
+        bmi: validBmi,
+        metadata: metadata,
+      );
+
+      final record2 = BodyMassIndexRecord(
+        time: now,
+        bmi: validBmi,
+        metadata: metadata,
+      );
+
+      final record3 = BodyMassIndexRecord(
+        time: now,
+        bmi: const Number(25.0),
+        metadata: metadata,
+      );
+
+      expect(record1 == record2, isTrue);
+      expect(record1 == record3, isFalse);
+      expect(record1.hashCode == record2.hashCode, isTrue);
+    });
+  });
+}

--- a/packages/health_connector_core/test/src/models/health_records/body_water_mass_record_test.dart
+++ b/packages/health_connector_core/test/src/models/health_records/body_water_mass_record_test.dart
@@ -1,0 +1,90 @@
+import 'package:health_connector_core/health_connector_core.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('BodyWaterMassRecord', () {
+    final now = DateTime(2026, 1, 11);
+    final metadata = Metadata.manualEntry();
+    const validMass = Mass.kilograms(45.0);
+
+    test('can be instantiated with valid parameters', () {
+      final record = BodyWaterMassRecord(
+        time: now,
+        mass: validMass,
+        metadata: metadata,
+      );
+
+      expect(record.time, now);
+      expect(record.mass, validMass);
+      expect(record.metadata, metadata);
+    });
+
+    test('throws ArgumentError when mass is below minMass', () {
+      expect(
+        () => BodyWaterMassRecord(
+          time: now,
+          mass: const Mass.kilograms(0.2),
+          metadata: metadata,
+        ),
+        throwsArgumentError,
+      );
+    });
+
+    test('throws ArgumentError when mass is above maxMass', () {
+      expect(
+        () => BodyWaterMassRecord(
+          time: now,
+          mass: const Mass.kilograms(500.1),
+          metadata: metadata,
+        ),
+        throwsArgumentError,
+      );
+    });
+
+    test('copyWith updates all fields correctly', () {
+      final record = BodyWaterMassRecord(
+        time: now,
+        mass: validMass,
+        metadata: metadata,
+      );
+
+      final newTime = now.add(const Duration(minutes: 5));
+      const newMass = Mass.kilograms(46.0);
+      final newMetadata = Metadata.manualEntry();
+
+      final updated = record.copyWith(
+        time: newTime,
+        mass: newMass,
+        metadata: newMetadata,
+      );
+
+      expect(updated.time, newTime);
+      expect(updated.mass, newMass);
+      expect(updated.metadata, newMetadata);
+    });
+
+    test('equality works correctly', () {
+      final record1 = BodyWaterMassRecord(
+        time: now,
+        mass: validMass,
+        metadata: metadata,
+      );
+
+      final record2 = BodyWaterMassRecord(
+        time: now,
+        mass: validMass,
+        metadata: metadata,
+      );
+
+      final record3 = BodyWaterMassRecord(
+        time: now,
+        mass: const Mass.kilograms(45.1),
+        metadata: metadata,
+      );
+
+      expect(record1 == record2, isTrue);
+      expect(record1 == record3, isFalse);
+      expect(record1.hashCode == record2.hashCode, isTrue);
+    });
+  });
+}

--- a/packages/health_connector_core/test/src/models/health_records/bone_mass_record_test.dart
+++ b/packages/health_connector_core/test/src/models/health_records/bone_mass_record_test.dart
@@ -1,0 +1,90 @@
+import 'package:health_connector_core/health_connector_core.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('BoneMassRecord', () {
+    final now = DateTime(2026, 1, 11);
+    final metadata = Metadata.manualEntry();
+    const validMass = Mass.kilograms(3.0);
+
+    test('can be instantiated with valid parameters', () {
+      final record = BoneMassRecord(
+        time: now,
+        mass: validMass,
+        metadata: metadata,
+      );
+
+      expect(record.time, now);
+      expect(record.mass, validMass);
+      expect(record.metadata, metadata);
+    });
+
+    test('throws ArgumentError when mass is below minMass', () {
+      expect(
+        () => BoneMassRecord(
+          time: now,
+          mass: const Mass.kilograms(0.05),
+          metadata: metadata,
+        ),
+        throwsArgumentError,
+      );
+    });
+
+    test('throws ArgumentError when mass is above maxMass', () {
+      expect(
+        () => BoneMassRecord(
+          time: now,
+          mass: const Mass.kilograms(15.1),
+          metadata: metadata,
+        ),
+        throwsArgumentError,
+      );
+    });
+
+    test('copyWith updates all fields correctly', () {
+      final record = BoneMassRecord(
+        time: now,
+        mass: validMass,
+        metadata: metadata,
+      );
+
+      final newTime = now.add(const Duration(minutes: 5));
+      const newMass = Mass.kilograms(3.5);
+      final newMetadata = Metadata.manualEntry();
+
+      final updated = record.copyWith(
+        time: newTime,
+        mass: newMass,
+        metadata: newMetadata,
+      );
+
+      expect(updated.time, newTime);
+      expect(updated.mass, newMass);
+      expect(updated.metadata, newMetadata);
+    });
+
+    test('equality works correctly', () {
+      final record1 = BoneMassRecord(
+        time: now,
+        mass: validMass,
+        metadata: metadata,
+      );
+
+      final record2 = BoneMassRecord(
+        time: now,
+        mass: validMass,
+        metadata: metadata,
+      );
+
+      final record3 = BoneMassRecord(
+        time: now,
+        mass: const Mass.kilograms(3.1),
+        metadata: metadata,
+      );
+
+      expect(record1 == record2, isTrue);
+      expect(record1 == record3, isFalse);
+      expect(record1.hashCode == record2.hashCode, isTrue);
+    });
+  });
+}

--- a/packages/health_connector_core/test/src/models/health_records/cycling_pedaling_cadence/cycling_pedaling_cadence_record_test.dart
+++ b/packages/health_connector_core/test/src/models/health_records/cycling_pedaling_cadence/cycling_pedaling_cadence_record_test.dart
@@ -1,0 +1,70 @@
+import 'package:health_connector_core/health_connector_core.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('CyclingPedalingCadenceRecord', () {
+    final now = DateTime(2026, 1, 11);
+    final metadata = Metadata.manualEntry();
+    final validCadence = Frequency.perMinute(90);
+
+    test('can be instantiated with valid parameters', () {
+      final record = CyclingPedalingCadenceRecord(
+        id: HealthRecordId.none,
+        time: now,
+        cadence: validCadence,
+        metadata: metadata,
+      );
+
+      expect(record.time, now);
+      expect(record.cadence, equals(validCadence));
+      expect(record.metadata, metadata);
+    });
+
+    test('throws ArgumentError when cadence is below minCadence', () {
+      expect(
+        () => CyclingPedalingCadenceRecord(
+          id: HealthRecordId.none,
+          time: now,
+          cadence: Frequency.perMinute(-1.0),
+          metadata: metadata,
+        ),
+        throwsArgumentError,
+      );
+    });
+
+    test('throws ArgumentError when cadence is above maxCadence', () {
+      expect(
+        () => CyclingPedalingCadenceRecord(
+          id: HealthRecordId.none,
+          time: now,
+          cadence: Frequency.perMinute(201.0),
+          metadata: metadata,
+        ),
+        throwsArgumentError,
+      );
+    });
+
+    test('copyWith updates all fields correctly', () {
+      final record = CyclingPedalingCadenceRecord(
+        id: HealthRecordId.none,
+        time: now,
+        cadence: validCadence,
+        metadata: metadata,
+      );
+
+      final newTime = now.add(const Duration(minutes: 5));
+      final newCadence = Frequency.perMinute(100);
+      final newMetadata = Metadata.manualEntry();
+
+      final updated = record.copyWith(
+        time: newTime,
+        cadence: newCadence,
+        metadata: newMetadata,
+      );
+
+      expect(updated.time, newTime);
+      expect(updated.cadence, newCadence);
+      expect(updated.metadata, newMetadata);
+    });
+  });
+}

--- a/packages/health_connector_core/test/src/models/health_records/cycling_pedaling_cadence/cycling_pedaling_cadence_series_record_test.dart
+++ b/packages/health_connector_core/test/src/models/health_records/cycling_pedaling_cadence/cycling_pedaling_cadence_series_record_test.dart
@@ -1,0 +1,141 @@
+import 'package:health_connector_core/health_connector_core.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('CyclingPedalingCadenceSample', () {
+    final now = DateTime(2026, 1, 11);
+    final validCadence = Frequency.perMinute(90);
+
+    test('can be instantiated with valid parameters', () {
+      final sample = CyclingPedalingCadenceSample(
+        time: now,
+        cadence: validCadence,
+      );
+
+      expect(sample.time, now);
+      expect(sample.cadence, equals(validCadence));
+    });
+
+    test('throws ArgumentError when cadence is below minCadence', () {
+      expect(
+        () => CyclingPedalingCadenceSample(
+          time: now,
+          cadence: Frequency.perMinute(-1.0),
+        ),
+        throwsArgumentError,
+      );
+    });
+
+    test('throws ArgumentError when cadence is above maxCadence', () {
+      expect(
+        () => CyclingPedalingCadenceSample(
+          time: now,
+          cadence: Frequency.perMinute(201.0),
+        ),
+        throwsArgumentError,
+      );
+    });
+  });
+
+  group('CyclingPedalingCadenceSeriesRecord', () {
+    final now = DateTime(2026, 1, 11);
+    final startTime = now.subtract(const Duration(minutes: 10));
+    final endTime = now;
+    final metadata = Metadata.manualEntry();
+
+    final samples = [
+      CyclingPedalingCadenceSample(
+        time: startTime,
+        cadence: Frequency.perMinute(60.0),
+      ),
+      CyclingPedalingCadenceSample(
+        time: startTime.add(const Duration(minutes: 5)),
+        cadence: Frequency.perMinute(80.0),
+      ),
+      CyclingPedalingCadenceSample(
+        time: endTime,
+        cadence: Frequency.perMinute(100.0),
+      ),
+    ];
+
+    test('can be instantiated with valid parameters', () {
+      final record = CyclingPedalingCadenceSeriesRecord(
+        startTime: startTime,
+        endTime: endTime,
+        metadata: metadata,
+        samples: samples,
+      );
+
+      expect(record.samples, samples);
+      expect(record.samplesCount, 3);
+      expect(record.metadata, metadata);
+    });
+
+    test('avgCadence calculates correctly', () {
+      final record = CyclingPedalingCadenceSeriesRecord(
+        startTime: startTime,
+        endTime: endTime,
+        metadata: metadata,
+        samples: samples,
+      );
+
+      // (60 + 80 + 100) / 3 = 80
+      expect(record.avgCadence.inPerMinute, closeTo(80.0, 0.01));
+    });
+
+    test('avgCadence returns zero when samples is empty', () {
+      final record = CyclingPedalingCadenceSeriesRecord(
+        startTime: startTime,
+        endTime: endTime,
+        metadata: metadata,
+        samples: const [],
+      );
+
+      expect(record.avgCadence, Frequency.zero);
+    });
+
+    test('minCadence calculates correctly', () {
+      final record = CyclingPedalingCadenceSeriesRecord(
+        startTime: startTime,
+        endTime: endTime,
+        metadata: metadata,
+        samples: samples,
+      );
+
+      expect(record.minCadence.inPerMinute, closeTo(60.0, 0.01));
+    });
+
+    test('minCadence returns zero when samples is empty', () {
+      final record = CyclingPedalingCadenceSeriesRecord(
+        startTime: startTime,
+        endTime: endTime,
+        metadata: metadata,
+        samples: const [],
+      );
+
+      expect(record.minCadence, Frequency.zero);
+    });
+
+    test('maxCadence calculates correctly', () {
+      final record = CyclingPedalingCadenceSeriesRecord(
+        startTime: startTime,
+        endTime: endTime,
+        metadata: metadata,
+        samples: samples,
+      );
+
+      expect(record.maxCadence.inPerMinute, closeTo(100.0, 0.01));
+    });
+
+    test('maxCadence returns zero when samples is empty', () {
+      final record = CyclingPedalingCadenceSeriesRecord(
+        startTime: startTime,
+        endTime: endTime,
+        metadata: metadata,
+        samples: const [],
+      );
+
+      expect(record.maxCadence, Frequency.zero);
+    });
+  });
+}

--- a/packages/health_connector_core/test/src/models/health_records/distance/cross_country_skiing_distance_record_test.dart
+++ b/packages/health_connector_core/test/src/models/health_records/distance/cross_country_skiing_distance_record_test.dart
@@ -1,0 +1,40 @@
+import 'package:health_connector_core/health_connector_core.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('CrossCountrySkiingDistanceRecord', () {
+    final now = DateTime(2026, 1, 11);
+    final startTime = now.subtract(const Duration(minutes: 90));
+    final endTime = now;
+    final metadata = Metadata.manualEntry();
+    const validValue = Length.meters(10000);
+
+    test('can be instantiated with valid parameters', () {
+      final record = CrossCountrySkiingDistanceRecord(
+        startTime: startTime,
+        endTime: endTime,
+        distance: validValue,
+        metadata: metadata,
+      );
+
+      expect(record.startTime, startTime);
+      expect(record.endTime, endTime);
+      expect(record.distance, equals(validValue));
+      expect(record.metadata, metadata);
+    });
+
+    test('copyWith updates fields correctly', () {
+      final record = CrossCountrySkiingDistanceRecord(
+        startTime: startTime,
+        endTime: endTime,
+        distance: validValue,
+        metadata: metadata,
+      );
+
+      const newDist = Length.meters(15000.0);
+      final updated = record.copyWith(distance: newDist);
+
+      expect(updated.distance, newDist);
+    });
+  });
+}

--- a/packages/health_connector_core/test/src/models/health_records/distance/cycling_distance_record_test.dart
+++ b/packages/health_connector_core/test/src/models/health_records/distance/cycling_distance_record_test.dart
@@ -1,0 +1,40 @@
+import 'package:health_connector_core/health_connector_core.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('CyclingDistanceRecord', () {
+    final now = DateTime(2026, 1, 11);
+    final startTime = now.subtract(const Duration(minutes: 60));
+    final endTime = now;
+    final metadata = Metadata.manualEntry();
+    const validValue = Length.meters(25000);
+
+    test('can be instantiated with valid parameters', () {
+      final record = CyclingDistanceRecord(
+        startTime: startTime,
+        endTime: endTime,
+        distance: validValue,
+        metadata: metadata,
+      );
+
+      expect(record.startTime, startTime);
+      expect(record.endTime, endTime);
+      expect(record.distance, equals(validValue));
+      expect(record.metadata, metadata);
+    });
+
+    test('copyWith updates fields correctly', () {
+      final record = CyclingDistanceRecord(
+        startTime: startTime,
+        endTime: endTime,
+        distance: validValue,
+        metadata: metadata,
+      );
+
+      const newDist = Length.meters(30000.0);
+      final updated = record.copyWith(distance: newDist);
+
+      expect(updated.distance, newDist);
+    });
+  });
+}

--- a/packages/health_connector_core/test/src/models/health_records/distance/distance_record_test.dart
+++ b/packages/health_connector_core/test/src/models/health_records/distance/distance_record_test.dart
@@ -1,0 +1,88 @@
+import 'package:health_connector_core/health_connector_core.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('DistanceRecord', () {
+    final now = DateTime(2026, 1, 11);
+    final startTime = now.subtract(const Duration(minutes: 10));
+    final endTime = now;
+    final metadata = Metadata.manualEntry();
+    const validValue = Length.meters(1000);
+
+    test('can be instantiated with valid parameters', () {
+      final record = DistanceRecord(
+        startTime: startTime,
+        endTime: endTime,
+        distance: validValue,
+        metadata: metadata,
+      );
+
+      expect(record.startTime, startTime);
+      expect(record.endTime, endTime);
+      expect(record.distance, equals(validValue));
+      expect(record.metadata, metadata);
+    });
+
+    test('throws ArgumentError when distance is below minDistance', () {
+      expect(
+        () => DistanceRecord(
+          startTime: startTime,
+          endTime: endTime,
+          distance: const Length.meters(-1.0),
+          metadata: metadata,
+        ),
+        throwsArgumentError,
+      );
+    });
+
+    test('throws ArgumentError when distance is above maxDistance', () {
+      expect(
+        () => DistanceRecord(
+          startTime: startTime,
+          endTime: endTime,
+          distance: const Length.kilometers(1001.0),
+          metadata: metadata,
+        ),
+        throwsArgumentError,
+      );
+    });
+
+    test('throws ArgumentError when endTime is not after startTime', () {
+      expect(
+        () => DistanceRecord(
+          startTime: endTime,
+          endTime: startTime,
+          distance: validValue,
+          metadata: metadata,
+        ),
+        throwsArgumentError,
+      );
+    });
+
+    test('copyWith updates all fields correctly', () {
+      final record = DistanceRecord(
+        startTime: startTime,
+        endTime: endTime,
+        distance: validValue,
+        metadata: metadata,
+      );
+
+      final newStartTime = startTime.subtract(const Duration(minutes: 5));
+      final newEndTime = endTime.add(const Duration(minutes: 5));
+      const newDist = Length.meters(2000.0);
+      final newMetadata = Metadata.manualEntry();
+
+      final updated = record.copyWith(
+        startTime: newStartTime,
+        endTime: newEndTime,
+        distance: newDist,
+        metadata: newMetadata,
+      );
+
+      expect(updated.startTime, newStartTime);
+      expect(updated.endTime, newEndTime);
+      expect(updated.distance, newDist);
+      expect(updated.metadata, newMetadata);
+    });
+  });
+}

--- a/packages/health_connector_core/test/src/models/health_records/distance/downhill_snow_sports_distance_record_test.dart
+++ b/packages/health_connector_core/test/src/models/health_records/distance/downhill_snow_sports_distance_record_test.dart
@@ -1,0 +1,40 @@
+import 'package:health_connector_core/health_connector_core.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('DownhillSnowSportsDistanceRecord', () {
+    final now = DateTime(2026, 1, 11);
+    final startTime = now.subtract(const Duration(hours: 2));
+    final endTime = now;
+    final metadata = Metadata.manualEntry();
+    const validValue = Length.meters(20000);
+
+    test('can be instantiated with valid parameters', () {
+      final record = DownhillSnowSportsDistanceRecord(
+        startTime: startTime,
+        endTime: endTime,
+        distance: validValue,
+        metadata: metadata,
+      );
+
+      expect(record.startTime, startTime);
+      expect(record.endTime, endTime);
+      expect(record.distance, equals(validValue));
+      expect(record.metadata, metadata);
+    });
+
+    test('copyWith updates fields correctly', () {
+      final record = DownhillSnowSportsDistanceRecord(
+        startTime: startTime,
+        endTime: endTime,
+        distance: validValue,
+        metadata: metadata,
+      );
+
+      const newDist = Length.meters(25000.0);
+      final updated = record.copyWith(distance: newDist);
+
+      expect(updated.distance, newDist);
+    });
+  });
+}

--- a/packages/health_connector_core/test/src/models/health_records/distance/paddle_sports_distance_record_test.dart
+++ b/packages/health_connector_core/test/src/models/health_records/distance/paddle_sports_distance_record_test.dart
@@ -1,0 +1,40 @@
+import 'package:health_connector_core/health_connector_core.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('PaddleSportsDistanceRecord', () {
+    final now = DateTime(2026, 1, 11);
+    final startTime = now.subtract(const Duration(minutes: 45));
+    final endTime = now;
+    final metadata = Metadata.manualEntry();
+    const validValue = Length.meters(3000);
+
+    test('can be instantiated with valid parameters', () {
+      final record = PaddleSportsDistanceRecord(
+        startTime: startTime,
+        endTime: endTime,
+        distance: validValue,
+        metadata: metadata,
+      );
+
+      expect(record.startTime, startTime);
+      expect(record.endTime, endTime);
+      expect(record.distance, equals(validValue));
+      expect(record.metadata, metadata);
+    });
+
+    test('copyWith updates fields correctly', () {
+      final record = PaddleSportsDistanceRecord(
+        startTime: startTime,
+        endTime: endTime,
+        distance: validValue,
+        metadata: metadata,
+      );
+
+      const newDist = Length.meters(4000.0);
+      final updated = record.copyWith(distance: newDist);
+
+      expect(updated.distance, newDist);
+    });
+  });
+}

--- a/packages/health_connector_core/test/src/models/health_records/distance/rowing_distance_record_test.dart
+++ b/packages/health_connector_core/test/src/models/health_records/distance/rowing_distance_record_test.dart
@@ -1,0 +1,40 @@
+import 'package:health_connector_core/health_connector_core.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('RowingDistanceRecord', () {
+    final now = DateTime(2026, 1, 11);
+    final startTime = now.subtract(const Duration(minutes: 30));
+    final endTime = now;
+    final metadata = Metadata.manualEntry();
+    const validValue = Length.meters(5000);
+
+    test('can be instantiated with valid parameters', () {
+      final record = RowingDistanceRecord(
+        startTime: startTime,
+        endTime: endTime,
+        distance: validValue,
+        metadata: metadata,
+      );
+
+      expect(record.startTime, startTime);
+      expect(record.endTime, endTime);
+      expect(record.distance, equals(validValue));
+      expect(record.metadata, metadata);
+    });
+
+    test('copyWith updates fields correctly', () {
+      final record = RowingDistanceRecord(
+        startTime: startTime,
+        endTime: endTime,
+        distance: validValue,
+        metadata: metadata,
+      );
+
+      const newDist = Length.meters(6000.0);
+      final updated = record.copyWith(distance: newDist);
+
+      expect(updated.distance, newDist);
+    });
+  });
+}

--- a/packages/health_connector_core/test/src/models/health_records/distance/six_minute_walk_test_distance_record_test.dart
+++ b/packages/health_connector_core/test/src/models/health_records/distance/six_minute_walk_test_distance_record_test.dart
@@ -1,0 +1,40 @@
+import 'package:health_connector_core/health_connector_core.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('SixMinuteWalkTestDistanceRecord', () {
+    final now = DateTime(2026, 1, 11);
+    final startTime = now.subtract(const Duration(minutes: 6));
+    final endTime = now;
+    final metadata = Metadata.manualEntry();
+    const validValue = Length.meters(500);
+
+    test('can be instantiated with valid parameters', () {
+      final record = SixMinuteWalkTestDistanceRecord(
+        startTime: startTime,
+        endTime: endTime,
+        distance: validValue,
+        metadata: metadata,
+      );
+
+      expect(record.startTime, startTime);
+      expect(record.endTime, endTime);
+      expect(record.distance, equals(validValue));
+      expect(record.metadata, metadata);
+    });
+
+    test('copyWith updates fields correctly', () {
+      final record = SixMinuteWalkTestDistanceRecord(
+        startTime: startTime,
+        endTime: endTime,
+        distance: validValue,
+        metadata: metadata,
+      );
+
+      const newDist = Length.meters(600.0);
+      final updated = record.copyWith(distance: newDist);
+
+      expect(updated.distance, newDist);
+    });
+  });
+}

--- a/packages/health_connector_core/test/src/models/health_records/distance/skating_sports_distance_record_test.dart
+++ b/packages/health_connector_core/test/src/models/health_records/distance/skating_sports_distance_record_test.dart
@@ -1,0 +1,40 @@
+import 'package:health_connector_core/health_connector_core.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('SkatingSportsDistanceRecord', () {
+    final now = DateTime(2026, 1, 11);
+    final startTime = now.subtract(const Duration(minutes: 60));
+    final endTime = now;
+    final metadata = Metadata.manualEntry();
+    const validValue = Length.meters(10000);
+
+    test('can be instantiated with valid parameters', () {
+      final record = SkatingSportsDistanceRecord(
+        startTime: startTime,
+        endTime: endTime,
+        distance: validValue,
+        metadata: metadata,
+      );
+
+      expect(record.startTime, startTime);
+      expect(record.endTime, endTime);
+      expect(record.distance, equals(validValue));
+      expect(record.metadata, metadata);
+    });
+
+    test('copyWith updates fields correctly', () {
+      final record = SkatingSportsDistanceRecord(
+        startTime: startTime,
+        endTime: endTime,
+        distance: validValue,
+        metadata: metadata,
+      );
+
+      const newDist = Length.meters(12000.0);
+      final updated = record.copyWith(distance: newDist);
+
+      expect(updated.distance, newDist);
+    });
+  });
+}

--- a/packages/health_connector_core/test/src/models/health_records/distance/swimming_distance_record_test.dart
+++ b/packages/health_connector_core/test/src/models/health_records/distance/swimming_distance_record_test.dart
@@ -1,0 +1,40 @@
+import 'package:health_connector_core/health_connector_core.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('SwimmingDistanceRecord', () {
+    final now = DateTime(2026, 1, 11);
+    final startTime = now.subtract(const Duration(minutes: 45));
+    final endTime = now;
+    final metadata = Metadata.manualEntry();
+    const validValue = Length.meters(1500);
+
+    test('can be instantiated with valid parameters', () {
+      final record = SwimmingDistanceRecord(
+        startTime: startTime,
+        endTime: endTime,
+        distance: validValue,
+        metadata: metadata,
+      );
+
+      expect(record.startTime, startTime);
+      expect(record.endTime, endTime);
+      expect(record.distance, equals(validValue));
+      expect(record.metadata, metadata);
+    });
+
+    test('copyWith updates fields correctly', () {
+      final record = SwimmingDistanceRecord(
+        startTime: startTime,
+        endTime: endTime,
+        distance: validValue,
+        metadata: metadata,
+      );
+
+      const newDist = Length.meters(2000.0);
+      final updated = record.copyWith(distance: newDist);
+
+      expect(updated.distance, newDist);
+    });
+  });
+}

--- a/packages/health_connector_core/test/src/models/health_records/distance/walking_running_distance_record_test.dart
+++ b/packages/health_connector_core/test/src/models/health_records/distance/walking_running_distance_record_test.dart
@@ -1,0 +1,40 @@
+import 'package:health_connector_core/health_connector_core.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('WalkingRunningDistanceRecord', () {
+    final now = DateTime(2026, 1, 11);
+    final startTime = now.subtract(const Duration(minutes: 30));
+    final endTime = now;
+    final metadata = Metadata.manualEntry();
+    const validValue = Length.meters(5000);
+
+    test('can be instantiated with valid parameters', () {
+      final record = WalkingRunningDistanceRecord(
+        startTime: startTime,
+        endTime: endTime,
+        distance: validValue,
+        metadata: metadata,
+      );
+
+      expect(record.startTime, startTime);
+      expect(record.endTime, endTime);
+      expect(record.distance, equals(validValue));
+      expect(record.metadata, metadata);
+    });
+
+    test('copyWith updates fields correctly', () {
+      final record = WalkingRunningDistanceRecord(
+        startTime: startTime,
+        endTime: endTime,
+        distance: validValue,
+        metadata: metadata,
+      );
+
+      const newDist = Length.meters(6000.0);
+      final updated = record.copyWith(distance: newDist);
+
+      expect(updated.distance, newDist);
+    });
+  });
+}

--- a/packages/health_connector_core/test/src/models/health_records/distance/wheelchair_distance_record_test.dart
+++ b/packages/health_connector_core/test/src/models/health_records/distance/wheelchair_distance_record_test.dart
@@ -1,0 +1,40 @@
+import 'package:health_connector_core/health_connector_core.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('WheelchairDistanceRecord', () {
+    final now = DateTime(2026, 1, 11);
+    final startTime = now.subtract(const Duration(minutes: 40));
+    final endTime = now;
+    final metadata = Metadata.manualEntry();
+    const validValue = Length.meters(3000);
+
+    test('can be instantiated with valid parameters', () {
+      final record = WheelchairDistanceRecord(
+        startTime: startTime,
+        endTime: endTime,
+        distance: validValue,
+        metadata: metadata,
+      );
+
+      expect(record.startTime, startTime);
+      expect(record.endTime, endTime);
+      expect(record.distance, equals(validValue));
+      expect(record.metadata, metadata);
+    });
+
+    test('copyWith updates fields correctly', () {
+      final record = WheelchairDistanceRecord(
+        startTime: startTime,
+        endTime: endTime,
+        distance: validValue,
+        metadata: metadata,
+      );
+
+      const newDist = Length.meters(4000.0);
+      final updated = record.copyWith(distance: newDist);
+
+      expect(updated.distance, newDist);
+    });
+  });
+}

--- a/packages/health_connector_core/test/src/models/health_records/energy_burned/active_energy_burned_record_test.dart
+++ b/packages/health_connector_core/test/src/models/health_records/energy_burned/active_energy_burned_record_test.dart
@@ -1,0 +1,103 @@
+import 'package:health_connector_core/health_connector_core.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('ActiveEnergyBurnedRecord', () {
+    final now = DateTime(2026, 1, 11);
+    final startTime = now.subtract(const Duration(minutes: 30));
+    final endTime = now;
+    final metadata = Metadata.manualEntry();
+    const validEnergy = Energy.kilocalories(300);
+
+    test('can be instantiated with valid parameters', () {
+      final record = ActiveEnergyBurnedRecord(
+        startTime: startTime,
+        endTime: endTime,
+        energy: validEnergy,
+        metadata: metadata,
+      );
+
+      expect(record.startTime, startTime);
+      expect(record.endTime, endTime);
+      expect(record.energy, equals(validEnergy));
+      expect(record.metadata, metadata);
+    });
+
+    test('throws ArgumentError when energy is below minEnergy', () {
+      expect(
+        () => ActiveEnergyBurnedRecord(
+          startTime: startTime,
+          endTime: endTime,
+          energy: const Energy.kilocalories(-0.1),
+          metadata: metadata,
+        ),
+        throwsArgumentError,
+      );
+    });
+
+    test('throws ArgumentError when energy is above maxEnergy', () {
+      expect(
+        () => ActiveEnergyBurnedRecord(
+          startTime: startTime,
+          endTime: endTime,
+          energy: const Energy.kilocalories(15001.0),
+          metadata: metadata,
+        ),
+        throwsArgumentError,
+      );
+    });
+
+    test('copyWith updates all fields correctly', () {
+      final record = ActiveEnergyBurnedRecord(
+        startTime: startTime,
+        endTime: endTime,
+        energy: validEnergy,
+        metadata: metadata,
+      );
+
+      final newStartTime = startTime.subtract(const Duration(minutes: 10));
+      final newEndTime = endTime.add(const Duration(minutes: 10));
+      const newEnergy = Energy.kilocalories(350);
+      final newMetadata = Metadata.manualEntry();
+
+      final updatedRecord = record.copyWith(
+        startTime: newStartTime,
+        endTime: newEndTime,
+        energy: newEnergy,
+        metadata: newMetadata,
+      );
+
+      expect(updatedRecord.startTime, newStartTime);
+      expect(updatedRecord.endTime, newEndTime);
+      expect(updatedRecord.energy, newEnergy);
+      expect(updatedRecord.metadata, newMetadata);
+    });
+
+    test('equality works correctly', () {
+      final record1 = ActiveEnergyBurnedRecord(
+        startTime: startTime,
+        endTime: endTime,
+        energy: validEnergy,
+        metadata: metadata,
+      );
+
+      final record2 = ActiveEnergyBurnedRecord(
+        startTime: startTime,
+        endTime: endTime,
+        energy: validEnergy,
+        metadata: metadata,
+      );
+
+      final record3 = ActiveEnergyBurnedRecord(
+        startTime: startTime,
+        endTime: endTime,
+        energy: const Energy.kilocalories(350),
+        metadata: metadata,
+      );
+
+      expect(record1 == record2, isTrue);
+      expect(record1 == record3, isFalse);
+      expect(record1.hashCode == record2.hashCode, isTrue);
+    });
+  });
+}

--- a/packages/health_connector_core/test/src/models/health_records/energy_burned/basal_energy_burned_record_test.dart
+++ b/packages/health_connector_core/test/src/models/health_records/energy_burned/basal_energy_burned_record_test.dart
@@ -1,0 +1,100 @@
+import 'package:health_connector_core/health_connector_core.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('BasalEnergyBurnedRecord', () {
+    final now = DateTime(2026, 1, 11);
+    final startTime = now.subtract(const Duration(minutes: 30));
+    final endTime = now;
+    final metadata = Metadata.manualEntry();
+    const validEnergy = Energy.kilocalories(60);
+
+    test('can be instantiated with valid parameters', () {
+      final record = BasalEnergyBurnedRecord(
+        startTime: startTime,
+        endTime: endTime,
+        energy: validEnergy,
+        metadata: metadata,
+      );
+
+      expect(record.startTime, startTime);
+      expect(record.endTime, endTime);
+      expect(record.energy, equals(validEnergy));
+      expect(record.metadata, metadata);
+    });
+
+    test('throws ArgumentError when energy is below minEnergy', () {
+      expect(
+        () => BasalEnergyBurnedRecord(
+          startTime: startTime,
+          endTime: endTime,
+          energy: const Energy.kilocalories(-0.1),
+          metadata: metadata,
+        ),
+        throwsArgumentError,
+      );
+    });
+
+    test('throws ArgumentError when energy is above maxEnergy', () {
+      expect(
+        () => BasalEnergyBurnedRecord(
+          startTime: startTime,
+          endTime: endTime,
+          energy: const Energy.kilocalories(5001.0),
+          metadata: metadata,
+        ),
+        throwsArgumentError,
+      );
+    });
+
+    test('copyWith updates all fields correctly', () {
+      final record = BasalEnergyBurnedRecord(
+        startTime: startTime,
+        endTime: endTime,
+        energy: validEnergy,
+        metadata: metadata,
+      );
+
+      final newStartTime = startTime.subtract(const Duration(minutes: 10));
+      const newEnergy = Energy.kilocalories(70);
+      final newMetadata = Metadata.manualEntry();
+
+      final updatedRecord = record.copyWith(
+        startTime: newStartTime,
+        energy: newEnergy,
+        metadata: newMetadata,
+      );
+
+      expect(updatedRecord.startTime, newStartTime);
+      expect(updatedRecord.energy, newEnergy);
+      expect(updatedRecord.metadata, newMetadata);
+    });
+
+    test('equality works correctly', () {
+      final record1 = BasalEnergyBurnedRecord(
+        startTime: startTime,
+        endTime: endTime,
+        energy: validEnergy,
+        metadata: metadata,
+      );
+
+      final record2 = BasalEnergyBurnedRecord(
+        startTime: startTime,
+        endTime: endTime,
+        energy: validEnergy,
+        metadata: metadata,
+      );
+
+      final record3 = BasalEnergyBurnedRecord(
+        startTime: startTime,
+        endTime: endTime,
+        energy: const Energy.kilocalories(70),
+        metadata: metadata,
+      );
+
+      expect(record1 == record2, isTrue);
+      expect(record1 == record3, isFalse);
+      expect(record1.hashCode == record2.hashCode, isTrue);
+    });
+  });
+}

--- a/packages/health_connector_core/test/src/models/health_records/energy_burned/total_energy_burned_record_test.dart
+++ b/packages/health_connector_core/test/src/models/health_records/energy_burned/total_energy_burned_record_test.dart
@@ -1,0 +1,100 @@
+import 'package:health_connector_core/health_connector_core.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('TotalEnergyBurnedRecord', () {
+    final now = DateTime(2026, 1, 11);
+    final startTime = now.subtract(const Duration(minutes: 30));
+    final endTime = now;
+    final metadata = Metadata.manualEntry();
+    const validEnergy = Energy.kilocalories(450);
+
+    test('can be instantiated with valid parameters', () {
+      final record = TotalEnergyBurnedRecord(
+        startTime: startTime,
+        endTime: endTime,
+        energy: validEnergy,
+        metadata: metadata,
+      );
+
+      expect(record.startTime, startTime);
+      expect(record.endTime, endTime);
+      expect(record.energy, equals(validEnergy));
+      expect(record.metadata, metadata);
+    });
+
+    test('throws ArgumentError when energy is below minEnergy', () {
+      expect(
+        () => TotalEnergyBurnedRecord(
+          startTime: startTime,
+          endTime: endTime,
+          energy: const Energy.kilocalories(-0.1),
+          metadata: metadata,
+        ),
+        throwsArgumentError,
+      );
+    });
+
+    test('throws ArgumentError when energy is above maxEnergy', () {
+      expect(
+        () => TotalEnergyBurnedRecord(
+          startTime: startTime,
+          endTime: endTime,
+          energy: const Energy.kilocalories(20001.0),
+          metadata: metadata,
+        ),
+        throwsArgumentError,
+      );
+    });
+
+    test('copyWith updates all fields correctly', () {
+      final record = TotalEnergyBurnedRecord(
+        startTime: startTime,
+        endTime: endTime,
+        energy: validEnergy,
+        metadata: metadata,
+      );
+
+      final newStartTime = startTime.subtract(const Duration(minutes: 10));
+      const newEnergy = Energy.kilocalories(500);
+      final newMetadata = Metadata.manualEntry();
+
+      final updatedRecord = record.copyWith(
+        startTime: newStartTime,
+        energy: newEnergy,
+        metadata: newMetadata,
+      );
+
+      expect(updatedRecord.startTime, newStartTime);
+      expect(updatedRecord.energy, newEnergy);
+      expect(updatedRecord.metadata, newMetadata);
+    });
+
+    test('equality works correctly', () {
+      final record1 = TotalEnergyBurnedRecord(
+        startTime: startTime,
+        endTime: endTime,
+        energy: validEnergy,
+        metadata: metadata,
+      );
+
+      final record2 = TotalEnergyBurnedRecord(
+        startTime: startTime,
+        endTime: endTime,
+        energy: validEnergy,
+        metadata: metadata,
+      );
+
+      final record3 = TotalEnergyBurnedRecord(
+        startTime: startTime,
+        endTime: endTime,
+        energy: const Energy.kilocalories(500),
+        metadata: metadata,
+      );
+
+      expect(record1 == record2, isTrue);
+      expect(record1 == record3, isFalse);
+      expect(record1.hashCode == record2.hashCode, isTrue);
+    });
+  });
+}

--- a/packages/health_connector_core/test/src/models/health_records/exercise/exercise_session_record_test.dart
+++ b/packages/health_connector_core/test/src/models/health_records/exercise/exercise_session_record_test.dart
@@ -1,0 +1,111 @@
+import 'package:health_connector_core/health_connector_core.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('ExerciseSessionRecord', () {
+    final now = DateTime(2026, 1, 11);
+    final startTime = now.subtract(const Duration(hours: 1));
+    final endTime = now;
+    final metadata = Metadata.manualEntry();
+    const exerciseType = ExerciseType.running;
+    const title = 'Morning Run';
+    const notes = 'Good pace';
+
+    test('can be instantiated with valid parameters', () {
+      final record = ExerciseSessionRecord(
+        startTime: startTime,
+        endTime: endTime,
+        exerciseType: exerciseType,
+        metadata: metadata,
+        title: title,
+        notes: notes,
+      );
+
+      expect(record.startTime, startTime);
+      expect(record.endTime, endTime);
+      expect(record.exerciseType, exerciseType);
+      expect(record.metadata, metadata);
+      expect(record.title, title);
+      expect(record.notes, notes);
+    });
+
+    test('throws ArgumentError when startTime is after endTime', () {
+      expect(
+        () => ExerciseSessionRecord(
+          startTime: endTime,
+          endTime: startTime,
+          exerciseType: exerciseType,
+          metadata: metadata,
+        ),
+        throwsArgumentError,
+      );
+    });
+
+    test('copyWith updates all fields correctly', () {
+      final record = ExerciseSessionRecord(
+        startTime: startTime,
+        endTime: endTime,
+        exerciseType: exerciseType,
+        metadata: metadata,
+        title: title,
+        notes: notes,
+      );
+
+      final newStartTime = startTime.subtract(const Duration(minutes: 10));
+      final newEndTime = endTime.add(const Duration(minutes: 10));
+      const newType = ExerciseType.cycling;
+      const newTitle = 'Evening Ride';
+      const newNotes = 'Windy';
+      final newMetadata = Metadata.manualEntry();
+
+      final updatedRecord = record.copyWith(
+        startTime: newStartTime,
+        endTime: newEndTime,
+        exerciseType: newType,
+        title: newTitle,
+        notes: newNotes,
+        metadata: newMetadata,
+      );
+
+      expect(updatedRecord.startTime, newStartTime);
+      expect(updatedRecord.endTime, newEndTime);
+      expect(updatedRecord.exerciseType, newType);
+      expect(updatedRecord.title, newTitle);
+      expect(updatedRecord.notes, newNotes);
+      expect(updatedRecord.metadata, newMetadata);
+    });
+
+    test('equality works correctly', () {
+      final record1 = ExerciseSessionRecord(
+        startTime: startTime,
+        endTime: endTime,
+        exerciseType: exerciseType,
+        metadata: metadata,
+        title: title,
+        notes: notes,
+      );
+
+      final record2 = ExerciseSessionRecord(
+        startTime: startTime,
+        endTime: endTime,
+        exerciseType: exerciseType,
+        metadata: metadata,
+        title: title,
+        notes: notes,
+      );
+
+      final record3 = ExerciseSessionRecord(
+        startTime: startTime,
+        endTime: endTime,
+        exerciseType: ExerciseType.cycling,
+        metadata: metadata,
+        title: title,
+        notes: notes,
+      );
+
+      expect(record1 == record2, isTrue);
+      expect(record1 == record3, isFalse);
+      expect(record1.hashCode == record2.hashCode, isTrue);
+    });
+  });
+}

--- a/packages/health_connector_core/test/src/models/health_records/floors_climbed_record_test.dart
+++ b/packages/health_connector_core/test/src/models/health_records/floors_climbed_record_test.dart
@@ -1,0 +1,101 @@
+import 'package:health_connector_core/health_connector_core.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('FloorsClimbedRecord', () {
+    final now = DateTime(2026, 1, 11);
+    final startTime = now.subtract(const Duration(hours: 1));
+    final endTime = now;
+    final metadata = Metadata.manualEntry();
+    const validCount = Number(5);
+
+    test('can be instantiated with valid parameters', () {
+      final record = FloorsClimbedRecord(
+        startTime: startTime,
+        endTime: endTime,
+        count: validCount,
+        metadata: metadata,
+      );
+
+      expect(record.startTime, startTime);
+      expect(record.endTime, endTime);
+      expect(record.count, equals(validCount));
+      expect(record.metadata, metadata);
+    });
+
+    test('throws ArgumentError when count is negative', () {
+      expect(
+        () => FloorsClimbedRecord(
+          startTime: startTime,
+          endTime: endTime,
+          count: const Number(-1),
+          metadata: metadata,
+        ),
+        throwsArgumentError,
+      );
+    });
+
+    test('throws ArgumentError when count is above maxFloors', () {
+      expect(
+        () => FloorsClimbedRecord(
+          startTime: startTime,
+          endTime: endTime,
+          count: const Number(1001),
+          metadata: metadata,
+        ),
+        throwsArgumentError,
+      );
+    });
+
+    test('copyWith updates all fields correctly', () {
+      final record = FloorsClimbedRecord(
+        startTime: startTime,
+        endTime: endTime,
+        count: validCount,
+        metadata: metadata,
+      );
+
+      final newStartTime = startTime.subtract(const Duration(minutes: 10));
+      const newCount = Number(10);
+      final newMetadata = Metadata.manualEntry();
+
+      final updatedRecord = record.copyWith(
+        startTime: newStartTime,
+        count: newCount,
+        metadata: newMetadata,
+      );
+
+      expect(updatedRecord.startTime, newStartTime);
+      expect(updatedRecord.count, newCount);
+      expect(updatedRecord.metadata, newMetadata);
+      expect(updatedRecord.endTime, endTime);
+    });
+
+    test('equality works correctly', () {
+      final record1 = FloorsClimbedRecord(
+        startTime: startTime,
+        endTime: endTime,
+        count: validCount,
+        metadata: metadata,
+      );
+
+      final record2 = FloorsClimbedRecord(
+        startTime: startTime,
+        endTime: endTime,
+        count: validCount,
+        metadata: metadata,
+      );
+
+      final record3 = FloorsClimbedRecord(
+        startTime: startTime,
+        endTime: endTime,
+        count: const Number(10),
+        metadata: metadata,
+      );
+
+      expect(record1 == record2, isTrue);
+      expect(record1 == record3, isFalse);
+      expect(record1.hashCode == record2.hashCode, isTrue);
+    });
+  });
+}

--- a/packages/health_connector_core/test/src/models/health_records/heart_rate/heart_rate_record_test.dart
+++ b/packages/health_connector_core/test/src/models/health_records/heart_rate/heart_rate_record_test.dart
@@ -1,0 +1,113 @@
+import 'package:health_connector_core/health_connector_core.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('HeartRateRecord', () {
+    final now = DateTime(2026, 1, 11);
+    final metadata = Metadata.manualEntry();
+    final validValue = Frequency.perMinute(72.0);
+    final minValue = Frequency.perMinute(1.0); // Updated from 27.0
+    final maxValue = Frequency.perMinute(300.0); // Updated from 240.0
+
+    test('can be instantiated with valid parameters', () {
+      final record = HeartRateRecord(
+        id: HealthRecordId.none,
+        time: now,
+        rate: validValue,
+        metadata: metadata,
+      );
+
+      expect(record.time, now);
+      expect(record.rate, equals(validValue));
+      expect(record.metadata, metadata);
+    });
+
+    test('throws ArgumentError when rate is below minRate', () {
+      expect(
+        () => HeartRateRecord(
+          id: HealthRecordId.none,
+          time: now,
+          rate: Frequency.perMinute(0.5), // Below 1.0
+          metadata: metadata,
+        ),
+        throwsArgumentError,
+      );
+    });
+
+    test('accepts minimum valid rate', () {
+      final record = HeartRateRecord(
+        id: HealthRecordId.none,
+        time: now,
+        rate: minValue, // 1.0 bpm
+        metadata: metadata,
+      );
+
+      expect(record.rate, equals(minValue));
+    });
+
+    test('accepts maximum valid rate', () {
+      final record = HeartRateRecord(
+        id: HealthRecordId.none,
+        time: now,
+        rate: maxValue, // 300.0 bpm
+        metadata: metadata,
+      );
+
+      expect(record.rate, equals(maxValue));
+    });
+
+    test('throws ArgumentError when rate is above maxRate', () {
+      expect(
+        () => HeartRateRecord(
+          id: HealthRecordId.none,
+          time: now,
+          rate: Frequency.perMinute(maxValue.inPerMinute + 1),
+          metadata: metadata,
+        ),
+        throwsArgumentError,
+      );
+    });
+
+    test('copyWith updates fields correctly', () {
+      final record = HeartRateRecord(
+        id: HealthRecordId.none,
+        time: now,
+        rate: validValue,
+        metadata: metadata,
+      );
+
+      final newTime = now.subtract(const Duration(minutes: 10));
+      final newRate = Frequency.perMinute(validValue.inPerMinute + 10);
+      final newMetadata = Metadata.manualEntry();
+
+      final updatedRecord = record.copyWith(
+        time: newTime,
+        rate: newRate,
+        metadata: newMetadata,
+      );
+
+      expect(updatedRecord.time, newTime);
+      expect(updatedRecord.rate, newRate);
+      expect(updatedRecord.metadata, newMetadata);
+    });
+
+    test('equality works correctly', () {
+      final record1 = HeartRateRecord(
+        id: HealthRecordId.none,
+        time: now,
+        rate: validValue,
+        metadata: metadata,
+      );
+
+      final record2 = HeartRateRecord(
+        id: HealthRecordId.none,
+        time: now,
+        rate: validValue,
+        metadata: metadata,
+      );
+
+      expect(record1, equals(record2));
+      expect(record1.hashCode, equals(record2.hashCode));
+    });
+  });
+}

--- a/packages/health_connector_core/test/src/models/health_records/heart_rate/heart_rate_series_record_test.dart
+++ b/packages/health_connector_core/test/src/models/health_records/heart_rate/heart_rate_series_record_test.dart
@@ -1,0 +1,136 @@
+import 'package:health_connector_core/health_connector_core.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('HeartRateSeriesRecord', () {
+    final now = DateTime(2026, 1, 11);
+    final startTime = now.subtract(const Duration(minutes: 10));
+    final endTime = now;
+    final metadata = Metadata.manualEntry();
+
+    final samples = [
+      HeartRateSample(
+        time: startTime,
+        rate: Frequency.perMinute(60),
+      ),
+      HeartRateSample(
+        time: startTime.add(const Duration(minutes: 5)),
+        rate: Frequency.perMinute(80),
+      ),
+      HeartRateSample(
+        time: endTime,
+        rate: Frequency.perMinute(100),
+      ),
+    ];
+
+    test('can be instantiated with valid parameters', () {
+      final record = HeartRateSeriesRecord(
+        startTime: startTime,
+        endTime: endTime,
+        samples: samples,
+        metadata: metadata,
+      );
+
+      expect(record.startTime, startTime);
+      expect(record.endTime, endTime);
+      expect(record.samples, samples);
+      expect(record.metadata, metadata);
+    });
+
+    test('calculates correct derived values (avg, min, max)', () {
+      final record = HeartRateSeriesRecord(
+        startTime: startTime,
+        endTime: endTime,
+        samples: samples,
+        metadata: metadata,
+      );
+
+      // Avg: (60 + 80 + 100) / 3 = 80
+      expect(record.avgRate.inPerMinute, closeTo(80, 0.1));
+
+      // Min: 60
+      expect(record.minRate.inPerMinute, closeTo(60, 0.1));
+
+      // Max: 100
+      expect(record.maxRate.inPerMinute, closeTo(100, 0.1));
+    });
+
+    test('derived values handle empty samples', () {
+      final record = HeartRateSeriesRecord(
+        startTime: startTime,
+        endTime: endTime,
+        samples: const [],
+        metadata: metadata,
+      );
+
+      expect(record.avgRate.inPerMinute, 0);
+      expect(record.minRate.inPerMinute, 0);
+      expect(record.maxRate.inPerMinute, 0);
+    });
+
+    test('derived values handle single sample', () {
+      final record = HeartRateSeriesRecord(
+        startTime: startTime,
+        endTime: endTime,
+        samples: [samples.first],
+        metadata: metadata,
+      );
+
+      expect(record.avgRate.inPerMinute, closeTo(60, 0.1));
+      expect(record.minRate.inPerMinute, closeTo(60, 0.1));
+      expect(record.maxRate.inPerMinute, closeTo(60, 0.1));
+    });
+
+    test('copyWith updates fields correctly', () {
+      final record = HeartRateSeriesRecord(
+        startTime: startTime,
+        endTime: endTime,
+        samples: samples,
+        metadata: metadata,
+      );
+
+      final newSamples = [samples.first];
+      final updatedRecord = record.copyWith(
+        samples: newSamples,
+      );
+
+      expect(updatedRecord.samples, newSamples);
+      expect(updatedRecord.startTime, startTime); // Unchanged
+    });
+
+    test('equality works correctly', () {
+      final record1 = HeartRateSeriesRecord(
+        startTime: startTime,
+        endTime: endTime,
+        samples: samples,
+        metadata: metadata,
+      );
+
+      // Recreate samples list to ensure deep equality check
+      final samples2 = [
+        HeartRateSample(
+          time: startTime,
+          rate: Frequency.perMinute(60),
+        ),
+        HeartRateSample(
+          time: startTime.add(const Duration(minutes: 5)),
+          rate: Frequency.perMinute(80),
+        ),
+        HeartRateSample(
+          time: endTime,
+          rate: Frequency.perMinute(100),
+        ),
+      ];
+
+      final record2 = HeartRateSeriesRecord(
+        startTime: startTime,
+        endTime: endTime,
+        samples: samples2,
+        metadata: metadata,
+      );
+
+      expect(record1, equals(record2));
+      expect(record1.hashCode, equals(record2.hashCode));
+    });
+  });
+}

--- a/packages/health_connector_core/test/src/models/health_records/heart_rate/heart_rate_variability_rmssd_record_test.dart
+++ b/packages/health_connector_core/test/src/models/health_records/heart_rate/heart_rate_variability_rmssd_record_test.dart
@@ -1,0 +1,83 @@
+import 'package:health_connector_core/health_connector_core.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('HeartRateVariabilityRMSSDRecord', () {
+    final now = DateTime(2026, 1, 11);
+    final metadata = Metadata.manualEntry();
+    const validValue = TimeDuration.milliseconds(50);
+    const maxValue = TimeDuration.milliseconds(250);
+
+    test('can be instantiated with valid parameters', () {
+      final record = HeartRateVariabilityRMSSDRecord(
+        time: now,
+        rmssd: validValue,
+        metadata: metadata,
+      );
+
+      expect(record.time, now);
+      expect(record.rmssd, equals(validValue));
+      expect(record.metadata, metadata);
+    });
+
+    test('throws ArgumentError when rmssd is too low', () {
+      expect(
+        () => HeartRateVariabilityRMSSDRecord(
+          time: now,
+          rmssd: const TimeDuration.milliseconds(0.9), // Min is 1.0
+          metadata: metadata,
+        ),
+        throwsArgumentError,
+      );
+    });
+
+    test('throws ArgumentError when rmssd is too high', () {
+      expect(
+        () => HeartRateVariabilityRMSSDRecord(
+          time: now,
+          rmssd: TimeDuration.milliseconds(maxValue.inMilliseconds + 0.1),
+          metadata: metadata,
+        ),
+        throwsArgumentError,
+      );
+    });
+
+    test('copyWith updates fields correctly', () {
+      final record = HeartRateVariabilityRMSSDRecord(
+        time: now,
+        rmssd: validValue,
+        metadata: metadata,
+      );
+
+      final newTime = now.subtract(const Duration(minutes: 10));
+      final updatedRecord = record.copyWith(
+        time: newTime,
+        rmssd: TimeDuration.milliseconds(validValue.inMilliseconds + 10),
+      );
+
+      expect(updatedRecord.time, newTime);
+      expect(
+        updatedRecord.rmssd.inMilliseconds,
+        closeTo(validValue.inMilliseconds + 10, 0.1),
+      );
+      expect(updatedRecord.metadata, metadata);
+    });
+
+    test('equality works correctly', () {
+      final record1 = HeartRateVariabilityRMSSDRecord(
+        time: now,
+        rmssd: validValue,
+        metadata: metadata,
+      );
+
+      final record2 = HeartRateVariabilityRMSSDRecord(
+        time: now,
+        rmssd: validValue,
+        metadata: metadata,
+      );
+
+      expect(record1, equals(record2));
+      expect(record1.hashCode, equals(record2.hashCode));
+    });
+  });
+}

--- a/packages/health_connector_core/test/src/models/health_records/heart_rate/heart_rate_variability_sdnn_record_test.dart
+++ b/packages/health_connector_core/test/src/models/health_records/heart_rate/heart_rate_variability_sdnn_record_test.dart
@@ -1,0 +1,83 @@
+import 'package:health_connector_core/health_connector_core.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('HeartRateVariabilitySDNNRecord', () {
+    final now = DateTime(2026, 1, 11);
+    final metadata = Metadata.manualEntry();
+    const validValue = TimeDuration.milliseconds(50);
+    const maxValue = TimeDuration.milliseconds(300);
+
+    test('can be instantiated with valid parameters', () {
+      final record = HeartRateVariabilitySDNNRecord(
+        time: now,
+        sdnn: validValue,
+        metadata: metadata,
+      );
+
+      expect(record.time, now);
+      expect(record.sdnn, equals(validValue));
+      expect(record.metadata, metadata);
+    });
+
+    test('throws ArgumentError when sdnn is too low', () {
+      expect(
+        () => HeartRateVariabilitySDNNRecord(
+          time: now,
+          sdnn: const TimeDuration.milliseconds(0.9), // Min is 1.0
+          metadata: metadata,
+        ),
+        throwsArgumentError,
+      );
+    });
+
+    test('throws ArgumentError when sdnn is too high', () {
+      expect(
+        () => HeartRateVariabilitySDNNRecord(
+          time: now,
+          sdnn: TimeDuration.milliseconds(maxValue.inMilliseconds + 0.1),
+          metadata: metadata,
+        ),
+        throwsArgumentError,
+      );
+    });
+
+    test('copyWith updates fields correctly', () {
+      final record = HeartRateVariabilitySDNNRecord(
+        time: now,
+        sdnn: validValue,
+        metadata: metadata,
+      );
+
+      final newTime = now.subtract(const Duration(minutes: 10));
+      final updatedRecord = record.copyWith(
+        time: newTime,
+        sdnn: TimeDuration.milliseconds(validValue.inMilliseconds + 10),
+      );
+
+      expect(updatedRecord.time, newTime);
+      expect(
+        updatedRecord.sdnn.inMilliseconds,
+        closeTo(validValue.inMilliseconds + 10, 0.1),
+      );
+      expect(updatedRecord.metadata, metadata);
+    });
+
+    test('equality works correctly', () {
+      final record1 = HeartRateVariabilitySDNNRecord(
+        time: now,
+        sdnn: validValue,
+        metadata: metadata,
+      );
+
+      final record2 = HeartRateVariabilitySDNNRecord(
+        time: now,
+        sdnn: validValue,
+        metadata: metadata,
+      );
+
+      expect(record1, equals(record2));
+      expect(record1.hashCode, equals(record2.hashCode));
+    });
+  });
+}

--- a/packages/health_connector_core/test/src/models/health_records/heart_rate/resting_heart_rate_record_test.dart
+++ b/packages/health_connector_core/test/src/models/health_records/heart_rate/resting_heart_rate_record_test.dart
@@ -1,0 +1,104 @@
+import 'package:health_connector_core/health_connector_core.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('RestingHeartRateRecord', () {
+    final now = DateTime(2026, 1, 11);
+    final metadata = Metadata.manualEntry();
+    final validValue = Frequency.perMinute(60);
+    final minValue = Frequency.perMinute(1.0); // Updated from 27.0
+    final maxValue = Frequency.perMinute(300); // Updated from 120
+
+    test('can be instantiated with valid parameters', () {
+      final record = RestingHeartRateRecord(
+        time: now,
+        rate: validValue,
+        metadata: metadata,
+      );
+
+      expect(record.time, now);
+      expect(record.rate, equals(validValue));
+      expect(record.metadata, metadata);
+    });
+
+    test('throws ArgumentError when rate is too low', () {
+      expect(
+        () => RestingHeartRateRecord(
+          time: now,
+          rate: Frequency.perMinute(0.5), // Below 1.0
+          metadata: metadata,
+        ),
+        throwsArgumentError,
+      );
+    });
+
+    test('accepts minimum valid rate', () {
+      final record = RestingHeartRateRecord(
+        time: now,
+        rate: minValue, // 1.0 bpm
+        metadata: metadata,
+      );
+
+      expect(record.rate, equals(minValue));
+    });
+
+    test('accepts maximum valid rate', () {
+      final record = RestingHeartRateRecord(
+        time: now,
+        rate: maxValue, // 300 bpm
+        metadata: metadata,
+      );
+
+      expect(record.rate, equals(maxValue));
+    });
+
+    test('throws ArgumentError when rate is too high', () {
+      expect(
+        () => RestingHeartRateRecord(
+          time: now,
+          rate: Frequency.perMinute(maxValue.inPerMinute + 1),
+          metadata: metadata,
+        ),
+        throwsArgumentError,
+      );
+    });
+
+    test('copyWith updates fields correctly', () {
+      final record = RestingHeartRateRecord(
+        time: now,
+        rate: validValue,
+        metadata: metadata,
+      );
+
+      final newTime = now.subtract(const Duration(minutes: 10));
+      final updatedRecord = record.copyWith(
+        time: newTime,
+        rate: Frequency.perMinute(validValue.inPerMinute + 10),
+      );
+
+      expect(updatedRecord.time, newTime);
+      expect(
+        updatedRecord.rate.inPerMinute,
+        closeTo(validValue.inPerMinute + 10, 0.1),
+      );
+      expect(updatedRecord.metadata, metadata);
+    });
+
+    test('equality works correctly', () {
+      final record1 = RestingHeartRateRecord(
+        time: now,
+        rate: validValue,
+        metadata: metadata,
+      );
+
+      final record2 = RestingHeartRateRecord(
+        time: now,
+        rate: validValue,
+        metadata: metadata,
+      );
+
+      expect(record1, equals(record2));
+      expect(record1.hashCode, equals(record2.hashCode));
+    });
+  });
+}

--- a/packages/health_connector_core/test/src/models/health_records/height_record_test.dart
+++ b/packages/health_connector_core/test/src/models/health_records/height_record_test.dart
@@ -1,0 +1,90 @@
+import 'package:health_connector_core/health_connector_core.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('HeightRecord', () {
+    final now = DateTime(2026, 1, 11);
+    final metadata = Metadata.manualEntry();
+    const validHeight = Length.meters(1.75);
+
+    test('can be instantiated with valid parameters', () {
+      final record = HeightRecord(
+        time: now,
+        height: validHeight,
+        metadata: metadata,
+      );
+
+      expect(record.time, now);
+      expect(record.height, equals(validHeight));
+      expect(record.metadata, metadata);
+    });
+
+    test('throws ArgumentError when height is below minHeight', () {
+      expect(
+        () => HeightRecord(
+          time: now,
+          height: Length.zero,
+          metadata: metadata,
+        ),
+        throwsArgumentError,
+      );
+    });
+
+    test('throws ArgumentError when height is above maxHeight', () {
+      expect(
+        () => HeightRecord(
+          time: now,
+          height: const Length.meters(3.1), // Typically max is around 3m
+          metadata: metadata,
+        ),
+        throwsArgumentError,
+      );
+    });
+
+    test('copyWith updates all fields correctly', () {
+      final record = HeightRecord(
+        time: now,
+        height: validHeight,
+        metadata: metadata,
+      );
+
+      final newTime = now.add(const Duration(minutes: 5));
+      const newHeight = Length.meters(1.80);
+      final newMetadata = Metadata.manualEntry();
+
+      final updated = record.copyWith(
+        time: newTime,
+        height: newHeight,
+        metadata: newMetadata,
+      );
+
+      expect(updated.time, newTime);
+      expect(updated.height, newHeight);
+      expect(updated.metadata, newMetadata);
+    });
+
+    test('equality works correctly', () {
+      final record1 = HeightRecord(
+        time: now,
+        height: validHeight,
+        metadata: metadata,
+      );
+
+      final record2 = HeightRecord(
+        time: now,
+        height: validHeight,
+        metadata: metadata,
+      );
+
+      final record3 = HeightRecord(
+        time: now,
+        height: const Length.meters(1.80),
+        metadata: metadata,
+      );
+
+      expect(record1 == record2, isTrue);
+      expect(record1 == record3, isFalse);
+      expect(record1.hashCode == record2.hashCode, isTrue);
+    });
+  });
+}

--- a/packages/health_connector_core/test/src/models/health_records/hydration_record_test.dart
+++ b/packages/health_connector_core/test/src/models/health_records/hydration_record_test.dart
@@ -1,0 +1,115 @@
+import 'package:health_connector_core/health_connector_core.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('HydrationRecord', () {
+    final now = DateTime(2026, 1, 11);
+    final startTime = now.subtract(const Duration(minutes: 30));
+    final endTime = now;
+    final metadata = Metadata.manualEntry();
+    const validVolume = Volume.milliliters(500.0);
+
+    test('can be instantiated with valid parameters', () {
+      final record = HydrationRecord(
+        startTime: startTime,
+        endTime: endTime,
+        volume: validVolume,
+        metadata: metadata,
+      );
+
+      expect(record.startTime, startTime);
+      expect(record.endTime, endTime);
+      expect(record.volume, validVolume);
+      expect(record.metadata, metadata);
+    });
+
+    test('throws ArgumentError when volume is below minVolume', () {
+      expect(
+        () => HydrationRecord(
+          startTime: startTime,
+          endTime: endTime,
+          volume: const Volume.liters(-0.1),
+          metadata: metadata,
+        ),
+        throwsArgumentError,
+      );
+    });
+
+    test('throws ArgumentError when volume is above maxVolume', () {
+      expect(
+        () => HydrationRecord(
+          startTime: startTime,
+          endTime: endTime,
+          volume: const Volume.liters(20.1),
+          metadata: metadata,
+        ),
+        throwsArgumentError,
+      );
+    });
+
+    test('throws ArgumentError when end time is before start time', () {
+      expect(
+        () => HydrationRecord(
+          startTime: endTime,
+          endTime: startTime,
+          volume: validVolume,
+          metadata: metadata,
+        ),
+        throwsArgumentError,
+      );
+    });
+
+    test('copyWith updates all fields correctly', () {
+      final record = HydrationRecord(
+        startTime: startTime,
+        endTime: endTime,
+        volume: validVolume,
+        metadata: metadata,
+      );
+
+      final newStartTime = startTime.subtract(const Duration(minutes: 5));
+      final newEndTime = endTime.add(const Duration(minutes: 5));
+      const newVolume = Volume.milliliters(600.0);
+      final newMetadata = Metadata.manualEntry();
+
+      final updated = record.copyWith(
+        startTime: newStartTime,
+        endTime: newEndTime,
+        volume: newVolume,
+        metadata: newMetadata,
+      );
+
+      expect(updated.startTime, newStartTime);
+      expect(updated.endTime, newEndTime);
+      expect(updated.volume, newVolume);
+      expect(updated.metadata, newMetadata);
+    });
+
+    test('equality works correctly', () {
+      final record1 = HydrationRecord(
+        startTime: startTime,
+        endTime: endTime,
+        volume: validVolume,
+        metadata: metadata,
+      );
+
+      final record2 = HydrationRecord(
+        startTime: startTime,
+        endTime: endTime,
+        volume: validVolume,
+        metadata: metadata,
+      );
+
+      final record3 = HydrationRecord(
+        startTime: startTime,
+        endTime: endTime,
+        volume: const Volume.milliliters(550.0),
+        metadata: metadata,
+      );
+
+      expect(record1 == record2, isTrue);
+      expect(record1 == record3, isFalse);
+      expect(record1.hashCode == record2.hashCode, isTrue);
+    });
+  });
+}

--- a/packages/health_connector_core/test/src/models/health_records/lean_body_mass_record_test.dart
+++ b/packages/health_connector_core/test/src/models/health_records/lean_body_mass_record_test.dart
@@ -1,0 +1,90 @@
+import 'package:health_connector_core/health_connector_core.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('LeanBodyMassRecord', () {
+    final now = DateTime(2026, 1, 11);
+    final metadata = Metadata.manualEntry();
+    const validMass = Mass.kilograms(60.0);
+
+    test('can be instantiated with valid parameters', () {
+      final record = LeanBodyMassRecord(
+        time: now,
+        mass: validMass,
+        metadata: metadata,
+      );
+
+      expect(record.time, now);
+      expect(record.mass, validMass);
+      expect(record.metadata, metadata);
+    });
+
+    test('throws ArgumentError when mass is below minMass', () {
+      expect(
+        () => LeanBodyMassRecord(
+          time: now,
+          mass: const Mass.kilograms(0.4),
+          metadata: metadata,
+        ),
+        throwsArgumentError,
+      );
+    });
+
+    test('throws ArgumentError when mass is above maxMass', () {
+      expect(
+        () => LeanBodyMassRecord(
+          time: now,
+          mass: const Mass.kilograms(200.1),
+          metadata: metadata,
+        ),
+        throwsArgumentError,
+      );
+    });
+
+    test('copyWith updates all fields correctly', () {
+      final record = LeanBodyMassRecord(
+        time: now,
+        mass: validMass,
+        metadata: metadata,
+      );
+
+      final newTime = now.add(const Duration(minutes: 5));
+      const newMass = Mass.kilograms(61.0);
+      final newMetadata = Metadata.manualEntry();
+
+      final updated = record.copyWith(
+        time: newTime,
+        mass: newMass,
+        metadata: newMetadata,
+      );
+
+      expect(updated.time, newTime);
+      expect(updated.mass, newMass);
+      expect(updated.metadata, newMetadata);
+    });
+
+    test('equality works correctly', () {
+      final record1 = LeanBodyMassRecord(
+        time: now,
+        mass: validMass,
+        metadata: metadata,
+      );
+
+      final record2 = LeanBodyMassRecord(
+        time: now,
+        mass: validMass,
+        metadata: metadata,
+      );
+
+      final record3 = LeanBodyMassRecord(
+        time: now,
+        mass: const Mass.kilograms(60.1),
+        metadata: metadata,
+      );
+
+      expect(record1 == record2, isTrue);
+      expect(record1 == record3, isFalse);
+      expect(record1.hashCode == record2.hashCode, isTrue);
+    });
+  });
+}

--- a/packages/health_connector_core/test/src/models/health_records/menstruation/cervical_mucus/cervical_mucus_record_test.dart
+++ b/packages/health_connector_core/test/src/models/health_records/menstruation/cervical_mucus/cervical_mucus_record_test.dart
@@ -1,0 +1,75 @@
+import 'package:health_connector_core/health_connector_core.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('CervicalMucusRecord', () {
+    final now = DateTime(2026, 1, 11);
+    final metadata = Metadata.manualEntry();
+    const appearance = CervicalMucusAppearance.eggWhite;
+    const sensation = CervicalMucusSensation.medium;
+
+    test('can be instantiated with valid parameters', () {
+      final record = CervicalMucusRecord(
+        time: now,
+        metadata: metadata,
+        appearance: appearance,
+        sensation: sensation,
+      );
+
+      expect(record.time, now);
+      expect(record.metadata, metadata);
+      expect(record.appearance, appearance);
+      expect(record.sensation, sensation);
+    });
+
+    test('can be instantiated with default values', () {
+      final record = CervicalMucusRecord(
+        time: now,
+        metadata: metadata,
+      );
+
+      expect(record.appearance, CervicalMucusAppearance.unknown);
+      expect(record.sensation, CervicalMucusSensation.unknown);
+    });
+
+    test('copyWith updates fields correctly', () {
+      final record = CervicalMucusRecord(
+        time: now,
+        metadata: metadata,
+        appearance: appearance,
+        sensation: sensation,
+      );
+
+      final newTime = now.subtract(const Duration(minutes: 10));
+      const newAppearance = CervicalMucusAppearance.sticky;
+
+      final updatedRecord = record.copyWith(
+        time: newTime,
+        appearance: newAppearance,
+      );
+
+      expect(updatedRecord.time, newTime);
+      expect(updatedRecord.appearance, newAppearance);
+      expect(updatedRecord.sensation, sensation); // Unchanged
+    });
+
+    test('equality works correctly', () {
+      final record1 = CervicalMucusRecord(
+        time: now,
+        metadata: metadata,
+        appearance: appearance,
+        sensation: sensation,
+      );
+
+      final record2 = CervicalMucusRecord(
+        time: now,
+        metadata: metadata,
+        appearance: appearance,
+        sensation: sensation,
+      );
+
+      expect(record1, equals(record2));
+      expect(record1.hashCode, equals(record2.hashCode));
+    });
+  });
+}

--- a/packages/health_connector_core/test/src/models/health_records/menstruation/intermenstrual_bleeding_record_test.dart
+++ b/packages/health_connector_core/test/src/models/health_records/menstruation/intermenstrual_bleeding_record_test.dart
@@ -1,0 +1,59 @@
+import 'package:health_connector_core/health_connector_core.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('IntermenstrualBleedingRecord', () {
+    final now = DateTime(2026, 1, 11);
+    final metadata = Metadata.manualEntry();
+
+    test('can be instantiated with valid parameters', () {
+      final record = IntermenstrualBleedingRecord(
+        time: now,
+        metadata: metadata,
+      );
+
+      expect(record.time, now);
+      expect(record.metadata, metadata);
+    });
+
+    test('copyWith updates all fields correctly', () {
+      final record = IntermenstrualBleedingRecord(
+        time: now,
+        metadata: metadata,
+      );
+
+      final newTime = now.subtract(const Duration(minutes: 10));
+      final newMetadata = Metadata.manualEntry();
+
+      final updatedRecord = record.copyWith(
+        time: newTime,
+        metadata: newMetadata,
+      );
+
+      expect(updatedRecord.time, newTime);
+      expect(updatedRecord.metadata, newMetadata);
+    });
+
+    test('equality works correctly', () {
+      final record1 = IntermenstrualBleedingRecord(
+        time: now,
+        metadata: metadata,
+      );
+
+      final record2 = IntermenstrualBleedingRecord(
+        time: now,
+        metadata: metadata,
+      );
+
+      // Mutate time slightly for inequality
+      final record3 = IntermenstrualBleedingRecord(
+        time: now.add(const Duration(seconds: 1)),
+        metadata: metadata,
+      );
+
+      expect(record1 == record2, isTrue);
+      expect(record1 == record3, isFalse);
+      expect(record1.hashCode == record2.hashCode, isTrue);
+    });
+  });
+}

--- a/packages/health_connector_core/test/src/models/health_records/menstruation/menstrual_flow/menstrual_flow_instant_record_test.dart
+++ b/packages/health_connector_core/test/src/models/health_records/menstruation/menstrual_flow/menstrual_flow_instant_record_test.dart
@@ -1,0 +1,59 @@
+import 'package:health_connector_core/health_connector_core.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('MenstrualFlowInstantRecord', () {
+    final now = DateTime(2026, 1, 11);
+    final metadata = Metadata.manualEntry();
+    const flow = MenstrualFlow.heavy;
+
+    test('can be instantiated with valid parameters', () {
+      final record = MenstrualFlowInstantRecord(
+        time: now,
+        metadata: metadata,
+        flow: flow,
+      );
+
+      expect(record.time, now);
+      expect(record.metadata, metadata);
+      expect(record.flow, flow);
+    });
+
+    test('copyWith updates fields correctly', () {
+      final record = MenstrualFlowInstantRecord(
+        time: now,
+        metadata: metadata,
+        flow: flow,
+      );
+
+      final newTime = now.subtract(const Duration(minutes: 10));
+      const newFlow = MenstrualFlow.light;
+
+      final updatedRecord = record.copyWith(
+        time: newTime,
+        flow: newFlow,
+      );
+
+      expect(updatedRecord.time, newTime);
+      expect(updatedRecord.flow, newFlow);
+      expect(updatedRecord.metadata, metadata);
+    });
+
+    test('equality works correctly', () {
+      final record1 = MenstrualFlowInstantRecord(
+        time: now,
+        metadata: metadata,
+        flow: flow,
+      );
+
+      final record2 = MenstrualFlowInstantRecord(
+        time: now,
+        metadata: metadata,
+        flow: flow,
+      );
+
+      expect(record1, equals(record2));
+      expect(record1.hashCode, equals(record2.hashCode));
+    });
+  });
+}

--- a/packages/health_connector_core/test/src/models/health_records/menstruation/menstrual_flow/menstrual_flow_record_test.dart
+++ b/packages/health_connector_core/test/src/models/health_records/menstruation/menstrual_flow/menstrual_flow_record_test.dart
@@ -1,0 +1,72 @@
+import 'package:health_connector_core/health_connector_core.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('MenstrualFlowRecord', () {
+    final now = DateTime(2026, 1, 11);
+    final startTime = now.subtract(const Duration(hours: 6));
+    final endTime = now;
+    final metadata = Metadata.manualEntry();
+    const flow = MenstrualFlow.heavy;
+    const isCycleStart = true;
+
+    test('can be instantiated with valid parameters', () {
+      final record = MenstrualFlowRecord(
+        startTime: startTime,
+        endTime: endTime,
+        metadata: metadata,
+        flow: flow,
+        isCycleStart: isCycleStart,
+      );
+
+      expect(record.startTime, startTime);
+      expect(record.endTime, endTime);
+      expect(record.metadata, metadata);
+      expect(record.flow, flow);
+      expect(record.isCycleStart, isCycleStart);
+    });
+
+    test('copyWith updates fields correctly', () {
+      final record = MenstrualFlowRecord(
+        startTime: startTime,
+        endTime: endTime,
+        metadata: metadata,
+        flow: flow,
+        isCycleStart: isCycleStart,
+      );
+
+      final newTime = startTime.subtract(const Duration(hours: 1));
+      const newFlow = MenstrualFlow.medium;
+
+      final updatedRecord = record.copyWith(
+        startTime: newTime,
+        flow: newFlow,
+      );
+
+      expect(updatedRecord.startTime, newTime);
+      expect(updatedRecord.flow, newFlow);
+      expect(updatedRecord.isCycleStart, isCycleStart); // Unchanged
+    });
+
+    test('equality works correctly', () {
+      final record1 = MenstrualFlowRecord(
+        startTime: startTime,
+        endTime: endTime,
+        metadata: metadata,
+        flow: flow,
+        isCycleStart: isCycleStart,
+      );
+
+      final record2 = MenstrualFlowRecord(
+        startTime: startTime,
+        endTime: endTime,
+        metadata: metadata,
+        flow: flow,
+        isCycleStart: isCycleStart,
+      );
+
+      expect(record1, equals(record2));
+      expect(record1.hashCode, equals(record2.hashCode));
+    });
+  });
+}

--- a/packages/health_connector_core/test/src/models/health_records/menstruation/ovulation_test/ovulation_test_record_test.dart
+++ b/packages/health_connector_core/test/src/models/health_records/menstruation/ovulation_test/ovulation_test_record_test.dart
@@ -1,0 +1,59 @@
+import 'package:health_connector_core/health_connector_core.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('OvulationTestRecord', () {
+    final now = DateTime(2026, 1, 11);
+    final metadata = Metadata.manualEntry();
+    const result = OvulationTestResult.positive;
+
+    test('can be instantiated with valid parameters', () {
+      final record = OvulationTestRecord(
+        time: now,
+        metadata: metadata,
+        result: result,
+      );
+
+      expect(record.time, now);
+      expect(record.metadata, metadata);
+      expect(record.result, result);
+    });
+
+    test('copyWith updates fields correctly', () {
+      final record = OvulationTestRecord(
+        time: now,
+        metadata: metadata,
+        result: result,
+      );
+
+      final newTime = now.subtract(const Duration(minutes: 10));
+      const newResult = OvulationTestResult.negative;
+
+      final updatedRecord = record.copyWith(
+        time: newTime,
+        result: newResult,
+      );
+
+      expect(updatedRecord.time, newTime);
+      expect(updatedRecord.result, newResult);
+      expect(updatedRecord.metadata, metadata);
+    });
+
+    test('equality works correctly', () {
+      final record1 = OvulationTestRecord(
+        time: now,
+        metadata: metadata,
+        result: result,
+      );
+
+      final record2 = OvulationTestRecord(
+        time: now,
+        metadata: metadata,
+        result: result,
+      );
+
+      expect(record1, equals(record2));
+      expect(record1.hashCode, equals(record2.hashCode));
+    });
+  });
+}

--- a/packages/health_connector_core/test/src/models/health_records/mindfulness/mindfulness_session_record_test.dart
+++ b/packages/health_connector_core/test/src/models/health_records/mindfulness/mindfulness_session_record_test.dart
@@ -1,0 +1,111 @@
+import 'package:health_connector_core/health_connector_core.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('MindfulnessSessionRecord', () {
+    final now = DateTime(2026, 1, 11);
+    final startTime = now.subtract(const Duration(minutes: 15));
+    final endTime = now;
+    final metadata = Metadata.manualEntry();
+    const sessionType = MindfulnessSessionType.meditation;
+    const title = 'Morning Meditation';
+    const notes = 'Focused on breath';
+
+    test('can be instantiated with valid parameters', () {
+      final record = MindfulnessSessionRecord(
+        startTime: startTime,
+        endTime: endTime,
+        metadata: metadata,
+        sessionType: sessionType,
+        title: title,
+        notes: notes,
+      );
+
+      expect(record.startTime, startTime);
+      expect(record.endTime, endTime);
+      expect(record.metadata, metadata);
+      expect(record.sessionType, sessionType);
+      expect(record.title, title);
+      expect(record.notes, notes);
+    });
+
+    test('throws ArgumentError when startTime is after endTime', () {
+      expect(
+        () => MindfulnessSessionRecord(
+          startTime: endTime,
+          endTime: startTime,
+          metadata: metadata,
+          sessionType: sessionType,
+        ),
+        throwsArgumentError,
+      );
+    });
+
+    test('copyWith updates all fields correctly', () {
+      final record = MindfulnessSessionRecord(
+        startTime: startTime,
+        endTime: endTime,
+        metadata: metadata,
+        sessionType: sessionType,
+        title: title,
+        notes: notes,
+      );
+
+      final newStartTime = startTime.subtract(const Duration(minutes: 5));
+      final newEndTime = endTime.add(const Duration(minutes: 5));
+      final newMetadata = Metadata.manualEntry();
+      const newType = MindfulnessSessionType.breathing;
+      const newTitle = 'Breathing Exercise';
+      const newNotes = 'Deep breaths';
+
+      final updatedRecord = record.copyWith(
+        startTime: newStartTime,
+        endTime: newEndTime,
+        metadata: newMetadata,
+        sessionType: newType,
+        title: newTitle,
+        notes: newNotes,
+      );
+
+      expect(updatedRecord.startTime, newStartTime);
+      expect(updatedRecord.endTime, newEndTime);
+      expect(updatedRecord.metadata, newMetadata);
+      expect(updatedRecord.sessionType, newType);
+      expect(updatedRecord.title, newTitle);
+      expect(updatedRecord.notes, newNotes);
+    });
+
+    test('equality works correctly', () {
+      final record1 = MindfulnessSessionRecord(
+        startTime: startTime,
+        endTime: endTime,
+        metadata: metadata,
+        sessionType: sessionType,
+        title: title,
+        notes: notes,
+      );
+
+      final record2 = MindfulnessSessionRecord(
+        startTime: startTime,
+        endTime: endTime,
+        metadata: metadata,
+        sessionType: sessionType,
+        title: title,
+        notes: notes,
+      );
+
+      final record3 = MindfulnessSessionRecord(
+        startTime: startTime,
+        endTime: endTime,
+        metadata: metadata,
+        sessionType: MindfulnessSessionType.music,
+        title: title,
+        notes: notes,
+      );
+
+      expect(record1 == record2, isTrue);
+      expect(record1 == record3, isFalse);
+      expect(record1.hashCode == record2.hashCode, isTrue);
+    });
+  });
+}

--- a/packages/health_connector_core/test/src/models/health_records/nutrition/dietary_biotin_record_test.dart
+++ b/packages/health_connector_core/test/src/models/health_records/nutrition/dietary_biotin_record_test.dart
@@ -1,0 +1,100 @@
+import 'package:health_connector_core/health_connector_core.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('DietaryBiotinRecord (Vitamin)', () {
+    final now = DateTime.now();
+    final metadata = Metadata.manualEntry();
+    const validMass = Mass.grams(0.00001); // 10 mcg
+
+    test('can be instantiated with valid parameters', () {
+      final record = DietaryBiotinRecord(
+        time: now,
+        metadata: metadata,
+        mass: validMass,
+        foodName: 'Egg',
+        mealType: MealType.breakfast,
+      );
+
+      expect(record.time, now);
+      expect(record.metadata, metadata);
+      expect(record.mass, equals(validMass));
+    });
+
+    test('throws ArgumentError when mass is below minMass', () {
+      expect(
+        () => DietaryBiotinRecord(
+          time: now,
+          metadata: metadata,
+          mass: const Mass.grams(-0.1),
+        ),
+        throwsArgumentError,
+      );
+    });
+
+    test('throws ArgumentError when mass is above maxMass', () {
+      expect(
+        () => DietaryBiotinRecord(
+          time: now,
+          metadata: metadata,
+          mass: const Mass.grams(10.1),
+        ),
+        throwsArgumentError,
+      );
+    });
+
+    test('copyWith updates all fields correctly', () {
+      final record = DietaryBiotinRecord(
+        time: now,
+        metadata: metadata,
+        mass: validMass,
+        foodName: 'Egg',
+        mealType: MealType.breakfast,
+      );
+
+      const newMass = Mass.grams(0.00003); // 30 mcg
+      final newTime = now.add(const Duration(minutes: 5));
+      final newMetadata = Metadata.manualEntry();
+      const newFoodName = 'Nuts';
+      const newMealType = MealType.snack;
+
+      final updatedRecord = record.copyWith(
+        mass: newMass,
+        time: newTime,
+        metadata: newMetadata,
+        foodName: newFoodName,
+        mealType: newMealType,
+      );
+
+      expect(updatedRecord.mass, newMass);
+      expect(updatedRecord.time, newTime);
+      expect(updatedRecord.metadata, newMetadata);
+      expect(updatedRecord.foodName, newFoodName);
+      expect(updatedRecord.mealType, newMealType);
+    });
+
+    test('equality works correctly', () {
+      final record1 = DietaryBiotinRecord(
+        time: now,
+        metadata: metadata,
+        mass: validMass,
+      );
+
+      final record2 = DietaryBiotinRecord(
+        time: now,
+        metadata: metadata,
+        mass: validMass,
+      );
+
+      final record3 = DietaryBiotinRecord(
+        time: now,
+        metadata: metadata,
+        mass: const Mass.grams(0.00005),
+      );
+
+      expect(record1 == record2, isTrue);
+      expect(record1 == record3, isFalse);
+      expect(record1.hashCode == record2.hashCode, isTrue);
+    });
+  });
+}

--- a/packages/health_connector_core/test/src/models/health_records/nutrition/dietary_caffeine_record_test.dart
+++ b/packages/health_connector_core/test/src/models/health_records/nutrition/dietary_caffeine_record_test.dart
@@ -1,0 +1,100 @@
+import 'package:health_connector_core/health_connector_core.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('DietaryCaffeineRecord', () {
+    final now = DateTime(2026, 1, 11);
+    final metadata = Metadata.manualEntry();
+    const validMass = Mass.grams(0.2); // 200 mg
+
+    test('can be instantiated with valid parameters', () {
+      final record = DietaryCaffeineRecord(
+        time: now,
+        metadata: metadata,
+        mass: validMass,
+        foodName: 'Coffee',
+        mealType: MealType.breakfast,
+      );
+
+      expect(record.time, now);
+      expect(record.metadata, metadata);
+      expect(record.mass, equals(validMass));
+    });
+
+    test('throws ArgumentError when mass is below minMass', () {
+      expect(
+        () => DietaryCaffeineRecord(
+          time: now,
+          metadata: metadata,
+          mass: const Mass.grams(-0.1),
+        ),
+        throwsArgumentError,
+      );
+    });
+
+    test('throws ArgumentError when mass is above maxMass', () {
+      expect(
+        () => DietaryCaffeineRecord(
+          time: now,
+          metadata: metadata,
+          mass: const Mass.grams(10.1),
+        ),
+        throwsArgumentError,
+      );
+    });
+
+    test('copyWith updates all fields correctly', () {
+      final record = DietaryCaffeineRecord(
+        time: now,
+        metadata: metadata,
+        mass: validMass,
+        foodName: 'Coffee',
+        mealType: MealType.breakfast,
+      );
+
+      const newMass = Mass.grams(0.15); // 150 mg
+      final newTime = now.add(const Duration(minutes: 5));
+      final newMetadata = Metadata.manualEntry();
+      const newFoodName = 'Tea';
+      const newMealType = MealType.snack;
+
+      final updatedRecord = record.copyWith(
+        mass: newMass,
+        time: newTime,
+        metadata: newMetadata,
+        foodName: newFoodName,
+        mealType: newMealType,
+      );
+
+      expect(updatedRecord.mass, newMass);
+      expect(updatedRecord.time, newTime);
+      expect(updatedRecord.metadata, newMetadata);
+      expect(updatedRecord.foodName, newFoodName);
+      expect(updatedRecord.mealType, newMealType);
+    });
+
+    test('equality works correctly', () {
+      final record1 = DietaryCaffeineRecord(
+        time: now,
+        metadata: metadata,
+        mass: validMass,
+      );
+
+      final record2 = DietaryCaffeineRecord(
+        time: now,
+        metadata: metadata,
+        mass: validMass,
+      );
+
+      final record3 = DietaryCaffeineRecord(
+        time: now,
+        metadata: metadata,
+        mass: const Mass.grams(0.5),
+      );
+
+      expect(record1 == record2, isTrue);
+      expect(record1 == record3, isFalse);
+      expect(record1.hashCode == record2.hashCode, isTrue);
+    });
+  });
+}

--- a/packages/health_connector_core/test/src/models/health_records/nutrition/dietary_calcium_record_test.dart
+++ b/packages/health_connector_core/test/src/models/health_records/nutrition/dietary_calcium_record_test.dart
@@ -1,0 +1,100 @@
+import 'package:health_connector_core/health_connector_core.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('DietaryCalciumRecord (Mineral)', () {
+    final now = DateTime(2026, 1, 11);
+    final metadata = Metadata.manualEntry();
+    const validMass = Mass.grams(0.3); // 300 mg
+
+    test('can be instantiated with valid parameters', () {
+      final record = DietaryCalciumRecord(
+        time: now,
+        metadata: metadata,
+        mass: validMass,
+        foodName: 'Milk',
+        mealType: MealType.breakfast,
+      );
+
+      expect(record.time, now);
+      expect(record.metadata, metadata);
+      expect(record.mass, equals(validMass));
+    });
+
+    test('throws ArgumentError when mass is below minMass', () {
+      expect(
+        () => DietaryCalciumRecord(
+          time: now,
+          metadata: metadata,
+          mass: const Mass.grams(-0.1),
+        ),
+        throwsArgumentError,
+      );
+    });
+
+    test('throws ArgumentError when mass is above maxMass', () {
+      expect(
+        () => DietaryCalciumRecord(
+          time: now,
+          metadata: metadata,
+          mass: const Mass.grams(100.1),
+        ),
+        throwsArgumentError,
+      );
+    });
+
+    test('copyWith updates all fields correctly', () {
+      final record = DietaryCalciumRecord(
+        time: now,
+        metadata: metadata,
+        mass: validMass,
+        foodName: 'Milk',
+        mealType: MealType.breakfast,
+      );
+
+      const newMass = Mass.grams(0.4); // 400 mg
+      final newTime = now.add(const Duration(minutes: 5));
+      final newMetadata = Metadata.manualEntry();
+      const newFoodName = 'Cheese';
+      const newMealType = MealType.snack;
+
+      final updatedRecord = record.copyWith(
+        mass: newMass,
+        time: newTime,
+        metadata: newMetadata,
+        foodName: newFoodName,
+        mealType: newMealType,
+      );
+
+      expect(updatedRecord.mass, newMass);
+      expect(updatedRecord.time, newTime);
+      expect(updatedRecord.metadata, newMetadata);
+      expect(updatedRecord.foodName, newFoodName);
+      expect(updatedRecord.mealType, newMealType);
+    });
+
+    test('equality works correctly', () {
+      final record1 = DietaryCalciumRecord(
+        time: now,
+        metadata: metadata,
+        mass: validMass,
+      );
+
+      final record2 = DietaryCalciumRecord(
+        time: now,
+        metadata: metadata,
+        mass: validMass,
+      );
+
+      final record3 = DietaryCalciumRecord(
+        time: now,
+        metadata: metadata,
+        mass: const Mass.grams(0.5),
+      );
+
+      expect(record1 == record2, isTrue);
+      expect(record1 == record3, isFalse);
+      expect(record1.hashCode == record2.hashCode, isTrue);
+    });
+  });
+}

--- a/packages/health_connector_core/test/src/models/health_records/nutrition/dietary_cholesterol_record_test.dart
+++ b/packages/health_connector_core/test/src/models/health_records/nutrition/dietary_cholesterol_record_test.dart
@@ -1,0 +1,100 @@
+import 'package:health_connector_core/health_connector_core.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('DietaryCholesterolRecord (Macronutrient)', () {
+    final now = DateTime.now();
+    final metadata = Metadata.manualEntry();
+    const validMass = Mass.grams(0.186); // 186 mg
+
+    test('can be instantiated with valid parameters', () {
+      final record = DietaryCholesterolRecord(
+        time: now,
+        metadata: metadata,
+        mass: validMass,
+        foodName: 'Egg',
+        mealType: MealType.breakfast,
+      );
+
+      expect(record.time, now);
+      expect(record.metadata, metadata);
+      expect(record.mass, equals(validMass));
+    });
+
+    test('throws ArgumentError when mass is below minMass', () {
+      expect(
+        () => DietaryCholesterolRecord(
+          time: now,
+          metadata: metadata,
+          mass: const Mass.grams(-0.1),
+        ),
+        throwsArgumentError,
+      );
+    });
+
+    test('throws ArgumentError when mass is above maxMass', () {
+      expect(
+        () => DietaryCholesterolRecord(
+          time: now,
+          metadata: metadata,
+          mass: const Mass.grams(1000.1),
+        ),
+        throwsArgumentError,
+      );
+    });
+
+    test('copyWith updates all fields correctly', () {
+      final record = DietaryCholesterolRecord(
+        time: now,
+        metadata: metadata,
+        mass: validMass,
+        foodName: 'Egg',
+        mealType: MealType.breakfast,
+      );
+
+      const newMass = Mass.grams(0.150); // 150 mg
+      final newTime = now.add(const Duration(minutes: 5));
+      final newMetadata = Metadata.manualEntry();
+      const newFoodName = 'Shrimp';
+      const newMealType = MealType.lunch;
+
+      final updatedRecord = record.copyWith(
+        mass: newMass,
+        time: newTime,
+        metadata: newMetadata,
+        foodName: newFoodName,
+        mealType: newMealType,
+      );
+
+      expect(updatedRecord.mass, newMass);
+      expect(updatedRecord.time, newTime);
+      expect(updatedRecord.metadata, newMetadata);
+      expect(updatedRecord.foodName, newFoodName);
+      expect(updatedRecord.mealType, newMealType);
+    });
+
+    test('equality works correctly', () {
+      final record1 = DietaryCholesterolRecord(
+        time: now,
+        metadata: metadata,
+        mass: validMass,
+      );
+
+      final record2 = DietaryCholesterolRecord(
+        time: now,
+        metadata: metadata,
+        mass: validMass,
+      );
+
+      final record3 = DietaryCholesterolRecord(
+        time: now,
+        metadata: metadata,
+        mass: const Mass.grams(0.200),
+      );
+
+      expect(record1 == record2, isTrue);
+      expect(record1 == record3, isFalse);
+      expect(record1.hashCode == record2.hashCode, isTrue);
+    });
+  });
+}

--- a/packages/health_connector_core/test/src/models/health_records/nutrition/dietary_energy_consumed_record_test.dart
+++ b/packages/health_connector_core/test/src/models/health_records/nutrition/dietary_energy_consumed_record_test.dart
@@ -1,0 +1,102 @@
+import 'package:health_connector_core/health_connector_core.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('DietaryEnergyConsumedRecord', () {
+    final now = DateTime(2026, 1, 11);
+    final metadata = Metadata.manualEntry();
+    const validEnergy = Energy.kilocalories(250);
+
+    test('can be instantiated with valid parameters', () {
+      final record = DietaryEnergyConsumedRecord(
+        time: now,
+        metadata: metadata,
+        energy: validEnergy,
+        foodName: 'Apple',
+        mealType: MealType.snack,
+      );
+
+      expect(record.time, now);
+      expect(record.metadata, metadata);
+      expect(record.energy, equals(validEnergy));
+      expect(record.foodName, 'Apple');
+      expect(record.mealType, MealType.snack);
+    });
+
+    test('throws ArgumentError when energy is below minEnergy', () {
+      expect(
+        () => DietaryEnergyConsumedRecord(
+          time: now,
+          metadata: metadata,
+          energy: const Energy.kilocalories(-1),
+        ),
+        throwsArgumentError,
+      );
+    });
+
+    test('throws ArgumentError when energy is above maxEnergy', () {
+      expect(
+        () => DietaryEnergyConsumedRecord(
+          time: now,
+          metadata: metadata,
+          energy: const Energy.kilocalories(10001),
+        ),
+        throwsArgumentError,
+      );
+    });
+
+    test('copyWith updates all fields correctly', () {
+      final record = DietaryEnergyConsumedRecord(
+        time: now,
+        metadata: metadata,
+        energy: validEnergy,
+        foodName: 'Apple',
+        mealType: MealType.snack,
+      );
+
+      final newTime = now.subtract(const Duration(minutes: 5));
+      const newEnergy = Energy.kilocalories(300);
+      final newMetadata = Metadata.manualEntry();
+      const newFoodName = 'Banana';
+      const newMealType = MealType.breakfast;
+
+      final updatedRecord = record.copyWith(
+        time: newTime,
+        energy: newEnergy,
+        metadata: newMetadata,
+        foodName: newFoodName,
+        mealType: newMealType,
+      );
+
+      expect(updatedRecord.time, newTime);
+      expect(updatedRecord.energy, newEnergy);
+      expect(updatedRecord.metadata, newMetadata);
+      expect(updatedRecord.foodName, newFoodName);
+      expect(updatedRecord.mealType, newMealType);
+    });
+
+    test('equality works correctly', () {
+      final record1 = DietaryEnergyConsumedRecord(
+        time: now,
+        metadata: metadata,
+        energy: validEnergy,
+      );
+
+      final record2 = DietaryEnergyConsumedRecord(
+        time: now,
+        metadata: metadata,
+        energy: validEnergy,
+      );
+
+      final record3 = DietaryEnergyConsumedRecord(
+        time: now,
+        metadata: metadata,
+        energy: const Energy.kilocalories(300),
+      );
+
+      expect(record1 == record2, isTrue);
+      expect(record1.hashCode, equals(record2.hashCode));
+      expect(record1 == record3, isFalse);
+    });
+  });
+}

--- a/packages/health_connector_core/test/src/models/health_records/nutrition/dietary_fiber_record_test.dart
+++ b/packages/health_connector_core/test/src/models/health_records/nutrition/dietary_fiber_record_test.dart
@@ -1,0 +1,100 @@
+import 'package:health_connector_core/health_connector_core.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('DietaryFiberRecord (Macronutrient)', () {
+    final now = DateTime.now();
+    final metadata = Metadata.manualEntry();
+    const validMass = Mass.grams(25.0); // 25 g
+
+    test('can be instantiated with valid parameters', () {
+      final record = DietaryFiberRecord(
+        time: now,
+        metadata: metadata,
+        mass: validMass,
+        foodName: 'Oatmeal',
+        mealType: MealType.breakfast,
+      );
+
+      expect(record.time, now);
+      expect(record.metadata, metadata);
+      expect(record.mass, equals(validMass));
+    });
+
+    test('throws ArgumentError when mass is below minMass', () {
+      expect(
+        () => DietaryFiberRecord(
+          time: now,
+          metadata: metadata,
+          mass: const Mass.grams(-0.1),
+        ),
+        throwsArgumentError,
+      );
+    });
+
+    test('throws ArgumentError when mass is above maxMass', () {
+      expect(
+        () => DietaryFiberRecord(
+          time: now,
+          metadata: metadata,
+          mass: const Mass.grams(1000.1),
+        ),
+        throwsArgumentError,
+      );
+    });
+
+    test('copyWith updates all fields correctly', () {
+      final record = DietaryFiberRecord(
+        time: now,
+        metadata: metadata,
+        mass: validMass,
+        foodName: 'Oatmeal',
+        mealType: MealType.breakfast,
+      );
+
+      const newMass = Mass.grams(30.0); // 30 g
+      final newTime = now.add(const Duration(minutes: 5));
+      final newMetadata = Metadata.manualEntry();
+      const newFoodName = 'Beans';
+      const newMealType = MealType.lunch;
+
+      final updatedRecord = record.copyWith(
+        mass: newMass,
+        time: newTime,
+        metadata: newMetadata,
+        foodName: newFoodName,
+        mealType: newMealType,
+      );
+
+      expect(updatedRecord.mass, newMass);
+      expect(updatedRecord.time, newTime);
+      expect(updatedRecord.metadata, newMetadata);
+      expect(updatedRecord.foodName, newFoodName);
+      expect(updatedRecord.mealType, newMealType);
+    });
+
+    test('equality works correctly', () {
+      final record1 = DietaryFiberRecord(
+        time: now,
+        metadata: metadata,
+        mass: validMass,
+      );
+
+      final record2 = DietaryFiberRecord(
+        time: now,
+        metadata: metadata,
+        mass: validMass,
+      );
+
+      final record3 = DietaryFiberRecord(
+        time: now,
+        metadata: metadata,
+        mass: const Mass.grams(28.0),
+      );
+
+      expect(record1 == record2, isTrue);
+      expect(record1 == record3, isFalse);
+      expect(record1.hashCode == record2.hashCode, isTrue);
+    });
+  });
+}

--- a/packages/health_connector_core/test/src/models/health_records/nutrition/dietary_folate_record_test.dart
+++ b/packages/health_connector_core/test/src/models/health_records/nutrition/dietary_folate_record_test.dart
@@ -1,0 +1,100 @@
+import 'package:health_connector_core/health_connector_core.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('DietaryFolateRecord (Vitamin)', () {
+    final now = DateTime.now();
+    final metadata = Metadata.manualEntry();
+    const validMass = Mass.grams(0.0004); // 400 mcg
+
+    test('can be instantiated with valid parameters', () {
+      final record = DietaryFolateRecord(
+        time: now,
+        metadata: metadata,
+        mass: validMass,
+        foodName: 'Spinach',
+        mealType: MealType.lunch,
+      );
+
+      expect(record.time, now);
+      expect(record.metadata, metadata);
+      expect(record.mass, equals(validMass));
+    });
+
+    test('throws ArgumentError when mass is below minMass', () {
+      expect(
+        () => DietaryFolateRecord(
+          time: now,
+          metadata: metadata,
+          mass: const Mass.grams(-0.1),
+        ),
+        throwsArgumentError,
+      );
+    });
+
+    test('throws ArgumentError when mass is above maxMass', () {
+      expect(
+        () => DietaryFolateRecord(
+          time: now,
+          metadata: metadata,
+          mass: const Mass.grams(10.1),
+        ),
+        throwsArgumentError,
+      );
+    });
+
+    test('copyWith updates all fields correctly', () {
+      final record = DietaryFolateRecord(
+        time: now,
+        metadata: metadata,
+        mass: validMass,
+        foodName: 'Spinach',
+        mealType: MealType.lunch,
+      );
+
+      const newMass = Mass.grams(0.0002); // 200 mcg
+      final newTime = now.add(const Duration(minutes: 5));
+      final newMetadata = Metadata.manualEntry();
+      const newFoodName = 'Broccoli';
+      const newMealType = MealType.dinner;
+
+      final updatedRecord = record.copyWith(
+        mass: newMass,
+        time: newTime,
+        metadata: newMetadata,
+        foodName: newFoodName,
+        mealType: newMealType,
+      );
+
+      expect(updatedRecord.mass, newMass);
+      expect(updatedRecord.time, newTime);
+      expect(updatedRecord.metadata, newMetadata);
+      expect(updatedRecord.foodName, newFoodName);
+      expect(updatedRecord.mealType, newMealType);
+    });
+
+    test('equality works correctly', () {
+      final record1 = DietaryFolateRecord(
+        time: now,
+        metadata: metadata,
+        mass: validMass,
+      );
+
+      final record2 = DietaryFolateRecord(
+        time: now,
+        metadata: metadata,
+        mass: validMass,
+      );
+
+      final record3 = DietaryFolateRecord(
+        time: now,
+        metadata: metadata,
+        mass: const Mass.grams(0.0006),
+      );
+
+      expect(record1 == record2, isTrue);
+      expect(record1 == record3, isFalse);
+      expect(record1.hashCode == record2.hashCode, isTrue);
+    });
+  });
+}

--- a/packages/health_connector_core/test/src/models/health_records/nutrition/dietary_iron_record_test.dart
+++ b/packages/health_connector_core/test/src/models/health_records/nutrition/dietary_iron_record_test.dart
@@ -1,0 +1,100 @@
+import 'package:health_connector_core/health_connector_core.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('DietaryIronRecord (Mineral)', () {
+    final now = DateTime.now();
+    final metadata = Metadata.manualEntry();
+    const validMass = Mass.grams(0.018); // 18 mg
+
+    test('can be instantiated with valid parameters', () {
+      final record = DietaryIronRecord(
+        time: now,
+        metadata: metadata,
+        mass: validMass,
+        foodName: 'Beef',
+        mealType: MealType.dinner,
+      );
+
+      expect(record.time, now);
+      expect(record.metadata, metadata);
+      expect(record.mass, equals(validMass));
+    });
+
+    test('throws ArgumentError when mass is below minMass', () {
+      expect(
+        () => DietaryIronRecord(
+          time: now,
+          metadata: metadata,
+          mass: const Mass.grams(-0.1),
+        ),
+        throwsArgumentError,
+      );
+    });
+
+    test('throws ArgumentError when mass is above maxMass', () {
+      expect(
+        () => DietaryIronRecord(
+          time: now,
+          metadata: metadata,
+          mass: const Mass.grams(100.1),
+        ),
+        throwsArgumentError,
+      );
+    });
+
+    test('copyWith updates all fields correctly', () {
+      final record = DietaryIronRecord(
+        time: now,
+        metadata: metadata,
+        mass: validMass,
+        foodName: 'Beef',
+        mealType: MealType.dinner,
+      );
+
+      const newMass = Mass.grams(0.008); // 8 mg
+      final newTime = now.add(const Duration(minutes: 5));
+      final newMetadata = Metadata.manualEntry();
+      const newFoodName = 'Spinach';
+      const newMealType = MealType.lunch;
+
+      final updatedRecord = record.copyWith(
+        mass: newMass,
+        time: newTime,
+        metadata: newMetadata,
+        foodName: newFoodName,
+        mealType: newMealType,
+      );
+
+      expect(updatedRecord.mass, newMass);
+      expect(updatedRecord.time, newTime);
+      expect(updatedRecord.metadata, newMetadata);
+      expect(updatedRecord.foodName, newFoodName);
+      expect(updatedRecord.mealType, newMealType);
+    });
+
+    test('equality works correctly', () {
+      final record1 = DietaryIronRecord(
+        time: now,
+        metadata: metadata,
+        mass: validMass,
+      );
+
+      final record2 = DietaryIronRecord(
+        time: now,
+        metadata: metadata,
+        mass: validMass,
+      );
+
+      final record3 = DietaryIronRecord(
+        time: now,
+        metadata: metadata,
+        mass: const Mass.grams(0.010),
+      );
+
+      expect(record1 == record2, isTrue);
+      expect(record1 == record3, isFalse);
+      expect(record1.hashCode == record2.hashCode, isTrue);
+    });
+  });
+}

--- a/packages/health_connector_core/test/src/models/health_records/nutrition/dietary_magnesium_record_test.dart
+++ b/packages/health_connector_core/test/src/models/health_records/nutrition/dietary_magnesium_record_test.dart
@@ -1,0 +1,100 @@
+import 'package:health_connector_core/health_connector_core.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('DietaryMagnesiumRecord (Mineral)', () {
+    final now = DateTime.now();
+    final metadata = Metadata.manualEntry();
+    const validMass = Mass.grams(0.4); // 400 mg
+
+    test('can be instantiated with valid parameters', () {
+      final record = DietaryMagnesiumRecord(
+        time: now,
+        metadata: metadata,
+        mass: validMass,
+        foodName: 'Almonds',
+        mealType: MealType.snack,
+      );
+
+      expect(record.time, now);
+      expect(record.metadata, metadata);
+      expect(record.mass, equals(validMass));
+    });
+
+    test('throws ArgumentError when mass is below minMass', () {
+      expect(
+        () => DietaryMagnesiumRecord(
+          time: now,
+          metadata: metadata,
+          mass: const Mass.grams(-0.1),
+        ),
+        throwsArgumentError,
+      );
+    });
+
+    test('throws ArgumentError when mass is above maxMass', () {
+      expect(
+        () => DietaryMagnesiumRecord(
+          time: now,
+          metadata: metadata,
+          mass: const Mass.grams(100.1),
+        ),
+        throwsArgumentError,
+      );
+    });
+
+    test('copyWith updates all fields correctly', () {
+      final record = DietaryMagnesiumRecord(
+        time: now,
+        metadata: metadata,
+        mass: validMass,
+        foodName: 'Almonds',
+        mealType: MealType.snack,
+      );
+
+      const newMass = Mass.grams(0.3); // 300 mg
+      final newTime = now.add(const Duration(minutes: 5));
+      final newMetadata = Metadata.manualEntry();
+      const newFoodName = 'Spinach';
+      const newMealType = MealType.lunch;
+
+      final updatedRecord = record.copyWith(
+        mass: newMass,
+        time: newTime,
+        metadata: newMetadata,
+        foodName: newFoodName,
+        mealType: newMealType,
+      );
+
+      expect(updatedRecord.mass, newMass);
+      expect(updatedRecord.time, newTime);
+      expect(updatedRecord.metadata, newMetadata);
+      expect(updatedRecord.foodName, newFoodName);
+      expect(updatedRecord.mealType, newMealType);
+    });
+
+    test('equality works correctly', () {
+      final record1 = DietaryMagnesiumRecord(
+        time: now,
+        metadata: metadata,
+        mass: validMass,
+      );
+
+      final record2 = DietaryMagnesiumRecord(
+        time: now,
+        metadata: metadata,
+        mass: validMass,
+      );
+
+      final record3 = DietaryMagnesiumRecord(
+        time: now,
+        metadata: metadata,
+        mass: const Mass.grams(0.5),
+      );
+
+      expect(record1 == record2, isTrue);
+      expect(record1 == record3, isFalse);
+      expect(record1.hashCode == record2.hashCode, isTrue);
+    });
+  });
+}

--- a/packages/health_connector_core/test/src/models/health_records/nutrition/dietary_manganese_record_test.dart
+++ b/packages/health_connector_core/test/src/models/health_records/nutrition/dietary_manganese_record_test.dart
@@ -1,0 +1,100 @@
+import 'package:health_connector_core/health_connector_core.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('DietaryManganeseRecord (Mineral)', () {
+    final now = DateTime.now();
+    final metadata = Metadata.manualEntry();
+    const validMass = Mass.grams(0.0023); // 2.3 mg
+
+    test('can be instantiated with valid parameters', () {
+      final record = DietaryManganeseRecord(
+        time: now,
+        metadata: metadata,
+        mass: validMass,
+        foodName: 'Pineapple',
+        mealType: MealType.snack,
+      );
+
+      expect(record.time, now);
+      expect(record.metadata, metadata);
+      expect(record.mass, equals(validMass));
+    });
+
+    test('throws ArgumentError when mass is below minMass', () {
+      expect(
+        () => DietaryManganeseRecord(
+          time: now,
+          metadata: metadata,
+          mass: const Mass.grams(-0.1),
+        ),
+        throwsArgumentError,
+      );
+    });
+
+    test('throws ArgumentError when mass is above maxMass', () {
+      expect(
+        () => DietaryManganeseRecord(
+          time: now,
+          metadata: metadata,
+          mass: const Mass.grams(100.1),
+        ),
+        throwsArgumentError,
+      );
+    });
+
+    test('copyWith updates all fields correctly', () {
+      final record = DietaryManganeseRecord(
+        time: now,
+        metadata: metadata,
+        mass: validMass,
+        foodName: 'Pineapple',
+        mealType: MealType.snack,
+      );
+
+      const newMass = Mass.grams(0.0018); // 1.8 mg
+      final newTime = now.add(const Duration(minutes: 5));
+      final newMetadata = Metadata.manualEntry();
+      const newFoodName = 'Oatmeal';
+      const newMealType = MealType.breakfast;
+
+      final updatedRecord = record.copyWith(
+        mass: newMass,
+        time: newTime,
+        metadata: newMetadata,
+        foodName: newFoodName,
+        mealType: newMealType,
+      );
+
+      expect(updatedRecord.mass, newMass);
+      expect(updatedRecord.time, newTime);
+      expect(updatedRecord.metadata, newMetadata);
+      expect(updatedRecord.foodName, newFoodName);
+      expect(updatedRecord.mealType, newMealType);
+    });
+
+    test('equality works correctly', () {
+      final record1 = DietaryManganeseRecord(
+        time: now,
+        metadata: metadata,
+        mass: validMass,
+      );
+
+      final record2 = DietaryManganeseRecord(
+        time: now,
+        metadata: metadata,
+        mass: validMass,
+      );
+
+      final record3 = DietaryManganeseRecord(
+        time: now,
+        metadata: metadata,
+        mass: const Mass.grams(0.0025),
+      );
+
+      expect(record1 == record2, isTrue);
+      expect(record1 == record3, isFalse);
+      expect(record1.hashCode == record2.hashCode, isTrue);
+    });
+  });
+}

--- a/packages/health_connector_core/test/src/models/health_records/nutrition/dietary_monounsaturated_fat_record_test.dart
+++ b/packages/health_connector_core/test/src/models/health_records/nutrition/dietary_monounsaturated_fat_record_test.dart
@@ -1,0 +1,100 @@
+import 'package:health_connector_core/health_connector_core.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('DietaryMonounsaturatedFatRecord (Macronutrient)', () {
+    final now = DateTime.now();
+    final metadata = Metadata.manualEntry();
+    const validMass = Mass.grams(15.0); // 15 g
+
+    test('can be instantiated with valid parameters', () {
+      final record = DietaryMonounsaturatedFatRecord(
+        time: now,
+        metadata: metadata,
+        mass: validMass,
+        foodName: 'Olive oil',
+        mealType: MealType.lunch,
+      );
+
+      expect(record.time, now);
+      expect(record.metadata, metadata);
+      expect(record.mass, equals(validMass));
+    });
+
+    test('throws ArgumentError when mass is below minMass', () {
+      expect(
+        () => DietaryMonounsaturatedFatRecord(
+          time: now,
+          metadata: metadata,
+          mass: const Mass.grams(-0.1),
+        ),
+        throwsArgumentError,
+      );
+    });
+
+    test('throws ArgumentError when mass is above maxMass', () {
+      expect(
+        () => DietaryMonounsaturatedFatRecord(
+          time: now,
+          metadata: metadata,
+          mass: const Mass.grams(1000.1),
+        ),
+        throwsArgumentError,
+      );
+    });
+
+    test('copyWith updates all fields correctly', () {
+      final record = DietaryMonounsaturatedFatRecord(
+        time: now,
+        metadata: metadata,
+        mass: validMass,
+        foodName: 'Olive oil',
+        mealType: MealType.lunch,
+      );
+
+      const newMass = Mass.grams(12.0); // 12 g
+      final newTime = now.add(const Duration(minutes: 5));
+      final newMetadata = Metadata.manualEntry();
+      const newFoodName = 'Avocado';
+      const newMealType = MealType.breakfast;
+
+      final updatedRecord = record.copyWith(
+        mass: newMass,
+        time: newTime,
+        metadata: newMetadata,
+        foodName: newFoodName,
+        mealType: newMealType,
+      );
+
+      expect(updatedRecord.mass, newMass);
+      expect(updatedRecord.time, newTime);
+      expect(updatedRecord.metadata, newMetadata);
+      expect(updatedRecord.foodName, newFoodName);
+      expect(updatedRecord.mealType, newMealType);
+    });
+
+    test('equality works correctly', () {
+      final record1 = DietaryMonounsaturatedFatRecord(
+        time: now,
+        metadata: metadata,
+        mass: validMass,
+      );
+
+      final record2 = DietaryMonounsaturatedFatRecord(
+        time: now,
+        metadata: metadata,
+        mass: validMass,
+      );
+
+      final record3 = DietaryMonounsaturatedFatRecord(
+        time: now,
+        metadata: metadata,
+        mass: const Mass.grams(18.0),
+      );
+
+      expect(record1 == record2, isTrue);
+      expect(record1 == record3, isFalse);
+      expect(record1.hashCode == record2.hashCode, isTrue);
+    });
+  });
+}

--- a/packages/health_connector_core/test/src/models/health_records/nutrition/dietary_niacin_record_test.dart
+++ b/packages/health_connector_core/test/src/models/health_records/nutrition/dietary_niacin_record_test.dart
@@ -1,0 +1,100 @@
+import 'package:health_connector_core/health_connector_core.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('DietaryNiacinRecord (Vitamin)', () {
+    final now = DateTime.now();
+    final metadata = Metadata.manualEntry();
+    const validMass = Mass.grams(0.016); // 16 mg
+
+    test('can be instantiated with valid parameters', () {
+      final record = DietaryNiacinRecord(
+        time: now,
+        metadata: metadata,
+        mass: validMass,
+        foodName: 'Chicken',
+        mealType: MealType.dinner,
+      );
+
+      expect(record.time, now);
+      expect(record.metadata, metadata);
+      expect(record.mass, equals(validMass));
+    });
+
+    test('throws ArgumentError when mass is below minMass', () {
+      expect(
+        () => DietaryNiacinRecord(
+          time: now,
+          metadata: metadata,
+          mass: const Mass.grams(-0.1),
+        ),
+        throwsArgumentError,
+      );
+    });
+
+    test('throws ArgumentError when mass is above maxMass', () {
+      expect(
+        () => DietaryNiacinRecord(
+          time: now,
+          metadata: metadata,
+          mass: const Mass.grams(10.1),
+        ),
+        throwsArgumentError,
+      );
+    });
+
+    test('copyWith updates all fields correctly', () {
+      final record = DietaryNiacinRecord(
+        time: now,
+        metadata: metadata,
+        mass: validMass,
+        foodName: 'Chicken',
+        mealType: MealType.dinner,
+      );
+
+      const newMass = Mass.grams(0.014); // 14 mg
+      final newTime = now.add(const Duration(minutes: 5));
+      final newMetadata = Metadata.manualEntry();
+      const newFoodName = 'Tuna';
+      const newMealType = MealType.lunch;
+
+      final updatedRecord = record.copyWith(
+        mass: newMass,
+        time: newTime,
+        metadata: newMetadata,
+        foodName: newFoodName,
+        mealType: newMealType,
+      );
+
+      expect(updatedRecord.mass, newMass);
+      expect(updatedRecord.time, newTime);
+      expect(updatedRecord.metadata, newMetadata);
+      expect(updatedRecord.foodName, newFoodName);
+      expect(updatedRecord.mealType, newMealType);
+    });
+
+    test('equality works correctly', () {
+      final record1 = DietaryNiacinRecord(
+        time: now,
+        metadata: metadata,
+        mass: validMass,
+      );
+
+      final record2 = DietaryNiacinRecord(
+        time: now,
+        metadata: metadata,
+        mass: validMass,
+      );
+
+      final record3 = DietaryNiacinRecord(
+        time: now,
+        metadata: metadata,
+        mass: const Mass.grams(0.020),
+      );
+
+      expect(record1 == record2, isTrue);
+      expect(record1 == record3, isFalse);
+      expect(record1.hashCode == record2.hashCode, isTrue);
+    });
+  });
+}

--- a/packages/health_connector_core/test/src/models/health_records/nutrition/dietary_pantothenic_acid_record_test.dart
+++ b/packages/health_connector_core/test/src/models/health_records/nutrition/dietary_pantothenic_acid_record_test.dart
@@ -1,0 +1,100 @@
+import 'package:health_connector_core/health_connector_core.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('DietaryPantothenicAcidRecord (Vitamin)', () {
+    final now = DateTime.now();
+    final metadata = Metadata.manualEntry();
+    const validMass = Mass.grams(0.005); // 5 mg
+
+    test('can be instantiated with valid parameters', () {
+      final record = DietaryPantothenicAcidRecord(
+        time: now,
+        metadata: metadata,
+        mass: validMass,
+        foodName: 'Mushrooms',
+        mealType: MealType.lunch,
+      );
+
+      expect(record.time, now);
+      expect(record.metadata, metadata);
+      expect(record.mass, equals(validMass));
+    });
+
+    test('throws ArgumentError when mass is below minMass', () {
+      expect(
+        () => DietaryPantothenicAcidRecord(
+          time: now,
+          metadata: metadata,
+          mass: const Mass.grams(-0.1),
+        ),
+        throwsArgumentError,
+      );
+    });
+
+    test('throws ArgumentError when mass is above maxMass', () {
+      expect(
+        () => DietaryPantothenicAcidRecord(
+          time: now,
+          metadata: metadata,
+          mass: const Mass.grams(10.1),
+        ),
+        throwsArgumentError,
+      );
+    });
+
+    test('copyWith updates all fields correctly', () {
+      final record = DietaryPantothenicAcidRecord(
+        time: now,
+        metadata: metadata,
+        mass: validMass,
+        foodName: 'Mushrooms',
+        mealType: MealType.lunch,
+      );
+
+      const newMass = Mass.grams(0.003); // 3 mg
+      final newTime = now.add(const Duration(minutes: 5));
+      final newMetadata = Metadata.manualEntry();
+      const newFoodName = 'Avocado';
+      const newMealType = MealType.breakfast;
+
+      final updatedRecord = record.copyWith(
+        mass: newMass,
+        time: newTime,
+        metadata: newMetadata,
+        foodName: newFoodName,
+        mealType: newMealType,
+      );
+
+      expect(updatedRecord.mass, newMass);
+      expect(updatedRecord.time, newTime);
+      expect(updatedRecord.metadata, newMetadata);
+      expect(updatedRecord.foodName, newFoodName);
+      expect(updatedRecord.mealType, newMealType);
+    });
+
+    test('equality works correctly', () {
+      final record1 = DietaryPantothenicAcidRecord(
+        time: now,
+        metadata: metadata,
+        mass: validMass,
+      );
+
+      final record2 = DietaryPantothenicAcidRecord(
+        time: now,
+        metadata: metadata,
+        mass: validMass,
+      );
+
+      final record3 = DietaryPantothenicAcidRecord(
+        time: now,
+        metadata: metadata,
+        mass: const Mass.grams(0.007),
+      );
+
+      expect(record1 == record2, isTrue);
+      expect(record1 == record3, isFalse);
+      expect(record1.hashCode == record2.hashCode, isTrue);
+    });
+  });
+}

--- a/packages/health_connector_core/test/src/models/health_records/nutrition/dietary_phosphorus_record_test.dart
+++ b/packages/health_connector_core/test/src/models/health_records/nutrition/dietary_phosphorus_record_test.dart
@@ -1,0 +1,100 @@
+import 'package:health_connector_core/health_connector_core.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('DietaryPhosphorusRecord (Mineral)', () {
+    final now = DateTime.now();
+    final metadata = Metadata.manualEntry();
+    const validMass = Mass.grams(0.7); // 700 mg
+
+    test('can be instantiated with valid parameters', () {
+      final record = DietaryPhosphorusRecord(
+        time: now,
+        metadata: metadata,
+        mass: validMass,
+        foodName: 'Salmon',
+        mealType: MealType.dinner,
+      );
+
+      expect(record.time, now);
+      expect(record.metadata, metadata);
+      expect(record.mass, equals(validMass));
+    });
+
+    test('throws ArgumentError when mass is below minMass', () {
+      expect(
+        () => DietaryPhosphorusRecord(
+          time: now,
+          metadata: metadata,
+          mass: const Mass.grams(-0.1),
+        ),
+        throwsArgumentError,
+      );
+    });
+
+    test('throws ArgumentError when mass is above maxMass', () {
+      expect(
+        () => DietaryPhosphorusRecord(
+          time: now,
+          metadata: metadata,
+          mass: const Mass.grams(100.1),
+        ),
+        throwsArgumentError,
+      );
+    });
+
+    test('copyWith updates all fields correctly', () {
+      final record = DietaryPhosphorusRecord(
+        time: now,
+        metadata: metadata,
+        mass: validMass,
+        foodName: 'Salmon',
+        mealType: MealType.dinner,
+      );
+
+      const newMass = Mass.grams(0.5); // 500 mg
+      final newTime = now.add(const Duration(minutes: 5));
+      final newMetadata = Metadata.manualEntry();
+      const newFoodName = 'Chicken';
+      const newMealType = MealType.lunch;
+
+      final updatedRecord = record.copyWith(
+        mass: newMass,
+        time: newTime,
+        metadata: newMetadata,
+        foodName: newFoodName,
+        mealType: newMealType,
+      );
+
+      expect(updatedRecord.mass, newMass);
+      expect(updatedRecord.time, newTime);
+      expect(updatedRecord.metadata, newMetadata);
+      expect(updatedRecord.foodName, newFoodName);
+      expect(updatedRecord.mealType, newMealType);
+    });
+
+    test('equality works correctly', () {
+      final record1 = DietaryPhosphorusRecord(
+        time: now,
+        metadata: metadata,
+        mass: validMass,
+      );
+
+      final record2 = DietaryPhosphorusRecord(
+        time: now,
+        metadata: metadata,
+        mass: validMass,
+      );
+
+      final record3 = DietaryPhosphorusRecord(
+        time: now,
+        metadata: metadata,
+        mass: const Mass.grams(0.8),
+      );
+
+      expect(record1 == record2, isTrue);
+      expect(record1 == record3, isFalse);
+      expect(record1.hashCode == record2.hashCode, isTrue);
+    });
+  });
+}

--- a/packages/health_connector_core/test/src/models/health_records/nutrition/dietary_polyunsaturated_fat_record_test.dart
+++ b/packages/health_connector_core/test/src/models/health_records/nutrition/dietary_polyunsaturated_fat_record_test.dart
@@ -1,0 +1,100 @@
+import 'package:health_connector_core/health_connector_core.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('DietaryPolyunsaturatedFatRecord (Macronutrient)', () {
+    final now = DateTime.now();
+    final metadata = Metadata.manualEntry();
+    const validMass = Mass.grams(12.0); // 12 g
+
+    test('can be instantiated with valid parameters', () {
+      final record = DietaryPolyunsaturatedFatRecord(
+        time: now,
+        metadata: metadata,
+        mass: validMass,
+        foodName: 'Salmon',
+        mealType: MealType.dinner,
+      );
+
+      expect(record.time, now);
+      expect(record.metadata, metadata);
+      expect(record.mass, equals(validMass));
+    });
+
+    test('throws ArgumentError when mass is below minMass', () {
+      expect(
+        () => DietaryPolyunsaturatedFatRecord(
+          time: now,
+          metadata: metadata,
+          mass: const Mass.grams(-0.1),
+        ),
+        throwsArgumentError,
+      );
+    });
+
+    test('throws ArgumentError when mass is above maxMass', () {
+      expect(
+        () => DietaryPolyunsaturatedFatRecord(
+          time: now,
+          metadata: metadata,
+          mass: const Mass.grams(1000.1),
+        ),
+        throwsArgumentError,
+      );
+    });
+
+    test('copyWith updates all fields correctly', () {
+      final record = DietaryPolyunsaturatedFatRecord(
+        time: now,
+        metadata: metadata,
+        mass: validMass,
+        foodName: 'Salmon',
+        mealType: MealType.dinner,
+      );
+
+      const newMass = Mass.grams(10.0); // 10 g
+      final newTime = now.add(const Duration(minutes: 5));
+      final newMetadata = Metadata.manualEntry();
+      const newFoodName = 'Walnuts';
+      const newMealType = MealType.snack;
+
+      final updatedRecord = record.copyWith(
+        mass: newMass,
+        time: newTime,
+        metadata: newMetadata,
+        foodName: newFoodName,
+        mealType: newMealType,
+      );
+
+      expect(updatedRecord.mass, newMass);
+      expect(updatedRecord.time, newTime);
+      expect(updatedRecord.metadata, newMetadata);
+      expect(updatedRecord.foodName, newFoodName);
+      expect(updatedRecord.mealType, newMealType);
+    });
+
+    test('equality works correctly', () {
+      final record1 = DietaryPolyunsaturatedFatRecord(
+        time: now,
+        metadata: metadata,
+        mass: validMass,
+      );
+
+      final record2 = DietaryPolyunsaturatedFatRecord(
+        time: now,
+        metadata: metadata,
+        mass: validMass,
+      );
+
+      final record3 = DietaryPolyunsaturatedFatRecord(
+        time: now,
+        metadata: metadata,
+        mass: const Mass.grams(15.0),
+      );
+
+      expect(record1 == record2, isTrue);
+      expect(record1 == record3, isFalse);
+      expect(record1.hashCode == record2.hashCode, isTrue);
+    });
+  });
+}

--- a/packages/health_connector_core/test/src/models/health_records/nutrition/dietary_potassium_record_test.dart
+++ b/packages/health_connector_core/test/src/models/health_records/nutrition/dietary_potassium_record_test.dart
@@ -1,0 +1,100 @@
+import 'package:health_connector_core/health_connector_core.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('DietaryPotassiumRecord (Mineral)', () {
+    final now = DateTime.now();
+    final metadata = Metadata.manualEntry();
+    const validMass = Mass.grams(3.5); // 3500 mg
+
+    test('can be instantiated with valid parameters', () {
+      final record = DietaryPotassiumRecord(
+        time: now,
+        metadata: metadata,
+        mass: validMass,
+        foodName: 'Banana',
+        mealType: MealType.snack,
+      );
+
+      expect(record.time, now);
+      expect(record.metadata, metadata);
+      expect(record.mass, equals(validMass));
+    });
+
+    test('throws ArgumentError when mass is below minMass', () {
+      expect(
+        () => DietaryPotassiumRecord(
+          time: now,
+          metadata: metadata,
+          mass: const Mass.grams(-0.1),
+        ),
+        throwsArgumentError,
+      );
+    });
+
+    test('throws ArgumentError when mass is above maxMass', () {
+      expect(
+        () => DietaryPotassiumRecord(
+          time: now,
+          metadata: metadata,
+          mass: const Mass.grams(100.1),
+        ),
+        throwsArgumentError,
+      );
+    });
+
+    test('copyWith updates all fields correctly', () {
+      final record = DietaryPotassiumRecord(
+        time: now,
+        metadata: metadata,
+        mass: validMass,
+        foodName: 'Banana',
+        mealType: MealType.snack,
+      );
+
+      const newMass = Mass.grams(2.6); // 2600 mg
+      final newTime = now.add(const Duration(minutes: 5));
+      final newMetadata = Metadata.manualEntry();
+      const newFoodName = 'Sweet potato';
+      const newMealType = MealType.dinner;
+
+      final updatedRecord = record.copyWith(
+        mass: newMass,
+        time: newTime,
+        metadata: newMetadata,
+        foodName: newFoodName,
+        mealType: newMealType,
+      );
+
+      expect(updatedRecord.mass, newMass);
+      expect(updatedRecord.time, newTime);
+      expect(updatedRecord.metadata, newMetadata);
+      expect(updatedRecord.foodName, newFoodName);
+      expect(updatedRecord.mealType, newMealType);
+    });
+
+    test('equality works correctly', () {
+      final record1 = DietaryPotassiumRecord(
+        time: now,
+        metadata: metadata,
+        mass: validMass,
+      );
+
+      final record2 = DietaryPotassiumRecord(
+        time: now,
+        metadata: metadata,
+        mass: validMass,
+      );
+
+      final record3 = DietaryPotassiumRecord(
+        time: now,
+        metadata: metadata,
+        mass: const Mass.grams(4.0),
+      );
+
+      expect(record1 == record2, isTrue);
+      expect(record1 == record3, isFalse);
+      expect(record1.hashCode == record2.hashCode, isTrue);
+    });
+  });
+}

--- a/packages/health_connector_core/test/src/models/health_records/nutrition/dietary_protein_record_test.dart
+++ b/packages/health_connector_core/test/src/models/health_records/nutrition/dietary_protein_record_test.dart
@@ -1,0 +1,102 @@
+import 'package:health_connector_core/health_connector_core.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('DietaryProteinRecord (Macronutrient)', () {
+    final now = DateTime(2026, 1, 11);
+    final metadata = Metadata.manualEntry();
+    const validMass = Mass.grams(30);
+
+    test('can be instantiated with valid parameters', () {
+      final record = DietaryProteinRecord(
+        time: now,
+        metadata: metadata,
+        mass: validMass,
+        foodName: 'Steak',
+        mealType: MealType.dinner,
+      );
+
+      expect(record.time, now);
+      expect(record.metadata, metadata);
+      expect(record.mass, equals(validMass));
+      expect(record.foodName, 'Steak');
+      expect(record.mealType, MealType.dinner);
+    });
+
+    test('throws ArgumentError when mass is below minMass', () {
+      expect(
+        () => DietaryProteinRecord(
+          time: now,
+          metadata: metadata,
+          mass: const Mass.grams(-1),
+        ),
+        throwsArgumentError,
+      );
+    });
+
+    test('throws ArgumentError when mass is above maxMass', () {
+      expect(
+        () => DietaryProteinRecord(
+          time: now,
+          metadata: metadata,
+          mass: const Mass.grams(1001),
+        ),
+        throwsArgumentError,
+      );
+    });
+
+    test('copyWith updates all fields correctly', () {
+      final record = DietaryProteinRecord(
+        time: now,
+        metadata: metadata,
+        mass: validMass,
+        foodName: 'Steak',
+        mealType: MealType.dinner,
+      );
+
+      const newMass = Mass.grams(40);
+      final newTime = now.add(const Duration(minutes: 5));
+      final newMetadata = Metadata.manualEntry();
+      const newFoodName = 'Chicken';
+      const newMealType = MealType.lunch;
+
+      final updatedRecord = record.copyWith(
+        mass: newMass,
+        time: newTime,
+        metadata: newMetadata,
+        foodName: newFoodName,
+        mealType: newMealType,
+      );
+
+      expect(updatedRecord.mass, newMass);
+      expect(updatedRecord.time, newTime);
+      expect(updatedRecord.metadata, newMetadata);
+      expect(updatedRecord.foodName, newFoodName);
+      expect(updatedRecord.mealType, newMealType);
+    });
+
+    test('equality works correctly', () {
+      final record1 = DietaryProteinRecord(
+        time: now,
+        metadata: metadata,
+        mass: validMass,
+      );
+
+      final record2 = DietaryProteinRecord(
+        time: now,
+        metadata: metadata,
+        mass: validMass,
+      );
+
+      final record3 = DietaryProteinRecord(
+        time: now,
+        metadata: metadata,
+        mass: const Mass.grams(40),
+      );
+
+      expect(record1 == record2, isTrue);
+      expect(record1.hashCode, equals(record2.hashCode));
+      expect(record1 == record3, isFalse);
+    });
+  });
+}

--- a/packages/health_connector_core/test/src/models/health_records/nutrition/dietary_riboflavin_record_test.dart
+++ b/packages/health_connector_core/test/src/models/health_records/nutrition/dietary_riboflavin_record_test.dart
@@ -1,0 +1,100 @@
+import 'package:health_connector_core/health_connector_core.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('DietaryRiboflavinRecord (Vitamin)', () {
+    final now = DateTime.now();
+    final metadata = Metadata.manualEntry();
+    const validMass = Mass.grams(0.0013); // 1.3 mg
+
+    test('can be instantiated with valid parameters', () {
+      final record = DietaryRiboflavinRecord(
+        time: now,
+        metadata: metadata,
+        mass: validMass,
+        foodName: 'Milk',
+        mealType: MealType.breakfast,
+      );
+
+      expect(record.time, now);
+      expect(record.metadata, metadata);
+      expect(record.mass, equals(validMass));
+    });
+
+    test('throws ArgumentError when mass is below minMass', () {
+      expect(
+        () => DietaryRiboflavinRecord(
+          time: now,
+          metadata: metadata,
+          mass: const Mass.grams(-0.1),
+        ),
+        throwsArgumentError,
+      );
+    });
+
+    test('throws ArgumentError when mass is above maxMass', () {
+      expect(
+        () => DietaryRiboflavinRecord(
+          time: now,
+          metadata: metadata,
+          mass: const Mass.grams(10.1),
+        ),
+        throwsArgumentError,
+      );
+    });
+
+    test('copyWith updates all fields correctly', () {
+      final record = DietaryRiboflavinRecord(
+        time: now,
+        metadata: metadata,
+        mass: validMass,
+        foodName: 'Milk',
+        mealType: MealType.breakfast,
+      );
+
+      const newMass = Mass.grams(0.0011); // 1.1 mg
+      final newTime = now.add(const Duration(minutes: 5));
+      final newMetadata = Metadata.manualEntry();
+      const newFoodName = 'Yogurt';
+      const newMealType = MealType.snack;
+
+      final updatedRecord = record.copyWith(
+        mass: newMass,
+        time: newTime,
+        metadata: newMetadata,
+        foodName: newFoodName,
+        mealType: newMealType,
+      );
+
+      expect(updatedRecord.mass, newMass);
+      expect(updatedRecord.time, newTime);
+      expect(updatedRecord.metadata, newMetadata);
+      expect(updatedRecord.foodName, newFoodName);
+      expect(updatedRecord.mealType, newMealType);
+    });
+
+    test('equality works correctly', () {
+      final record1 = DietaryRiboflavinRecord(
+        time: now,
+        metadata: metadata,
+        mass: validMass,
+      );
+
+      final record2 = DietaryRiboflavinRecord(
+        time: now,
+        metadata: metadata,
+        mass: validMass,
+      );
+
+      final record3 = DietaryRiboflavinRecord(
+        time: now,
+        metadata: metadata,
+        mass: const Mass.grams(0.0015),
+      );
+
+      expect(record1 == record2, isTrue);
+      expect(record1 == record3, isFalse);
+      expect(record1.hashCode == record2.hashCode, isTrue);
+    });
+  });
+}

--- a/packages/health_connector_core/test/src/models/health_records/nutrition/dietary_saturated_fat_record_test.dart
+++ b/packages/health_connector_core/test/src/models/health_records/nutrition/dietary_saturated_fat_record_test.dart
@@ -1,0 +1,100 @@
+import 'package:health_connector_core/health_connector_core.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('DietarySaturatedFatRecord (Macronutrient)', () {
+    final now = DateTime.now();
+    final metadata = Metadata.manualEntry();
+    const validMass = Mass.grams(20.0); // 20 g
+
+    test('can be instantiated with valid parameters', () {
+      final record = DietarySaturatedFatRecord(
+        time: now,
+        metadata: metadata,
+        mass: validMass,
+        foodName: 'Butter',
+        mealType: MealType.breakfast,
+      );
+
+      expect(record.time, now);
+      expect(record.metadata, metadata);
+      expect(record.mass, equals(validMass));
+    });
+
+    test('throws ArgumentError when mass is below minMass', () {
+      expect(
+        () => DietarySaturatedFatRecord(
+          time: now,
+          metadata: metadata,
+          mass: const Mass.grams(-0.1),
+        ),
+        throwsArgumentError,
+      );
+    });
+
+    test('throws ArgumentError when mass is above maxMass', () {
+      expect(
+        () => DietarySaturatedFatRecord(
+          time: now,
+          metadata: metadata,
+          mass: const Mass.grams(1000.1),
+        ),
+        throwsArgumentError,
+      );
+    });
+
+    test('copyWith updates all fields correctly', () {
+      final record = DietarySaturatedFatRecord(
+        time: now,
+        metadata: metadata,
+        mass: validMass,
+        foodName: 'Butter',
+        mealType: MealType.breakfast,
+      );
+
+      const newMass = Mass.grams(15.0); // 15 g
+      final newTime = now.add(const Duration(minutes: 5));
+      final newMetadata = Metadata.manualEntry();
+      const newFoodName = 'Cheese';
+      const newMealType = MealType.lunch;
+
+      final updatedRecord = record.copyWith(
+        mass: newMass,
+        time: newTime,
+        metadata: newMetadata,
+        foodName: newFoodName,
+        mealType: newMealType,
+      );
+
+      expect(updatedRecord.mass, newMass);
+      expect(updatedRecord.time, newTime);
+      expect(updatedRecord.metadata, newMetadata);
+      expect(updatedRecord.foodName, newFoodName);
+      expect(updatedRecord.mealType, newMealType);
+    });
+
+    test('equality works correctly', () {
+      final record1 = DietarySaturatedFatRecord(
+        time: now,
+        metadata: metadata,
+        mass: validMass,
+      );
+
+      final record2 = DietarySaturatedFatRecord(
+        time: now,
+        metadata: metadata,
+        mass: validMass,
+      );
+
+      final record3 = DietarySaturatedFatRecord(
+        time: now,
+        metadata: metadata,
+        mass: const Mass.grams(25.0),
+      );
+
+      expect(record1 == record2, isTrue);
+      expect(record1 == record3, isFalse);
+      expect(record1.hashCode == record2.hashCode, isTrue);
+    });
+  });
+}

--- a/packages/health_connector_core/test/src/models/health_records/nutrition/dietary_selenium_record_test.dart
+++ b/packages/health_connector_core/test/src/models/health_records/nutrition/dietary_selenium_record_test.dart
@@ -1,0 +1,100 @@
+import 'package:health_connector_core/health_connector_core.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('DietarySeleniumRecord (Mineral)', () {
+    final now = DateTime.now();
+    final metadata = Metadata.manualEntry();
+    const validMass = Mass.grams(0.000055); // 55 mcg
+
+    test('can be instantiated with valid parameters', () {
+      final record = DietarySeleniumRecord(
+        time: now,
+        metadata: metadata,
+        mass: validMass,
+        foodName: 'Brazil nuts',
+        mealType: MealType.snack,
+      );
+
+      expect(record.time, now);
+      expect(record.metadata, metadata);
+      expect(record.mass, equals(validMass));
+    });
+
+    test('throws ArgumentError when mass is below minMass', () {
+      expect(
+        () => DietarySeleniumRecord(
+          time: now,
+          metadata: metadata,
+          mass: const Mass.grams(-0.1),
+        ),
+        throwsArgumentError,
+      );
+    });
+
+    test('throws ArgumentError when mass is above maxMass', () {
+      expect(
+        () => DietarySeleniumRecord(
+          time: now,
+          metadata: metadata,
+          mass: const Mass.grams(100.1),
+        ),
+        throwsArgumentError,
+      );
+    });
+
+    test('copyWith updates all fields correctly', () {
+      final record = DietarySeleniumRecord(
+        time: now,
+        metadata: metadata,
+        mass: validMass,
+        foodName: 'Brazil nuts',
+        mealType: MealType.snack,
+      );
+
+      const newMass = Mass.grams(0.000035); // 35 mcg
+      final newTime = now.add(const Duration(minutes: 5));
+      final newMetadata = Metadata.manualEntry();
+      const newFoodName = 'Tuna';
+      const newMealType = MealType.lunch;
+
+      final updatedRecord = record.copyWith(
+        mass: newMass,
+        time: newTime,
+        metadata: newMetadata,
+        foodName: newFoodName,
+        mealType: newMealType,
+      );
+
+      expect(updatedRecord.mass, newMass);
+      expect(updatedRecord.time, newTime);
+      expect(updatedRecord.metadata, newMetadata);
+      expect(updatedRecord.foodName, newFoodName);
+      expect(updatedRecord.mealType, newMealType);
+    });
+
+    test('equality works correctly', () {
+      final record1 = DietarySeleniumRecord(
+        time: now,
+        metadata: metadata,
+        mass: validMass,
+      );
+
+      final record2 = DietarySeleniumRecord(
+        time: now,
+        metadata: metadata,
+        mass: validMass,
+      );
+
+      final record3 = DietarySeleniumRecord(
+        time: now,
+        metadata: metadata,
+        mass: const Mass.grams(0.000070),
+      );
+
+      expect(record1 == record2, isTrue);
+      expect(record1 == record3, isFalse);
+      expect(record1.hashCode == record2.hashCode, isTrue);
+    });
+  });
+}

--- a/packages/health_connector_core/test/src/models/health_records/nutrition/dietary_sodium_record_test.dart
+++ b/packages/health_connector_core/test/src/models/health_records/nutrition/dietary_sodium_record_test.dart
@@ -1,0 +1,100 @@
+import 'package:health_connector_core/health_connector_core.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('DietarySodiumRecord (Mineral)', () {
+    final now = DateTime.now();
+    final metadata = Metadata.manualEntry();
+    const validMass = Mass.grams(2.3); // 2300 mg
+
+    test('can be instantiated with valid parameters', () {
+      final record = DietarySodiumRecord(
+        time: now,
+        metadata: metadata,
+        mass: validMass,
+        foodName: 'Canned soup',
+        mealType: MealType.lunch,
+      );
+
+      expect(record.time, now);
+      expect(record.metadata, metadata);
+      expect(record.mass, equals(validMass));
+    });
+
+    test('throws ArgumentError when mass is below minMass', () {
+      expect(
+        () => DietarySodiumRecord(
+          time: now,
+          metadata: metadata,
+          mass: const Mass.grams(-0.1),
+        ),
+        throwsArgumentError,
+      );
+    });
+
+    test('throws ArgumentError when mass is above maxMass', () {
+      expect(
+        () => DietarySodiumRecord(
+          time: now,
+          metadata: metadata,
+          mass: const Mass.grams(100.1),
+        ),
+        throwsArgumentError,
+      );
+    });
+
+    test('copyWith updates all fields correctly', () {
+      final record = DietarySodiumRecord(
+        time: now,
+        metadata: metadata,
+        mass: validMass,
+        foodName: 'Canned soup',
+        mealType: MealType.lunch,
+      );
+
+      const newMass = Mass.grams(1.5); // 1500 mg
+      final newTime = now.add(const Duration(minutes: 5));
+      final newMetadata = Metadata.manualEntry();
+      const newFoodName = 'Bread';
+      const newMealType = MealType.breakfast;
+
+      final updatedRecord = record.copyWith(
+        mass: newMass,
+        time: newTime,
+        metadata: newMetadata,
+        foodName: newFoodName,
+        mealType: newMealType,
+      );
+
+      expect(updatedRecord.mass, newMass);
+      expect(updatedRecord.time, newTime);
+      expect(updatedRecord.metadata, newMetadata);
+      expect(updatedRecord.foodName, newFoodName);
+      expect(updatedRecord.mealType, newMealType);
+    });
+
+    test('equality works correctly', () {
+      final record1 = DietarySodiumRecord(
+        time: now,
+        metadata: metadata,
+        mass: validMass,
+      );
+
+      final record2 = DietarySodiumRecord(
+        time: now,
+        metadata: metadata,
+        mass: validMass,
+      );
+
+      final record3 = DietarySodiumRecord(
+        time: now,
+        metadata: metadata,
+        mass: const Mass.grams(3.0),
+      );
+
+      expect(record1 == record2, isTrue);
+      expect(record1 == record3, isFalse);
+      expect(record1.hashCode == record2.hashCode, isTrue);
+    });
+  });
+}

--- a/packages/health_connector_core/test/src/models/health_records/nutrition/dietary_sugar_record_test.dart
+++ b/packages/health_connector_core/test/src/models/health_records/nutrition/dietary_sugar_record_test.dart
@@ -1,0 +1,100 @@
+import 'package:health_connector_core/health_connector_core.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('DietarySugarRecord (Macronutrient)', () {
+    final now = DateTime.now();
+    final metadata = Metadata.manualEntry();
+    const validMass = Mass.grams(50.0); // 50 g
+
+    test('can be instantiated with valid parameters', () {
+      final record = DietarySugarRecord(
+        time: now,
+        metadata: metadata,
+        mass: validMass,
+        foodName: 'Soda',
+        mealType: MealType.snack,
+      );
+
+      expect(record.time, now);
+      expect(record.metadata, metadata);
+      expect(record.mass, equals(validMass));
+    });
+
+    test('throws ArgumentError when mass is below minMass', () {
+      expect(
+        () => DietarySugarRecord(
+          time: now,
+          metadata: metadata,
+          mass: const Mass.grams(-0.1),
+        ),
+        throwsArgumentError,
+      );
+    });
+
+    test('throws ArgumentError when mass is above maxMass', () {
+      expect(
+        () => DietarySugarRecord(
+          time: now,
+          metadata: metadata,
+          mass: const Mass.grams(1000.1),
+        ),
+        throwsArgumentError,
+      );
+    });
+
+    test('copyWith updates all fields correctly', () {
+      final record = DietarySugarRecord(
+        time: now,
+        metadata: metadata,
+        mass: validMass,
+        foodName: 'Soda',
+        mealType: MealType.snack,
+      );
+
+      const newMass = Mass.grams(25.0); // 25 g
+      final newTime = now.add(const Duration(minutes: 5));
+      final newMetadata = Metadata.manualEntry();
+      const newFoodName = 'Apple';
+      const newMealType = MealType.breakfast;
+
+      final updatedRecord = record.copyWith(
+        mass: newMass,
+        time: newTime,
+        metadata: newMetadata,
+        foodName: newFoodName,
+        mealType: newMealType,
+      );
+
+      expect(updatedRecord.mass, newMass);
+      expect(updatedRecord.time, newTime);
+      expect(updatedRecord.metadata, newMetadata);
+      expect(updatedRecord.foodName, newFoodName);
+      expect(updatedRecord.mealType, newMealType);
+    });
+
+    test('equality works correctly', () {
+      final record1 = DietarySugarRecord(
+        time: now,
+        metadata: metadata,
+        mass: validMass,
+      );
+
+      final record2 = DietarySugarRecord(
+        time: now,
+        metadata: metadata,
+        mass: validMass,
+      );
+
+      final record3 = DietarySugarRecord(
+        time: now,
+        metadata: metadata,
+        mass: const Mass.grams(30.0),
+      );
+
+      expect(record1 == record2, isTrue);
+      expect(record1 == record3, isFalse);
+      expect(record1.hashCode == record2.hashCode, isTrue);
+    });
+  });
+}

--- a/packages/health_connector_core/test/src/models/health_records/nutrition/dietary_thiamin_record_test.dart
+++ b/packages/health_connector_core/test/src/models/health_records/nutrition/dietary_thiamin_record_test.dart
@@ -1,0 +1,100 @@
+import 'package:health_connector_core/health_connector_core.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('DietaryThiaminRecord (Vitamin)', () {
+    final now = DateTime.now();
+    final metadata = Metadata.manualEntry();
+    const validMass = Mass.grams(0.0012); // 1.2 mg
+
+    test('can be instantiated with valid parameters', () {
+      final record = DietaryThiaminRecord(
+        time: now,
+        metadata: metadata,
+        mass: validMass,
+        foodName: 'Pork',
+        mealType: MealType.dinner,
+      );
+
+      expect(record.time, now);
+      expect(record.metadata, metadata);
+      expect(record.mass, equals(validMass));
+    });
+
+    test('throws ArgumentError when mass is below minMass', () {
+      expect(
+        () => DietaryThiaminRecord(
+          time: now,
+          metadata: metadata,
+          mass: const Mass.grams(-0.1),
+        ),
+        throwsArgumentError,
+      );
+    });
+
+    test('throws ArgumentError when mass is above maxMass', () {
+      expect(
+        () => DietaryThiaminRecord(
+          time: now,
+          metadata: metadata,
+          mass: const Mass.grams(10.1),
+        ),
+        throwsArgumentError,
+      );
+    });
+
+    test('copyWith updates all fields correctly', () {
+      final record = DietaryThiaminRecord(
+        time: now,
+        metadata: metadata,
+        mass: validMass,
+        foodName: 'Pork',
+        mealType: MealType.dinner,
+      );
+
+      const newMass = Mass.grams(0.0010); // 1.0 mg
+      final newTime = now.add(const Duration(minutes: 5));
+      final newMetadata = Metadata.manualEntry();
+      const newFoodName = 'Whole wheat bread';
+      const newMealType = MealType.breakfast;
+
+      final updatedRecord = record.copyWith(
+        mass: newMass,
+        time: newTime,
+        metadata: newMetadata,
+        foodName: newFoodName,
+        mealType: newMealType,
+      );
+
+      expect(updatedRecord.mass, newMass);
+      expect(updatedRecord.time, newTime);
+      expect(updatedRecord.metadata, newMetadata);
+      expect(updatedRecord.foodName, newFoodName);
+      expect(updatedRecord.mealType, newMealType);
+    });
+
+    test('equality works correctly', () {
+      final record1 = DietaryThiaminRecord(
+        time: now,
+        metadata: metadata,
+        mass: validMass,
+      );
+
+      final record2 = DietaryThiaminRecord(
+        time: now,
+        metadata: metadata,
+        mass: validMass,
+      );
+
+      final record3 = DietaryThiaminRecord(
+        time: now,
+        metadata: metadata,
+        mass: const Mass.grams(0.0014),
+      );
+
+      expect(record1 == record2, isTrue);
+      expect(record1 == record3, isFalse);
+      expect(record1.hashCode == record2.hashCode, isTrue);
+    });
+  });
+}

--- a/packages/health_connector_core/test/src/models/health_records/nutrition/dietary_total_carbohydrate_record_test.dart
+++ b/packages/health_connector_core/test/src/models/health_records/nutrition/dietary_total_carbohydrate_record_test.dart
@@ -1,0 +1,100 @@
+import 'package:health_connector_core/health_connector_core.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('DietaryTotalCarbohydrateRecord (Macronutrient)', () {
+    final now = DateTime.now();
+    final metadata = Metadata.manualEntry();
+    const validMass = Mass.grams(250.0); // 250 g
+
+    test('can be instantiated with valid parameters', () {
+      final record = DietaryTotalCarbohydrateRecord(
+        time: now,
+        metadata: metadata,
+        mass: validMass,
+        foodName: 'Pasta',
+        mealType: MealType.dinner,
+      );
+
+      expect(record.time, now);
+      expect(record.metadata, metadata);
+      expect(record.mass, equals(validMass));
+    });
+
+    test('throws ArgumentError when mass is below minMass', () {
+      expect(
+        () => DietaryTotalCarbohydrateRecord(
+          time: now,
+          metadata: metadata,
+          mass: const Mass.grams(-0.1),
+        ),
+        throwsArgumentError,
+      );
+    });
+
+    test('throws ArgumentError when mass is above maxMass', () {
+      expect(
+        () => DietaryTotalCarbohydrateRecord(
+          time: now,
+          metadata: metadata,
+          mass: const Mass.grams(1000.1),
+        ),
+        throwsArgumentError,
+      );
+    });
+
+    test('copyWith updates all fields correctly', () {
+      final record = DietaryTotalCarbohydrateRecord(
+        time: now,
+        metadata: metadata,
+        mass: validMass,
+        foodName: 'Pasta',
+        mealType: MealType.dinner,
+      );
+
+      const newMass = Mass.grams(200.0); // 200 g
+      final newTime = now.add(const Duration(minutes: 5));
+      final newMetadata = Metadata.manualEntry();
+      const newFoodName = 'Rice';
+      const newMealType = MealType.lunch;
+
+      final updatedRecord = record.copyWith(
+        mass: newMass,
+        time: newTime,
+        metadata: newMetadata,
+        foodName: newFoodName,
+        mealType: newMealType,
+      );
+
+      expect(updatedRecord.mass, newMass);
+      expect(updatedRecord.time, newTime);
+      expect(updatedRecord.metadata, newMetadata);
+      expect(updatedRecord.foodName, newFoodName);
+      expect(updatedRecord.mealType, newMealType);
+    });
+
+    test('equality works correctly', () {
+      final record1 = DietaryTotalCarbohydrateRecord(
+        time: now,
+        metadata: metadata,
+        mass: validMass,
+      );
+
+      final record2 = DietaryTotalCarbohydrateRecord(
+        time: now,
+        metadata: metadata,
+        mass: validMass,
+      );
+
+      final record3 = DietaryTotalCarbohydrateRecord(
+        time: now,
+        metadata: metadata,
+        mass: const Mass.grams(300.0),
+      );
+
+      expect(record1 == record2, isTrue);
+      expect(record1 == record3, isFalse);
+      expect(record1.hashCode == record2.hashCode, isTrue);
+    });
+  });
+}

--- a/packages/health_connector_core/test/src/models/health_records/nutrition/dietary_total_fat_record_test.dart
+++ b/packages/health_connector_core/test/src/models/health_records/nutrition/dietary_total_fat_record_test.dart
@@ -1,0 +1,100 @@
+import 'package:health_connector_core/health_connector_core.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('DietaryTotalFatRecord (Macronutrient)', () {
+    final now = DateTime.now();
+    final metadata = Metadata.manualEntry();
+    const validMass = Mass.grams(65.0); // 65 g
+
+    test('can be instantiated with valid parameters', () {
+      final record = DietaryTotalFatRecord(
+        time: now,
+        metadata: metadata,
+        mass: validMass,
+        foodName: 'Nuts',
+        mealType: MealType.snack,
+      );
+
+      expect(record.time, now);
+      expect(record.metadata, metadata);
+      expect(record.mass, equals(validMass));
+    });
+
+    test('throws ArgumentError when mass is below minMass', () {
+      expect(
+        () => DietaryTotalFatRecord(
+          time: now,
+          metadata: metadata,
+          mass: const Mass.grams(-0.1),
+        ),
+        throwsArgumentError,
+      );
+    });
+
+    test('throws ArgumentError when mass is above maxMass', () {
+      expect(
+        () => DietaryTotalFatRecord(
+          time: now,
+          metadata: metadata,
+          mass: const Mass.grams(1000.1),
+        ),
+        throwsArgumentError,
+      );
+    });
+
+    test('copyWith updates all fields correctly', () {
+      final record = DietaryTotalFatRecord(
+        time: now,
+        metadata: metadata,
+        mass: validMass,
+        foodName: 'Nuts',
+        mealType: MealType.snack,
+      );
+
+      const newMass = Mass.grams(50.0); // 50 g
+      final newTime = now.add(const Duration(minutes: 5));
+      final newMetadata = Metadata.manualEntry();
+      const newFoodName = 'Cheese';
+      const newMealType = MealType.lunch;
+
+      final updatedRecord = record.copyWith(
+        mass: newMass,
+        time: newTime,
+        metadata: newMetadata,
+        foodName: newFoodName,
+        mealType: newMealType,
+      );
+
+      expect(updatedRecord.mass, newMass);
+      expect(updatedRecord.time, newTime);
+      expect(updatedRecord.metadata, newMetadata);
+      expect(updatedRecord.foodName, newFoodName);
+      expect(updatedRecord.mealType, newMealType);
+    });
+
+    test('equality works correctly', () {
+      final record1 = DietaryTotalFatRecord(
+        time: now,
+        metadata: metadata,
+        mass: validMass,
+      );
+
+      final record2 = DietaryTotalFatRecord(
+        time: now,
+        metadata: metadata,
+        mass: validMass,
+      );
+
+      final record3 = DietaryTotalFatRecord(
+        time: now,
+        metadata: metadata,
+        mass: const Mass.grams(80.0),
+      );
+
+      expect(record1 == record2, isTrue);
+      expect(record1 == record3, isFalse);
+      expect(record1.hashCode == record2.hashCode, isTrue);
+    });
+  });
+}

--- a/packages/health_connector_core/test/src/models/health_records/nutrition/dietary_vitamin_a_record_test.dart
+++ b/packages/health_connector_core/test/src/models/health_records/nutrition/dietary_vitamin_a_record_test.dart
@@ -1,0 +1,100 @@
+import 'package:health_connector_core/health_connector_core.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('DietaryVitaminARecord (Vitamin)', () {
+    final now = DateTime(2026, 1, 11);
+    final metadata = Metadata.manualEntry();
+    const validMass = Mass.grams(0.0008); // 800 mcg
+
+    test('can be instantiated with valid parameters', () {
+      final record = DietaryVitaminARecord(
+        time: now,
+        metadata: metadata,
+        mass: validMass,
+        foodName: 'Carrot',
+        mealType: MealType.snack,
+      );
+
+      expect(record.time, now);
+      expect(record.metadata, metadata);
+      expect(record.mass, equals(validMass));
+    });
+
+    test('throws ArgumentError when mass is below minMass', () {
+      expect(
+        () => DietaryVitaminARecord(
+          time: now,
+          metadata: metadata,
+          mass: const Mass.grams(-0.1),
+        ),
+        throwsArgumentError,
+      );
+    });
+
+    test('throws ArgumentError when mass is above maxMass', () {
+      expect(
+        () => DietaryVitaminARecord(
+          time: now,
+          metadata: metadata,
+          mass: const Mass.grams(10.1),
+        ),
+        throwsArgumentError,
+      );
+    });
+
+    test('copyWith updates all fields correctly', () {
+      final record = DietaryVitaminARecord(
+        time: now,
+        metadata: metadata,
+        mass: validMass,
+        foodName: 'Carrot',
+        mealType: MealType.snack,
+      );
+
+      const newMass = Mass.grams(0.0009); // 900 mcg
+      final newTime = now.add(const Duration(minutes: 5));
+      final newMetadata = Metadata.manualEntry();
+      const newFoodName = 'Pumpkin';
+      const newMealType = MealType.dinner;
+
+      final updatedRecord = record.copyWith(
+        mass: newMass,
+        time: newTime,
+        metadata: newMetadata,
+        foodName: newFoodName,
+        mealType: newMealType,
+      );
+
+      expect(updatedRecord.mass, newMass);
+      expect(updatedRecord.time, newTime);
+      expect(updatedRecord.metadata, newMetadata);
+      expect(updatedRecord.foodName, newFoodName);
+      expect(updatedRecord.mealType, newMealType);
+    });
+
+    test('equality works correctly', () {
+      final record1 = DietaryVitaminARecord(
+        time: now,
+        metadata: metadata,
+        mass: validMass,
+      );
+
+      final record2 = DietaryVitaminARecord(
+        time: now,
+        metadata: metadata,
+        mass: validMass,
+      );
+
+      final record3 = DietaryVitaminARecord(
+        time: now,
+        metadata: metadata,
+        mass: const Mass.grams(0.001),
+      );
+
+      expect(record1 == record2, isTrue);
+      expect(record1.hashCode, equals(record2.hashCode));
+      expect(record1 == record3, isFalse);
+    });
+  });
+}

--- a/packages/health_connector_core/test/src/models/health_records/nutrition/dietary_vitamin_b12_record_test.dart
+++ b/packages/health_connector_core/test/src/models/health_records/nutrition/dietary_vitamin_b12_record_test.dart
@@ -1,0 +1,100 @@
+import 'package:health_connector_core/health_connector_core.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('DietaryVitaminB12Record (Vitamin)', () {
+    final now = DateTime.now();
+    final metadata = Metadata.manualEntry();
+    const validMass = Mass.grams(0.0000024); // 2.4 mcg
+
+    test('can be instantiated with valid parameters', () {
+      final record = DietaryVitaminB12Record(
+        time: now,
+        metadata: metadata,
+        mass: validMass,
+        foodName: 'Beef',
+        mealType: MealType.dinner,
+      );
+
+      expect(record.time, now);
+      expect(record.metadata, metadata);
+      expect(record.mass, equals(validMass));
+    });
+
+    test('throws ArgumentError when mass is below minMass', () {
+      expect(
+        () => DietaryVitaminB12Record(
+          time: now,
+          metadata: metadata,
+          mass: const Mass.grams(-0.1),
+        ),
+        throwsArgumentError,
+      );
+    });
+
+    test('throws ArgumentError when mass is above maxMass', () {
+      expect(
+        () => DietaryVitaminB12Record(
+          time: now,
+          metadata: metadata,
+          mass: const Mass.grams(10.1),
+        ),
+        throwsArgumentError,
+      );
+    });
+
+    test('copyWith updates all fields correctly', () {
+      final record = DietaryVitaminB12Record(
+        time: now,
+        metadata: metadata,
+        mass: validMass,
+        foodName: 'Beef',
+        mealType: MealType.dinner,
+      );
+
+      const newMass = Mass.grams(0.0000030); // 3.0 mcg
+      final newTime = now.add(const Duration(minutes: 5));
+      final newMetadata = Metadata.manualEntry();
+      const newFoodName = 'Salmon';
+      const newMealType = MealType.lunch;
+
+      final updatedRecord = record.copyWith(
+        mass: newMass,
+        time: newTime,
+        metadata: newMetadata,
+        foodName: newFoodName,
+        mealType: newMealType,
+      );
+
+      expect(updatedRecord.mass, newMass);
+      expect(updatedRecord.time, newTime);
+      expect(updatedRecord.metadata, newMetadata);
+      expect(updatedRecord.foodName, newFoodName);
+      expect(updatedRecord.mealType, newMealType);
+    });
+
+    test('equality works correctly', () {
+      final record1 = DietaryVitaminB12Record(
+        time: now,
+        metadata: metadata,
+        mass: validMass,
+      );
+
+      final record2 = DietaryVitaminB12Record(
+        time: now,
+        metadata: metadata,
+        mass: validMass,
+      );
+
+      final record3 = DietaryVitaminB12Record(
+        time: now,
+        metadata: metadata,
+        mass: const Mass.grams(0.0000050),
+      );
+
+      expect(record1 == record2, isTrue);
+      expect(record1 == record3, isFalse);
+      expect(record1.hashCode == record2.hashCode, isTrue);
+    });
+  });
+}

--- a/packages/health_connector_core/test/src/models/health_records/nutrition/dietary_vitamin_b6_record_test.dart
+++ b/packages/health_connector_core/test/src/models/health_records/nutrition/dietary_vitamin_b6_record_test.dart
@@ -1,0 +1,100 @@
+import 'package:health_connector_core/health_connector_core.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('DietaryVitaminB6Record (Vitamin)', () {
+    final now = DateTime.now();
+    final metadata = Metadata.manualEntry();
+    const validMass = Mass.grams(0.0013); // 1.3 mg
+
+    test('can be instantiated with valid parameters', () {
+      final record = DietaryVitaminB6Record(
+        time: now,
+        metadata: metadata,
+        mass: validMass,
+        foodName: 'Banana',
+        mealType: MealType.snack,
+      );
+
+      expect(record.time, now);
+      expect(record.metadata, metadata);
+      expect(record.mass, equals(validMass));
+    });
+
+    test('throws ArgumentError when mass is below minMass', () {
+      expect(
+        () => DietaryVitaminB6Record(
+          time: now,
+          metadata: metadata,
+          mass: const Mass.grams(-0.1),
+        ),
+        throwsArgumentError,
+      );
+    });
+
+    test('throws ArgumentError when mass is above maxMass', () {
+      expect(
+        () => DietaryVitaminB6Record(
+          time: now,
+          metadata: metadata,
+          mass: const Mass.grams(10.1),
+        ),
+        throwsArgumentError,
+      );
+    });
+
+    test('copyWith updates all fields correctly', () {
+      final record = DietaryVitaminB6Record(
+        time: now,
+        metadata: metadata,
+        mass: validMass,
+        foodName: 'Banana',
+        mealType: MealType.snack,
+      );
+
+      const newMass = Mass.grams(0.0017); // 1.7 mg
+      final newTime = now.add(const Duration(minutes: 5));
+      final newMetadata = Metadata.manualEntry();
+      const newFoodName = 'Salmon';
+      const newMealType = MealType.dinner;
+
+      final updatedRecord = record.copyWith(
+        mass: newMass,
+        time: newTime,
+        metadata: newMetadata,
+        foodName: newFoodName,
+        mealType: newMealType,
+      );
+
+      expect(updatedRecord.mass, newMass);
+      expect(updatedRecord.time, newTime);
+      expect(updatedRecord.metadata, newMetadata);
+      expect(updatedRecord.foodName, newFoodName);
+      expect(updatedRecord.mealType, newMealType);
+    });
+
+    test('equality works correctly', () {
+      final record1 = DietaryVitaminB6Record(
+        time: now,
+        metadata: metadata,
+        mass: validMass,
+      );
+
+      final record2 = DietaryVitaminB6Record(
+        time: now,
+        metadata: metadata,
+        mass: validMass,
+      );
+
+      final record3 = DietaryVitaminB6Record(
+        time: now,
+        metadata: metadata,
+        mass: const Mass.grams(0.0020),
+      );
+
+      expect(record1 == record2, isTrue);
+      expect(record1 == record3, isFalse);
+      expect(record1.hashCode == record2.hashCode, isTrue);
+    });
+  });
+}

--- a/packages/health_connector_core/test/src/models/health_records/nutrition/dietary_vitamin_c_record_test.dart
+++ b/packages/health_connector_core/test/src/models/health_records/nutrition/dietary_vitamin_c_record_test.dart
@@ -1,0 +1,100 @@
+import 'package:health_connector_core/health_connector_core.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('DietaryVitaminCRecord (Vitamin)', () {
+    final now = DateTime.now();
+    final metadata = Metadata.manualEntry();
+    const validMass = Mass.grams(0.09); // 90 mg
+
+    test('can be instantiated with valid parameters', () {
+      final record = DietaryVitaminCRecord(
+        time: now,
+        metadata: metadata,
+        mass: validMass,
+        foodName: 'Orange',
+        mealType: MealType.snack,
+      );
+
+      expect(record.time, now);
+      expect(record.metadata, metadata);
+      expect(record.mass, equals(validMass));
+    });
+
+    test('throws ArgumentError when mass is below minMass', () {
+      expect(
+        () => DietaryVitaminCRecord(
+          time: now,
+          metadata: metadata,
+          mass: const Mass.grams(-0.1),
+        ),
+        throwsArgumentError,
+      );
+    });
+
+    test('throws ArgumentError when mass is above maxMass', () {
+      expect(
+        () => DietaryVitaminCRecord(
+          time: now,
+          metadata: metadata,
+          mass: const Mass.grams(10.1),
+        ),
+        throwsArgumentError,
+      );
+    });
+
+    test('copyWith updates all fields correctly', () {
+      final record = DietaryVitaminCRecord(
+        time: now,
+        metadata: metadata,
+        mass: validMass,
+        foodName: 'Orange',
+        mealType: MealType.snack,
+      );
+
+      const newMass = Mass.grams(0.075); // 75 mg
+      final newTime = now.add(const Duration(minutes: 5));
+      final newMetadata = Metadata.manualEntry();
+      const newFoodName = 'Strawberries';
+      const newMealType = MealType.breakfast;
+
+      final updatedRecord = record.copyWith(
+        mass: newMass,
+        time: newTime,
+        metadata: newMetadata,
+        foodName: newFoodName,
+        mealType: newMealType,
+      );
+
+      expect(updatedRecord.mass, newMass);
+      expect(updatedRecord.time, newTime);
+      expect(updatedRecord.metadata, newMetadata);
+      expect(updatedRecord.foodName, newFoodName);
+      expect(updatedRecord.mealType, newMealType);
+    });
+
+    test('equality works correctly', () {
+      final record1 = DietaryVitaminCRecord(
+        time: now,
+        metadata: metadata,
+        mass: validMass,
+      );
+
+      final record2 = DietaryVitaminCRecord(
+        time: now,
+        metadata: metadata,
+        mass: validMass,
+      );
+
+      final record3 = DietaryVitaminCRecord(
+        time: now,
+        metadata: metadata,
+        mass: const Mass.grams(0.120),
+      );
+
+      expect(record1 == record2, isTrue);
+      expect(record1 == record3, isFalse);
+      expect(record1.hashCode == record2.hashCode, isTrue);
+    });
+  });
+}

--- a/packages/health_connector_core/test/src/models/health_records/nutrition/dietary_vitamin_d_record_test.dart
+++ b/packages/health_connector_core/test/src/models/health_records/nutrition/dietary_vitamin_d_record_test.dart
@@ -1,0 +1,100 @@
+import 'package:health_connector_core/health_connector_core.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('DietaryVitaminDRecord (Vitamin)', () {
+    final now = DateTime.now();
+    final metadata = Metadata.manualEntry();
+    const validMass = Mass.grams(0.00002); // 20 mcg
+
+    test('can be instantiated with valid parameters', () {
+      final record = DietaryVitaminDRecord(
+        time: now,
+        metadata: metadata,
+        mass: validMass,
+        foodName: 'Salmon',
+        mealType: MealType.dinner,
+      );
+
+      expect(record.time, now);
+      expect(record.metadata, metadata);
+      expect(record.mass, equals(validMass));
+    });
+
+    test('throws ArgumentError when mass is below minMass', () {
+      expect(
+        () => DietaryVitaminDRecord(
+          time: now,
+          metadata: metadata,
+          mass: const Mass.grams(-0.1),
+        ),
+        throwsArgumentError,
+      );
+    });
+
+    test('throws ArgumentError when mass is above maxMass', () {
+      expect(
+        () => DietaryVitaminDRecord(
+          time: now,
+          metadata: metadata,
+          mass: const Mass.grams(10.1),
+        ),
+        throwsArgumentError,
+      );
+    });
+
+    test('copyWith updates all fields correctly', () {
+      final record = DietaryVitaminDRecord(
+        time: now,
+        metadata: metadata,
+        mass: validMass,
+        foodName: 'Salmon',
+        mealType: MealType.dinner,
+      );
+
+      const newMass = Mass.grams(0.000015); // 15 mcg
+      final newTime = now.add(const Duration(minutes: 5));
+      final newMetadata = Metadata.manualEntry();
+      const newFoodName = 'Fortified milk';
+      const newMealType = MealType.breakfast;
+
+      final updatedRecord = record.copyWith(
+        mass: newMass,
+        time: newTime,
+        metadata: newMetadata,
+        foodName: newFoodName,
+        mealType: newMealType,
+      );
+
+      expect(updatedRecord.mass, newMass);
+      expect(updatedRecord.time, newTime);
+      expect(updatedRecord.metadata, newMetadata);
+      expect(updatedRecord.foodName, newFoodName);
+      expect(updatedRecord.mealType, newMealType);
+    });
+
+    test('equality works correctly', () {
+      final record1 = DietaryVitaminDRecord(
+        time: now,
+        metadata: metadata,
+        mass: validMass,
+      );
+
+      final record2 = DietaryVitaminDRecord(
+        time: now,
+        metadata: metadata,
+        mass: validMass,
+      );
+
+      final record3 = DietaryVitaminDRecord(
+        time: now,
+        metadata: metadata,
+        mass: const Mass.grams(0.000025),
+      );
+
+      expect(record1 == record2, isTrue);
+      expect(record1 == record3, isFalse);
+      expect(record1.hashCode == record2.hashCode, isTrue);
+    });
+  });
+}

--- a/packages/health_connector_core/test/src/models/health_records/nutrition/dietary_vitamin_e_record_test.dart
+++ b/packages/health_connector_core/test/src/models/health_records/nutrition/dietary_vitamin_e_record_test.dart
@@ -1,0 +1,100 @@
+import 'package:health_connector_core/health_connector_core.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('DietaryVitaminERecord (Vitamin)', () {
+    final now = DateTime.now();
+    final metadata = Metadata.manualEntry();
+    const validMass = Mass.grams(0.015); // 15 mg
+
+    test('can be instantiated with valid parameters', () {
+      final record = DietaryVitaminERecord(
+        time: now,
+        metadata: metadata,
+        mass: validMass,
+        foodName: 'Almonds',
+        mealType: MealType.snack,
+      );
+
+      expect(record.time, now);
+      expect(record.metadata, metadata);
+      expect(record.mass, equals(validMass));
+    });
+
+    test('throws ArgumentError when mass is below minMass', () {
+      expect(
+        () => DietaryVitaminERecord(
+          time: now,
+          metadata: metadata,
+          mass: const Mass.grams(-0.1),
+        ),
+        throwsArgumentError,
+      );
+    });
+
+    test('throws ArgumentError when mass is above maxMass', () {
+      expect(
+        () => DietaryVitaminERecord(
+          time: now,
+          metadata: metadata,
+          mass: const Mass.grams(10.1),
+        ),
+        throwsArgumentError,
+      );
+    });
+
+    test('copyWith updates all fields correctly', () {
+      final record = DietaryVitaminERecord(
+        time: now,
+        metadata: metadata,
+        mass: validMass,
+        foodName: 'Almonds',
+        mealType: MealType.snack,
+      );
+
+      const newMass = Mass.grams(0.012); // 12 mg
+      final newTime = now.add(const Duration(minutes: 5));
+      final newMetadata = Metadata.manualEntry();
+      const newFoodName = 'Sunflower seeds';
+      const newMealType = MealType.breakfast;
+
+      final updatedRecord = record.copyWith(
+        mass: newMass,
+        time: newTime,
+        metadata: newMetadata,
+        foodName: newFoodName,
+        mealType: newMealType,
+      );
+
+      expect(updatedRecord.mass, newMass);
+      expect(updatedRecord.time, newTime);
+      expect(updatedRecord.metadata, newMetadata);
+      expect(updatedRecord.foodName, newFoodName);
+      expect(updatedRecord.mealType, newMealType);
+    });
+
+    test('equality works correctly', () {
+      final record1 = DietaryVitaminERecord(
+        time: now,
+        metadata: metadata,
+        mass: validMass,
+      );
+
+      final record2 = DietaryVitaminERecord(
+        time: now,
+        metadata: metadata,
+        mass: validMass,
+      );
+
+      final record3 = DietaryVitaminERecord(
+        time: now,
+        metadata: metadata,
+        mass: const Mass.grams(0.020),
+      );
+
+      expect(record1 == record2, isTrue);
+      expect(record1 == record3, isFalse);
+      expect(record1.hashCode == record2.hashCode, isTrue);
+    });
+  });
+}

--- a/packages/health_connector_core/test/src/models/health_records/nutrition/dietary_vitamin_k_record_test.dart
+++ b/packages/health_connector_core/test/src/models/health_records/nutrition/dietary_vitamin_k_record_test.dart
@@ -1,0 +1,100 @@
+import 'package:health_connector_core/health_connector_core.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('DietaryVitaminKRecord (Vitamin)', () {
+    final now = DateTime.now();
+    final metadata = Metadata.manualEntry();
+    const validMass = Mass.grams(0.00012); // 120 mcg
+
+    test('can be instantiated with valid parameters', () {
+      final record = DietaryVitaminKRecord(
+        time: now,
+        metadata: metadata,
+        mass: validMass,
+        foodName: 'Kale',
+        mealType: MealType.lunch,
+      );
+
+      expect(record.time, now);
+      expect(record.metadata, metadata);
+      expect(record.mass, equals(validMass));
+    });
+
+    test('throws ArgumentError when mass is below minMass', () {
+      expect(
+        () => DietaryVitaminKRecord(
+          time: now,
+          metadata: metadata,
+          mass: const Mass.grams(-0.1),
+        ),
+        throwsArgumentError,
+      );
+    });
+
+    test('throws ArgumentError when mass is above maxMass', () {
+      expect(
+        () => DietaryVitaminKRecord(
+          time: now,
+          metadata: metadata,
+          mass: const Mass.grams(10.1),
+        ),
+        throwsArgumentError,
+      );
+    });
+
+    test('copyWith updates all fields correctly', () {
+      final record = DietaryVitaminKRecord(
+        time: now,
+        metadata: metadata,
+        mass: validMass,
+        foodName: 'Kale',
+        mealType: MealType.lunch,
+      );
+
+      const newMass = Mass.grams(0.00009); // 90 mcg
+      final newTime = now.add(const Duration(minutes: 5));
+      final newMetadata = Metadata.manualEntry();
+      const newFoodName = 'Spinach';
+      const newMealType = MealType.dinner;
+
+      final updatedRecord = record.copyWith(
+        mass: newMass,
+        time: newTime,
+        metadata: newMetadata,
+        foodName: newFoodName,
+        mealType: newMealType,
+      );
+
+      expect(updatedRecord.mass, newMass);
+      expect(updatedRecord.time, newTime);
+      expect(updatedRecord.metadata, newMetadata);
+      expect(updatedRecord.foodName, newFoodName);
+      expect(updatedRecord.mealType, newMealType);
+    });
+
+    test('equality works correctly', () {
+      final record1 = DietaryVitaminKRecord(
+        time: now,
+        metadata: metadata,
+        mass: validMass,
+      );
+
+      final record2 = DietaryVitaminKRecord(
+        time: now,
+        metadata: metadata,
+        mass: validMass,
+      );
+
+      final record3 = DietaryVitaminKRecord(
+        time: now,
+        metadata: metadata,
+        mass: const Mass.grams(0.00015),
+      );
+
+      expect(record1 == record2, isTrue);
+      expect(record1 == record3, isFalse);
+      expect(record1.hashCode == record2.hashCode, isTrue);
+    });
+  });
+}

--- a/packages/health_connector_core/test/src/models/health_records/nutrition/dietary_zinc_record_test.dart
+++ b/packages/health_connector_core/test/src/models/health_records/nutrition/dietary_zinc_record_test.dart
@@ -1,0 +1,100 @@
+import 'package:health_connector_core/health_connector_core.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('DietaryZincRecord (Mineral)', () {
+    final now = DateTime.now();
+    final metadata = Metadata.manualEntry();
+    const validMass = Mass.grams(0.011); // 11 mg
+
+    test('can be instantiated with valid parameters', () {
+      final record = DietaryZincRecord(
+        time: now,
+        metadata: metadata,
+        mass: validMass,
+        foodName: 'Oysters',
+        mealType: MealType.dinner,
+      );
+
+      expect(record.time, now);
+      expect(record.metadata, metadata);
+      expect(record.mass, equals(validMass));
+    });
+
+    test('throws ArgumentError when mass is below minMass', () {
+      expect(
+        () => DietaryZincRecord(
+          time: now,
+          metadata: metadata,
+          mass: const Mass.grams(-0.1),
+        ),
+        throwsArgumentError,
+      );
+    });
+
+    test('throws ArgumentError when mass is above maxMass', () {
+      expect(
+        () => DietaryZincRecord(
+          time: now,
+          metadata: metadata,
+          mass: const Mass.grams(100.1),
+        ),
+        throwsArgumentError,
+      );
+    });
+
+    test('copyWith updates all fields correctly', () {
+      final record = DietaryZincRecord(
+        time: now,
+        metadata: metadata,
+        mass: validMass,
+        foodName: 'Oysters',
+        mealType: MealType.dinner,
+      );
+
+      const newMass = Mass.grams(0.008); // 8 mg
+      final newTime = now.add(const Duration(minutes: 5));
+      final newMetadata = Metadata.manualEntry();
+      const newFoodName = 'Beef';
+      const newMealType = MealType.lunch;
+
+      final updatedRecord = record.copyWith(
+        mass: newMass,
+        time: newTime,
+        metadata: newMetadata,
+        foodName: newFoodName,
+        mealType: newMealType,
+      );
+
+      expect(updatedRecord.mass, newMass);
+      expect(updatedRecord.time, newTime);
+      expect(updatedRecord.metadata, newMetadata);
+      expect(updatedRecord.foodName, newFoodName);
+      expect(updatedRecord.mealType, newMealType);
+    });
+
+    test('equality works correctly', () {
+      final record1 = DietaryZincRecord(
+        time: now,
+        metadata: metadata,
+        mass: validMass,
+      );
+
+      final record2 = DietaryZincRecord(
+        time: now,
+        metadata: metadata,
+        mass: validMass,
+      );
+
+      final record3 = DietaryZincRecord(
+        time: now,
+        metadata: metadata,
+        mass: const Mass.grams(0.015),
+      );
+
+      expect(record1 == record2, isTrue);
+      expect(record1 == record3, isFalse);
+      expect(record1.hashCode == record2.hashCode, isTrue);
+    });
+  });
+}

--- a/packages/health_connector_core/test/src/models/health_records/nutrition/nutrition_record_test.dart
+++ b/packages/health_connector_core/test/src/models/health_records/nutrition/nutrition_record_test.dart
@@ -1,0 +1,170 @@
+import 'package:health_connector_core/health_connector_core.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('NutritionRecord', () {
+    final now = DateTime(2026, 1, 11);
+    final startTime = now.subtract(const Duration(minutes: 30));
+    final endTime = now;
+    final metadata = Metadata.manualEntry();
+
+    // Test Values
+    const energy = Energy.kilocalories(450);
+    const protein = Mass.grams(35);
+    const carb = Mass.grams(50);
+    const fat = Mass.grams(10);
+    const vitaminA = Mass.grams(0.000835); // 835 mcg
+    const calcium = Mass.grams(0.3); // 300 mg
+
+    test('can be instantiated with valid parameters', () {
+      final record = NutritionRecord(
+        startTime: startTime,
+        endTime: endTime,
+        metadata: metadata,
+        foodName: 'Chicken with Rice',
+        mealType: MealType.lunch,
+        energy: energy,
+        protein: protein,
+        totalCarbohydrate: carb,
+        totalFat: fat,
+        vitaminA: vitaminA,
+        calcium: calcium,
+      );
+
+      expect(record.startTime, startTime);
+      expect(record.endTime, endTime);
+      expect(record.metadata, metadata);
+      expect(record.foodName, 'Chicken with Rice');
+      expect(record.mealType, MealType.lunch);
+      expect(record.energy, equals(energy));
+      expect(record.protein, equals(protein));
+      expect(record.vitaminA, equals(vitaminA));
+      expect(record.calcium, equals(calcium));
+    });
+
+    test('validates energy range', () {
+      expect(
+        () => NutritionRecord(
+          startTime: startTime,
+          endTime: endTime,
+          metadata: metadata,
+          energy: const Energy.kilocalories(-1), // Invalid
+        ),
+        throwsArgumentError,
+      );
+
+      expect(
+        () => NutritionRecord(
+          startTime: startTime,
+          endTime: endTime,
+          metadata: metadata,
+          energy: const Energy.kilocalories(10001), // Invalid
+        ),
+        throwsArgumentError,
+      );
+    });
+
+    test('validates macronutrient range', () {
+      expect(
+        () => NutritionRecord(
+          startTime: startTime,
+          endTime: endTime,
+          metadata: metadata,
+          protein: const Mass.grams(-1), // Invalid
+        ),
+        throwsArgumentError,
+      );
+
+      expect(
+        () => NutritionRecord(
+          startTime: startTime,
+          endTime: endTime,
+          metadata: metadata,
+          protein: const Mass.grams(1001), // Invalid
+        ),
+        throwsArgumentError,
+      );
+    });
+
+    test('validates vitamin range', () {
+      expect(
+        () => NutritionRecord(
+          startTime: startTime,
+          endTime: endTime,
+          metadata: metadata,
+          vitaminA: const Mass.grams(-1), // Invalid
+        ),
+        throwsArgumentError,
+      );
+
+      expect(
+        () => NutritionRecord(
+          startTime: startTime,
+          endTime: endTime,
+          metadata: metadata,
+          vitaminA: const Mass.grams(10.1), // Invalid > 10g
+        ),
+        throwsArgumentError,
+      );
+    });
+
+    test('validates mineral range', () {
+      expect(
+        () => NutritionRecord(
+          startTime: startTime,
+          endTime: endTime,
+          metadata: metadata,
+          calcium: const Mass.grams(-1), // Invalid
+        ),
+        throwsArgumentError,
+      );
+
+      expect(
+        () => NutritionRecord(
+          startTime: startTime,
+          endTime: endTime,
+          metadata: metadata,
+          calcium: const Mass.grams(100.1), // Invalid > 100g
+        ),
+        throwsArgumentError,
+      );
+    });
+
+    test('copyWith updates all fields correctly', () {
+      final record = NutritionRecord(
+        startTime: startTime,
+        endTime: endTime,
+        metadata: metadata,
+        foodName: 'Chicken with Rice',
+        mealType: MealType.lunch,
+        energy: energy,
+        protein: protein,
+        calcium: calcium,
+      );
+
+      final newTime = startTime.subtract(const Duration(minutes: 5));
+      const newEnergy = Energy.kilocalories(500);
+      const newFoodName = 'Different Food';
+      const newMealType = MealType.dinner;
+      const newProtein = Mass.grams(40);
+      const newCalcium = Mass.grams(0.4);
+
+      final updatedRecord = record.copyWith(
+        startTime: newTime,
+        energy: newEnergy,
+        foodName: newFoodName,
+        mealType: newMealType,
+        protein: newProtein,
+        calcium: newCalcium,
+      );
+
+      expect(updatedRecord.startTime, newTime);
+      expect(updatedRecord.energy, newEnergy);
+      expect(updatedRecord.foodName, newFoodName);
+      expect(updatedRecord.mealType, newMealType);
+      expect(updatedRecord.protein, newProtein);
+      expect(updatedRecord.calcium, newCalcium);
+      expect(updatedRecord.metadata, metadata); // Unchanged
+    });
+  });
+}

--- a/packages/health_connector_core/test/src/models/health_records/oxygen_saturation_record_test.dart
+++ b/packages/health_connector_core/test/src/models/health_records/oxygen_saturation_record_test.dart
@@ -1,0 +1,94 @@
+import 'package:health_connector_core/health_connector_core.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('OxygenSaturationRecord', () {
+    final now = DateTime(2026, 1, 11);
+    final metadata = Metadata.manualEntry();
+    const validSaturation = Percentage.fromWhole(98);
+
+    test('can be instantiated with valid parameters', () {
+      final record = OxygenSaturationRecord(
+        time: now,
+        saturation: validSaturation,
+        metadata: metadata,
+      );
+
+      expect(record.time, now);
+      expect(record.saturation, validSaturation);
+      expect(record.metadata, metadata);
+    });
+
+    // Validation Rationale:
+    // Min at 0% (Percentage.zero) - hard to violate unless negative
+    // Max at 100% (Percentage.full) - hard to violate unless > 1.0
+
+    test('throws ArgumentError when saturation is below minSaturation', () {
+      expect(
+        () => OxygenSaturationRecord(
+          time: now,
+          saturation: const Percentage.fromWhole(-1.0),
+          metadata: metadata,
+        ),
+        throwsArgumentError,
+      );
+    });
+
+    test('throws ArgumentError when saturation is above maxSaturation', () {
+      expect(
+        () => OxygenSaturationRecord(
+          time: now,
+          saturation: const Percentage.fromWhole(101.0),
+          metadata: metadata,
+        ),
+        throwsArgumentError,
+      );
+    });
+
+    test('copyWith updates all fields correctly', () {
+      final record = OxygenSaturationRecord(
+        time: now,
+        saturation: validSaturation,
+        metadata: metadata,
+      );
+
+      final newTime = now.add(const Duration(minutes: 5));
+      const newSaturation = Percentage.fromWhole(95.0);
+      final newMetadata = Metadata.manualEntry();
+
+      final updated = record.copyWith(
+        time: newTime,
+        saturation: newSaturation,
+        metadata: newMetadata,
+      );
+
+      expect(updated.time, newTime);
+      expect(updated.saturation, newSaturation);
+      expect(updated.metadata, newMetadata);
+    });
+
+    test('equality works correctly', () {
+      final record1 = OxygenSaturationRecord(
+        time: now,
+        saturation: validSaturation,
+        metadata: metadata,
+      );
+
+      final record2 = OxygenSaturationRecord(
+        time: now,
+        saturation: validSaturation,
+        metadata: metadata,
+      );
+
+      final record3 = OxygenSaturationRecord(
+        time: now,
+        saturation: const Percentage.fromWhole(99.0),
+        metadata: metadata,
+      );
+
+      expect(record1 == record2, isTrue);
+      expect(record1 == record3, isFalse);
+      expect(record1.hashCode == record2.hashCode, isTrue);
+    });
+  });
+}

--- a/packages/health_connector_core/test/src/models/health_records/power/cycling_power_record_test.dart
+++ b/packages/health_connector_core/test/src/models/health_records/power/cycling_power_record_test.dart
@@ -1,0 +1,90 @@
+import 'package:health_connector_core/health_connector_core.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('CyclingPowerRecord', () {
+    final now = DateTime(2026, 1, 11);
+    final metadata = Metadata.manualEntry();
+    const validPower = Power.watts(200);
+
+    test('can be instantiated with valid parameters', () {
+      final record = CyclingPowerRecord(
+        time: now,
+        metadata: metadata,
+        power: validPower,
+      );
+
+      expect(record.time, now);
+      expect(record.metadata, metadata);
+      expect(record.power, equals(validPower));
+    });
+
+    test('throws ArgumentError when power is below minPower', () {
+      expect(
+        () => CyclingPowerRecord(
+          time: now,
+          metadata: metadata,
+          power: const Power.watts(-1),
+        ),
+        throwsArgumentError,
+      );
+    });
+
+    test('throws ArgumentError when power is above maxPower', () {
+      expect(
+        () => CyclingPowerRecord(
+          time: now,
+          metadata: metadata,
+          power: const Power.watts(3001),
+        ),
+        throwsArgumentError,
+      );
+    });
+
+    test('copyWith updates all fields correctly', () {
+      final record = CyclingPowerRecord(
+        time: now,
+        metadata: metadata,
+        power: validPower,
+      );
+
+      final newTime = now.add(const Duration(minutes: 5));
+      const newPower = Power.watts(250);
+      final newMetadata = Metadata.manualEntry();
+
+      final updatedRecord = record.copyWith(
+        time: newTime,
+        power: newPower,
+        metadata: newMetadata,
+      );
+
+      expect(updatedRecord.time, newTime);
+      expect(updatedRecord.power, newPower);
+      expect(updatedRecord.metadata, newMetadata);
+    });
+
+    test('equality works correctly', () {
+      final record1 = CyclingPowerRecord(
+        time: now,
+        metadata: metadata,
+        power: validPower,
+      );
+
+      final record2 = CyclingPowerRecord(
+        time: now,
+        metadata: metadata,
+        power: validPower,
+      );
+
+      final record3 = CyclingPowerRecord(
+        time: now,
+        metadata: metadata,
+        power: const Power.watts(150),
+      );
+
+      expect(record1 == record2, isTrue);
+      expect(record1 == record3, isFalse);
+      expect(record1.hashCode == record2.hashCode, isTrue);
+    });
+  });
+}

--- a/packages/health_connector_core/test/src/models/health_records/power/power_series_record_test.dart
+++ b/packages/health_connector_core/test/src/models/health_records/power/power_series_record_test.dart
@@ -1,0 +1,155 @@
+import 'package:health_connector_core/health_connector_core.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('PowerSeriesRecord', () {
+    final startTime = DateTime.now().subtract(const Duration(hours: 1));
+    final endTime = DateTime.now();
+    final metadata = Metadata.manualEntry();
+    final samples = [
+      PowerSample(
+        time: startTime,
+        power: const Power.watts(100),
+      ),
+      PowerSample(
+        time: startTime.add(const Duration(minutes: 30)),
+        power: const Power.watts(200),
+      ),
+      PowerSample(
+        time: endTime,
+        power: const Power.watts(300),
+      ),
+    ];
+
+    test('can be instantiated with valid parameters', () {
+      final record = PowerSeriesRecord(
+        startTime: startTime,
+        endTime: endTime,
+        metadata: metadata,
+        samples: samples,
+      );
+
+      expect(record.startTime, startTime);
+      expect(record.endTime, endTime);
+      expect(record.metadata, metadata);
+      expect(record.samples, samples);
+    });
+
+    test('calculates derived values correctly', () {
+      final record = PowerSeriesRecord(
+        startTime: startTime,
+        endTime: endTime,
+        metadata: metadata,
+        samples: samples,
+      );
+
+      expect(record.minPower.inWatts, closeTo(100, 0.1));
+      expect(record.maxPower.inWatts, closeTo(300, 0.1));
+      expect(record.avgPower.inWatts, closeTo(200, 0.1));
+    });
+
+    test('throws ArgumentError when sample power is below minPower', () {
+      expect(
+        () => PowerSample(
+          time: startTime,
+          power: const Power.watts(-1),
+        ),
+        throwsArgumentError,
+      );
+    });
+
+    test('throws ArgumentError when sample power is above maxPower', () {
+      expect(
+        () => PowerSample(
+          time: startTime,
+          power: const Power.watts(3001),
+        ),
+        throwsArgumentError,
+      );
+    });
+
+    test('copyWith updates all fields correctly', () {
+      final record = PowerSeriesRecord(
+        startTime: startTime,
+        endTime: endTime,
+        metadata: metadata,
+        samples: samples,
+      );
+
+      final newStartTime = startTime.subtract(const Duration(minutes: 10));
+      final newEndTime = endTime.add(const Duration(minutes: 10));
+      final newMetadata = Metadata.manualEntry();
+      final newSamples = [
+        PowerSample(
+          time: startTime,
+          power: const Power.watts(400),
+        ),
+      ];
+
+      final updatedRecord = record.copyWith(
+        startTime: newStartTime,
+        endTime: newEndTime,
+        metadata: newMetadata,
+        samples: newSamples,
+      );
+
+      expect(updatedRecord.startTime, newStartTime);
+      expect(updatedRecord.endTime, newEndTime);
+      expect(updatedRecord.metadata, newMetadata);
+      expect(updatedRecord.samples, newSamples);
+    });
+
+    test('equality works correctly', () {
+      final record1 = PowerSeriesRecord(
+        startTime: startTime,
+        endTime: endTime,
+        metadata: metadata,
+        samples: samples,
+      );
+
+      final record2 = PowerSeriesRecord(
+        startTime: startTime,
+        endTime: endTime,
+        metadata: metadata,
+        samples: [
+          PowerSample(
+            time: startTime,
+            power: const Power.watts(100),
+          ),
+          PowerSample(
+            time: startTime.add(const Duration(minutes: 30)),
+            power: const Power.watts(200),
+          ),
+          PowerSample(
+            time: endTime,
+            power: const Power.watts(300),
+          ),
+        ],
+      );
+
+      final record3 = PowerSeriesRecord(
+        startTime: startTime,
+        endTime: endTime,
+        metadata: metadata,
+        samples: const [],
+      );
+
+      expect(record1 == record2, isTrue);
+      expect(record1 == record3, isFalse);
+      expect(record1.hashCode == record2.hashCode, isTrue);
+    });
+
+    test('handles empty samples gracefully', () {
+      final record = PowerSeriesRecord(
+        startTime: startTime,
+        endTime: endTime,
+        metadata: metadata,
+        samples: const [],
+      );
+
+      expect(record.minPower, Power.zero);
+      expect(record.maxPower, Power.zero);
+      expect(record.avgPower, Power.zero);
+    });
+  });
+}

--- a/packages/health_connector_core/test/src/models/health_records/respiratory_rate_record_test.dart
+++ b/packages/health_connector_core/test/src/models/health_records/respiratory_rate_record_test.dart
@@ -1,0 +1,110 @@
+import 'package:health_connector_core/health_connector_core.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('RespiratoryRateRecord', () {
+    final now = DateTime(2026, 1, 11);
+    final metadata = Metadata.manualEntry();
+    final validRate = Frequency.perMinute(16.0);
+
+    test('can be instantiated with valid parameters', () {
+      final record = RespiratoryRateRecord(
+        time: now,
+        rate: validRate,
+        metadata: metadata,
+      );
+
+      expect(record.time, now);
+      expect(record.rate, validRate);
+      expect(record.metadata, metadata);
+    });
+
+    test('accepts minimum valid rate', () {
+      final record = RespiratoryRateRecord(
+        time: now,
+        rate: Frequency.perMinute(0.0), // New min is 0.0
+        metadata: metadata,
+      );
+
+      expect(record.rate.inPerMinute, equals(0.0));
+    });
+
+    test('throws ArgumentError when rate is below minRate', () {
+      expect(
+        () => RespiratoryRateRecord(
+          time: now,
+          rate: Frequency.perMinute(-1.0), // Below 0.0
+          metadata: metadata,
+        ),
+        throwsArgumentError,
+      );
+    });
+
+    test('accepts maximum valid rate', () {
+      final record = RespiratoryRateRecord(
+        time: now,
+        rate: Frequency.perMinute(1000.0), // New max is 1000.0
+        metadata: metadata,
+      );
+
+      expect(record.rate.inPerMinute, equals(1000.0));
+    });
+
+    test('throws ArgumentError when rate is above maxRate', () {
+      expect(
+        () => RespiratoryRateRecord(
+          time: now,
+          rate: Frequency.perMinute(1001.0), // Above 1000.0
+          metadata: metadata,
+        ),
+        throwsArgumentError,
+      );
+    });
+
+    test('copyWith updates all fields correctly', () {
+      final record = RespiratoryRateRecord(
+        time: now,
+        rate: validRate,
+        metadata: metadata,
+      );
+
+      final newTime = now.add(const Duration(minutes: 5));
+      final newRate = Frequency.perMinute(20.0);
+      final newMetadata = Metadata.manualEntry();
+
+      final updated = record.copyWith(
+        time: newTime,
+        rate: newRate,
+        metadata: newMetadata,
+      );
+
+      expect(updated.time, newTime);
+      expect(updated.rate, newRate);
+      expect(updated.metadata, newMetadata);
+    });
+
+    test('equality works correctly', () {
+      final record1 = RespiratoryRateRecord(
+        time: now,
+        rate: validRate,
+        metadata: metadata,
+      );
+
+      final record2 = RespiratoryRateRecord(
+        time: now,
+        rate: validRate,
+        metadata: metadata,
+      );
+
+      final record3 = RespiratoryRateRecord(
+        time: now,
+        rate: Frequency.perMinute(18.0),
+        metadata: metadata,
+      );
+
+      expect(record1 == record2, isTrue);
+      expect(record1 == record3, isFalse);
+      expect(record1.hashCode == record2.hashCode, isTrue);
+    });
+  });
+}

--- a/packages/health_connector_core/test/src/models/health_records/sleep/sleep_session_record_test.dart
+++ b/packages/health_connector_core/test/src/models/health_records/sleep/sleep_session_record_test.dart
@@ -1,0 +1,223 @@
+import 'package:health_connector_core/health_connector_core.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('SleepSessionRecord', () {
+    final now = DateTime(2026, 1, 11);
+    final startTime = now.subtract(const Duration(hours: 8));
+    final endTime = now;
+    final metadata = Metadata.manualEntry();
+    final samples = [
+      SleepStageSample(
+        startTime: startTime,
+        endTime: startTime.add(const Duration(hours: 4)),
+        stageType: SleepStage.light,
+      ),
+      SleepStageSample(
+        startTime: startTime.add(const Duration(hours: 4)),
+        endTime: endTime,
+        stageType: SleepStage.deep,
+      ),
+    ];
+
+    test('can be instantiated with valid parameters', () {
+      final record = SleepSessionRecord(
+        id: HealthRecordId.none,
+        startTime: startTime,
+        endTime: endTime,
+        samples: samples,
+        metadata: metadata,
+        title: 'Night Sleep',
+        notes: 'Good sleep',
+      );
+
+      expect(record.startTime, startTime);
+      expect(record.endTime, endTime);
+      expect(record.samples, samples);
+      expect(record.metadata, metadata);
+      expect(record.title, 'Night Sleep');
+      expect(record.notes, 'Good sleep');
+    });
+
+    test('throws ArgumentError when duration is below minDuration', () {
+      final shortEndTime = startTime.add(const Duration(seconds: 30));
+      expect(
+        () => SleepSessionRecord(
+          id: HealthRecordId.none,
+          startTime: startTime,
+          endTime: shortEndTime,
+          samples: const [],
+          metadata: metadata,
+        ),
+        throwsArgumentError,
+      );
+    });
+
+    test('throws ArgumentError when duration is above maxDuration', () {
+      final longEndTime = startTime.add(const Duration(hours: 24, minutes: 1));
+      expect(
+        () => SleepSessionRecord(
+          id: HealthRecordId.none,
+          startTime: startTime,
+          endTime: longEndTime,
+          samples: const [],
+          metadata: metadata,
+        ),
+        throwsArgumentError,
+      );
+    });
+
+    test('totalSleepDuration calculates correctly', () {
+      final record = SleepSessionRecord(
+        id: HealthRecordId.none,
+        startTime: startTime,
+        endTime: endTime,
+        samples: [
+          SleepStageSample(
+            startTime: startTime,
+            endTime: startTime.add(const Duration(hours: 2)),
+            stageType: SleepStage.light,
+          ),
+          SleepStageSample(
+            startTime: startTime.add(const Duration(hours: 2)),
+            endTime: startTime.add(const Duration(hours: 3)),
+            stageType: SleepStage.awake, // Should be excluded
+          ),
+          SleepStageSample(
+            startTime: startTime.add(const Duration(hours: 3)),
+            endTime: startTime.add(const Duration(hours: 5)),
+            stageType: SleepStage.deep,
+          ),
+        ],
+        metadata: metadata,
+      );
+
+      // 2h light + 2h deep = 4h
+      expect(record.totalSleepDuration, const Duration(hours: 4));
+    });
+
+    test('copyWith updates all fields correctly', () {
+      final record = SleepSessionRecord(
+        id: HealthRecordId.none,
+        startTime: startTime,
+        endTime: endTime,
+        samples: samples,
+        metadata: metadata,
+      );
+
+      final newStartTime = startTime.subtract(const Duration(minutes: 5));
+      final newEndTime = endTime.add(const Duration(minutes: 5));
+      const newTitle = 'Updated Title';
+      const newNotes = 'Updated Notes';
+      final newSamples = [samples.first];
+
+      final updated = record.copyWith(
+        startTime: newStartTime,
+        endTime: newEndTime,
+        samples: newSamples,
+        title: newTitle,
+        notes: newNotes,
+      );
+
+      expect(updated.startTime, newStartTime);
+      expect(updated.endTime, newEndTime);
+      expect(updated.samples, newSamples);
+      expect(updated.title, newTitle);
+      expect(updated.notes, newNotes);
+    });
+
+    test('equality works correctly', () {
+      final record1 = SleepSessionRecord(
+        id: HealthRecordId.none,
+        startTime: startTime,
+        endTime: endTime,
+        samples: samples,
+        metadata: metadata,
+      );
+
+      final record2 = SleepSessionRecord(
+        id: HealthRecordId.none,
+        startTime: startTime,
+        endTime: endTime,
+        samples: samples,
+        metadata: metadata, // same instance
+      );
+
+      // Deep copy of samples for record 2 to test deep equality?
+      // actually samples list is same instance in this test.
+      // Let's create new list with same content
+      final samples2 = [
+        SleepStageSample(
+          startTime: startTime,
+          endTime: startTime.add(const Duration(hours: 4)),
+          stageType: SleepStage.light,
+        ),
+        SleepStageSample(
+          startTime: startTime.add(const Duration(hours: 4)),
+          endTime: endTime,
+          stageType: SleepStage.deep,
+        ),
+      ];
+
+      final record3 = SleepSessionRecord(
+        id: HealthRecordId.none,
+        startTime: startTime,
+        endTime: endTime,
+        samples: samples2,
+        metadata: metadata,
+      );
+
+      expect(record1 == record2, isTrue);
+      // ListEquality should make record1 == record3 true as contents are same
+      expect(record1 == record3, isTrue);
+
+      final record4 = SleepSessionRecord(
+        id: HealthRecordId.none,
+        startTime: startTime,
+        endTime: endTime,
+        samples: const [],
+        metadata: metadata,
+      );
+
+      expect(record1 == record4, isFalse);
+    });
+  });
+
+  group('SleepStageSample', () {
+    test('throws ArgumentError if endTime is before startTime', () {
+      final now = DateTime(2026, 1, 11);
+      expect(
+        () => SleepStageSample(
+          startTime: now,
+          endTime: now.subtract(const Duration(minutes: 1)),
+          stageType: SleepStage.light,
+        ),
+        throwsArgumentError,
+      );
+    });
+
+    test('equality works correctly', () {
+      final now = DateTime(2026, 1, 11);
+      final end = now.add(const Duration(minutes: 30));
+      final sample1 = SleepStageSample(
+        startTime: now,
+        endTime: end,
+        stageType: SleepStage.light,
+      );
+      final sample2 = SleepStageSample(
+        startTime: now,
+        endTime: end,
+        stageType: SleepStage.light,
+      );
+      final sample3 = SleepStageSample(
+        startTime: now,
+        endTime: end,
+        stageType: SleepStage.deep,
+      );
+
+      expect(sample1 == sample2, isTrue);
+      expect(sample1 == sample3, isFalse);
+      expect(sample1.hashCode == sample2.hashCode, isTrue);
+    });
+  });
+}

--- a/packages/health_connector_core/test/src/models/health_records/sleep/sleep_stage_record_test.dart
+++ b/packages/health_connector_core/test/src/models/health_records/sleep/sleep_stage_record_test.dart
@@ -1,0 +1,127 @@
+import 'package:health_connector_core/health_connector_core.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('SleepStageRecord', () {
+    final now = DateTime(2026, 1, 11);
+    final startTime = now.subtract(const Duration(minutes: 30));
+    final endTime = now;
+    final metadata = Metadata.manualEntry();
+    const stageType = SleepStage.light;
+
+    test('can be instantiated with valid parameters', () {
+      final record = SleepStageRecord(
+        id: HealthRecordId.none,
+        startTime: startTime,
+        endTime: endTime,
+        stageType: stageType,
+        metadata: metadata,
+        title: 'Nap',
+        notes: 'Good',
+      );
+
+      expect(record.startTime, startTime);
+      expect(record.endTime, endTime);
+      expect(record.stageType, stageType);
+      expect(record.metadata, metadata);
+      expect(record.title, 'Nap');
+      expect(record.notes, 'Good');
+    });
+
+    test('throws ArgumentError when endTime is before startTime', () {
+      expect(
+        () => SleepStageRecord(
+          id: HealthRecordId.none,
+          startTime: endTime,
+          endTime: startTime,
+          stageType: stageType,
+          metadata: metadata,
+        ),
+        throwsArgumentError,
+      );
+    });
+
+    test('isActualSleep returns correct values', () {
+      var record = SleepStageRecord(
+        id: HealthRecordId.none,
+        startTime: startTime,
+        endTime: endTime,
+        stageType: SleepStage.light,
+        metadata: metadata,
+      );
+      expect(record.isActualSleep, isTrue);
+
+      record = record.copyWith(stageType: SleepStage.awake);
+      expect(record.isActualSleep, isFalse);
+
+      record = record.copyWith(stageType: SleepStage.inBed);
+      expect(record.isActualSleep, isFalse);
+
+      record = record.copyWith(stageType: SleepStage.deep);
+      expect(record.isActualSleep, isTrue);
+    });
+
+    test('copyWith updates all fields correctly', () {
+      final record = SleepStageRecord(
+        id: HealthRecordId.none,
+        startTime: startTime,
+        endTime: endTime,
+        stageType: stageType,
+        metadata: metadata,
+      );
+
+      final newStartTime = startTime.subtract(const Duration(minutes: 5));
+      final newEndTime = endTime.add(const Duration(minutes: 5));
+      const newStageType = SleepStage.deep;
+      const newTitle = 'Updated';
+      const newNotes = 'Notes';
+      final newMetadata = Metadata.manualEntry();
+
+      final updated = record.copyWith(
+        startTime: newStartTime,
+        endTime: newEndTime,
+        stageType: newStageType,
+        title: newTitle,
+        notes: newNotes,
+        metadata: newMetadata,
+      );
+
+      expect(updated.startTime, newStartTime);
+      expect(updated.endTime, newEndTime);
+      expect(updated.stageType, newStageType);
+      expect(updated.title, newTitle);
+      expect(updated.notes, newNotes);
+      expect(updated.metadata, newMetadata);
+    });
+
+    test('equality works correctly', () {
+      final record1 = SleepStageRecord(
+        id: HealthRecordId.none,
+        startTime: startTime,
+        endTime: endTime,
+        stageType: stageType,
+        metadata: metadata,
+      );
+
+      final record2 = SleepStageRecord(
+        id: HealthRecordId.none,
+        startTime: startTime,
+        endTime: endTime,
+        stageType: stageType,
+        metadata: metadata,
+      );
+
+      final record3 = SleepStageRecord(
+        id: HealthRecordId.none,
+        startTime: startTime,
+        endTime: endTime,
+        stageType: SleepStage.deep,
+        metadata: metadata,
+      );
+
+      expect(record1 == record2, isTrue);
+      expect(record1 == record3, isFalse);
+      expect(record1.hashCode == record2.hashCode, isTrue);
+    });
+  });
+}

--- a/packages/health_connector_core/test/src/models/health_records/speed/running_speed_record_test.dart
+++ b/packages/health_connector_core/test/src/models/health_records/speed/running_speed_record_test.dart
@@ -1,0 +1,90 @@
+import 'package:health_connector_core/health_connector_core.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('RunningSpeedRecord', () {
+    final now = DateTime(2026, 1, 11);
+    final metadata = Metadata.manualEntry();
+    const validSpeed = Velocity.kilometersPerHour(10.0);
+
+    test('can be instantiated with valid parameters', () {
+      final record = RunningSpeedRecord(
+        time: now,
+        speed: validSpeed,
+        metadata: metadata,
+      );
+
+      expect(record.time, now);
+      expect(record.speed, validSpeed);
+      expect(record.metadata, metadata);
+    });
+
+    test('throws ArgumentError when speed is below minSpeed', () {
+      expect(
+        () => RunningSpeedRecord(
+          time: now,
+          speed: const Velocity.kilometersPerHour(-0.1),
+          metadata: metadata,
+        ),
+        throwsArgumentError,
+      );
+    });
+
+    test('throws ArgumentError when speed is above maxSpeed', () {
+      expect(
+        () => RunningSpeedRecord(
+          time: now,
+          speed: const Velocity.kilometersPerHour(50.1),
+          metadata: metadata,
+        ),
+        throwsArgumentError,
+      );
+    });
+
+    test('copyWith updates all fields correctly', () {
+      final record = RunningSpeedRecord(
+        time: now,
+        speed: validSpeed,
+        metadata: metadata,
+      );
+
+      final newTime = now.add(const Duration(minutes: 5));
+      const newSpeed = Velocity.kilometersPerHour(12.0);
+      final newMetadata = Metadata.manualEntry();
+
+      final updated = record.copyWith(
+        time: newTime,
+        speed: newSpeed,
+        metadata: newMetadata,
+      );
+
+      expect(updated.time, newTime);
+      expect(updated.speed, newSpeed);
+      expect(updated.metadata, newMetadata);
+    });
+
+    test('equality works correctly', () {
+      final record1 = RunningSpeedRecord(
+        time: now,
+        speed: validSpeed,
+        metadata: metadata,
+      );
+
+      final record2 = RunningSpeedRecord(
+        time: now,
+        speed: validSpeed,
+        metadata: metadata,
+      );
+
+      final record3 = RunningSpeedRecord(
+        time: now,
+        speed: const Velocity.kilometersPerHour(10.1),
+        metadata: metadata,
+      );
+
+      expect(record1 == record2, isTrue);
+      expect(record1 == record3, isFalse);
+      expect(record1.hashCode == record2.hashCode, isTrue);
+    });
+  });
+}

--- a/packages/health_connector_core/test/src/models/health_records/speed/speed_series_record_test.dart
+++ b/packages/health_connector_core/test/src/models/health_records/speed/speed_series_record_test.dart
@@ -1,0 +1,162 @@
+import 'package:health_connector_core/health_connector_core.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('SpeedSeriesRecord', () {
+    final now = DateTime(2026, 1, 11);
+    final startTime = now.subtract(const Duration(minutes: 30));
+    final endTime = now;
+    final metadata = Metadata.manualEntry();
+    final samples = [
+      SpeedSample(
+        time: startTime,
+        speed: const Velocity.kilometersPerHour(5.0),
+      ),
+      SpeedSample(
+        time: endTime,
+        speed: const Velocity.kilometersPerHour(6.0),
+      ),
+    ];
+
+    test('can be instantiated with valid parameters', () {
+      final record = SpeedSeriesRecord(
+        startTime: startTime,
+        endTime: endTime,
+        samples: samples,
+        metadata: metadata,
+      );
+
+      expect(record.startTime, startTime);
+      expect(record.endTime, endTime);
+      expect(record.samples, samples);
+      expect(record.metadata, metadata);
+    });
+
+    test('throws ArgumentError when endTime is before startTime', () {
+      expect(
+        () => SpeedSeriesRecord(
+          startTime: endTime,
+          endTime: startTime,
+          samples: const [],
+          metadata: metadata,
+        ),
+        throwsArgumentError,
+      );
+    });
+
+    test('calculates statistics correctly', () {
+      final record = SpeedSeriesRecord(
+        startTime: startTime,
+        endTime: endTime,
+        samples: samples,
+        metadata: metadata,
+      );
+
+      // 5.0 and 6.0 avg = 5.5
+      expect(record.avgSpeed.inKilometersPerHour, closeTo(5.5, 0.001));
+      expect(record.maxSpeed.inKilometersPerHour, 6.0);
+      expect(record.minSpeed.inKilometersPerHour, 5.0);
+    });
+
+    test('calculates statistics correctly with empty samples', () {
+      final record = SpeedSeriesRecord(
+        startTime: startTime,
+        endTime: endTime,
+        samples: const [],
+        metadata: metadata,
+      );
+
+      expect(record.avgSpeed, Velocity.zero);
+      expect(record.maxSpeed, Velocity.zero);
+      expect(record.minSpeed, Velocity.zero);
+    });
+
+    test('copyWith updates all fields correctly', () {
+      final record = SpeedSeriesRecord(
+        startTime: startTime,
+        endTime: endTime,
+        samples: samples,
+        metadata: metadata,
+      );
+
+      final newStartTime = startTime.subtract(const Duration(minutes: 5));
+      final newEndTime = endTime.add(const Duration(minutes: 5));
+      final newSamples = [samples.first];
+      final newMetadata = Metadata.manualEntry();
+
+      final updated = record.copyWith(
+        startTime: newStartTime,
+        endTime: newEndTime,
+        samples: newSamples,
+        metadata: newMetadata,
+      );
+
+      expect(updated.startTime, newStartTime);
+      expect(updated.endTime, newEndTime);
+      expect(updated.samples, newSamples);
+      expect(updated.metadata, newMetadata);
+    });
+
+    test('equality works correctly', () {
+      final record1 = SpeedSeriesRecord(
+        startTime: startTime,
+        endTime: endTime,
+        samples: samples,
+        metadata: metadata,
+      );
+
+      final record2 = SpeedSeriesRecord(
+        startTime: startTime,
+        endTime: endTime,
+        samples: samples,
+        metadata: metadata,
+      );
+
+      // Different samples
+      final samples2 = [samples.first];
+      final record3 = SpeedSeriesRecord(
+        startTime: startTime,
+        endTime: endTime,
+        samples: samples2,
+        metadata: metadata,
+      );
+
+      expect(record1 == record2, isTrue);
+      // Samples contain identical objects in same order
+      expect(record1.samples.first == record2.samples.first, isTrue);
+      expect(record1 == record3, isFalse);
+    });
+  });
+
+  group('SpeedSample', () {
+    test('throws ArgumentError when speed is invalid', () {
+      expect(
+        () => SpeedSample(
+          time: DateTime.now(),
+          speed: const Velocity.kilometersPerHour(-0.1),
+        ),
+        throwsArgumentError,
+      );
+    });
+
+    test('equality works correctly', () {
+      final now = DateTime(2026, 1, 11);
+      final sample1 = SpeedSample(
+        time: now,
+        speed: const Velocity.kilometersPerHour(5.0),
+      );
+      final sample2 = SpeedSample(
+        time: now,
+        speed: const Velocity.kilometersPerHour(5.0),
+      );
+      final sample3 = SpeedSample(
+        time: now,
+        speed: const Velocity.kilometersPerHour(6.0),
+      );
+
+      expect(sample1 == sample2, isTrue);
+      expect(sample1 == sample3, isFalse);
+      expect(sample1.hashCode == sample2.hashCode, isTrue);
+    });
+  });
+}

--- a/packages/health_connector_core/test/src/models/health_records/speed/stair_ascent_speed_record_test.dart
+++ b/packages/health_connector_core/test/src/models/health_records/speed/stair_ascent_speed_record_test.dart
@@ -1,0 +1,90 @@
+import 'package:health_connector_core/health_connector_core.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('StairAscentSpeedRecord', () {
+    final now = DateTime(2026, 1, 11);
+    final metadata = Metadata.manualEntry();
+    const validSpeed = Velocity.kilometersPerHour(1.0);
+
+    test('can be instantiated with valid parameters', () {
+      final record = StairAscentSpeedRecord(
+        time: now,
+        speed: validSpeed,
+        metadata: metadata,
+      );
+
+      expect(record.time, now);
+      expect(record.speed, validSpeed);
+      expect(record.metadata, metadata);
+    });
+
+    test('throws ArgumentError when speed is below minSpeed', () {
+      expect(
+        () => StairAscentSpeedRecord(
+          time: now,
+          speed: const Velocity.kilometersPerHour(-0.1),
+          metadata: metadata,
+        ),
+        throwsArgumentError,
+      );
+    });
+
+    test('throws ArgumentError when speed is above maxSpeed', () {
+      expect(
+        () => StairAscentSpeedRecord(
+          time: now,
+          speed: const Velocity.kilometersPerHour(2.1),
+          metadata: metadata,
+        ),
+        throwsArgumentError,
+      );
+    });
+
+    test('copyWith updates all fields correctly', () {
+      final record = StairAscentSpeedRecord(
+        time: now,
+        speed: validSpeed,
+        metadata: metadata,
+      );
+
+      final newTime = now.add(const Duration(minutes: 5));
+      const newSpeed = Velocity.kilometersPerHour(1.2);
+      final newMetadata = Metadata.manualEntry();
+
+      final updated = record.copyWith(
+        time: newTime,
+        speed: newSpeed,
+        metadata: newMetadata,
+      );
+
+      expect(updated.time, newTime);
+      expect(updated.speed, newSpeed);
+      expect(updated.metadata, newMetadata);
+    });
+
+    test('equality works correctly', () {
+      final record1 = StairAscentSpeedRecord(
+        time: now,
+        speed: validSpeed,
+        metadata: metadata,
+      );
+
+      final record2 = StairAscentSpeedRecord(
+        time: now,
+        speed: validSpeed,
+        metadata: metadata,
+      );
+
+      final record3 = StairAscentSpeedRecord(
+        time: now,
+        speed: const Velocity.kilometersPerHour(1.1),
+        metadata: metadata,
+      );
+
+      expect(record1 == record2, isTrue);
+      expect(record1 == record3, isFalse);
+      expect(record1.hashCode == record2.hashCode, isTrue);
+    });
+  });
+}

--- a/packages/health_connector_core/test/src/models/health_records/speed/stair_descent_speed_record_test.dart
+++ b/packages/health_connector_core/test/src/models/health_records/speed/stair_descent_speed_record_test.dart
@@ -1,0 +1,90 @@
+import 'package:health_connector_core/health_connector_core.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('StairDescentSpeedRecord', () {
+    final now = DateTime(2026, 1, 11);
+    final metadata = Metadata.manualEntry();
+    const validSpeed = Velocity.kilometersPerHour(1.5);
+
+    test('can be instantiated with valid parameters', () {
+      final record = StairDescentSpeedRecord(
+        time: now,
+        speed: validSpeed,
+        metadata: metadata,
+      );
+
+      expect(record.time, now);
+      expect(record.speed, validSpeed);
+      expect(record.metadata, metadata);
+    });
+
+    test('throws ArgumentError when speed is below minSpeed', () {
+      expect(
+        () => StairDescentSpeedRecord(
+          time: now,
+          speed: const Velocity.kilometersPerHour(-0.1),
+          metadata: metadata,
+        ),
+        throwsArgumentError,
+      );
+    });
+
+    test('throws ArgumentError when speed is above maxSpeed', () {
+      expect(
+        () => StairDescentSpeedRecord(
+          time: now,
+          speed: const Velocity.kilometersPerHour(3.1),
+          metadata: metadata,
+        ),
+        throwsArgumentError,
+      );
+    });
+
+    test('copyWith updates all fields correctly', () {
+      final record = StairDescentSpeedRecord(
+        time: now,
+        speed: validSpeed,
+        metadata: metadata,
+      );
+
+      final newTime = now.add(const Duration(minutes: 5));
+      const newSpeed = Velocity.kilometersPerHour(1.8);
+      final newMetadata = Metadata.manualEntry();
+
+      final updated = record.copyWith(
+        time: newTime,
+        speed: newSpeed,
+        metadata: newMetadata,
+      );
+
+      expect(updated.time, newTime);
+      expect(updated.speed, newSpeed);
+      expect(updated.metadata, newMetadata);
+    });
+
+    test('equality works correctly', () {
+      final record1 = StairDescentSpeedRecord(
+        time: now,
+        speed: validSpeed,
+        metadata: metadata,
+      );
+
+      final record2 = StairDescentSpeedRecord(
+        time: now,
+        speed: validSpeed,
+        metadata: metadata,
+      );
+
+      final record3 = StairDescentSpeedRecord(
+        time: now,
+        speed: const Velocity.kilometersPerHour(1.6),
+        metadata: metadata,
+      );
+
+      expect(record1 == record2, isTrue);
+      expect(record1 == record3, isFalse);
+      expect(record1.hashCode == record2.hashCode, isTrue);
+    });
+  });
+}

--- a/packages/health_connector_core/test/src/models/health_records/speed/walking_speed_record_test.dart
+++ b/packages/health_connector_core/test/src/models/health_records/speed/walking_speed_record_test.dart
@@ -1,0 +1,90 @@
+import 'package:health_connector_core/health_connector_core.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('WalkingSpeedRecord', () {
+    final now = DateTime(2026, 1, 11);
+    final metadata = Metadata.manualEntry();
+    const validSpeed = Velocity.kilometersPerHour(5.0);
+
+    test('can be instantiated with valid parameters', () {
+      final record = WalkingSpeedRecord(
+        time: now,
+        speed: validSpeed,
+        metadata: metadata,
+      );
+
+      expect(record.time, now);
+      expect(record.speed, validSpeed);
+      expect(record.metadata, metadata);
+    });
+
+    test('throws ArgumentError when speed is below minSpeed', () {
+      expect(
+        () => WalkingSpeedRecord(
+          time: now,
+          speed: const Velocity.kilometersPerHour(-0.1),
+          metadata: metadata,
+        ),
+        throwsArgumentError,
+      );
+    });
+
+    test('throws ArgumentError when speed is above maxSpeed', () {
+      expect(
+        () => WalkingSpeedRecord(
+          time: now,
+          speed: const Velocity.kilometersPerHour(12.1),
+          metadata: metadata,
+        ),
+        throwsArgumentError,
+      );
+    });
+
+    test('copyWith updates all fields correctly', () {
+      final record = WalkingSpeedRecord(
+        time: now,
+        speed: validSpeed,
+        metadata: metadata,
+      );
+
+      final newTime = now.add(const Duration(minutes: 5));
+      const newSpeed = Velocity.kilometersPerHour(5.5);
+      final newMetadata = Metadata.manualEntry();
+
+      final updated = record.copyWith(
+        time: newTime,
+        speed: newSpeed,
+        metadata: newMetadata,
+      );
+
+      expect(updated.time, newTime);
+      expect(updated.speed, newSpeed);
+      expect(updated.metadata, newMetadata);
+    });
+
+    test('equality works correctly', () {
+      final record1 = WalkingSpeedRecord(
+        time: now,
+        speed: validSpeed,
+        metadata: metadata,
+      );
+
+      final record2 = WalkingSpeedRecord(
+        time: now,
+        speed: validSpeed,
+        metadata: metadata,
+      );
+
+      final record3 = WalkingSpeedRecord(
+        time: now,
+        speed: const Velocity.kilometersPerHour(5.1),
+        metadata: metadata,
+      );
+
+      expect(record1 == record2, isTrue);
+      expect(record1 == record3, isFalse);
+      expect(record1.hashCode == record2.hashCode, isTrue);
+    });
+  });
+}

--- a/packages/health_connector_core/test/src/models/health_records/steps_record_test.dart
+++ b/packages/health_connector_core/test/src/models/health_records/steps_record_test.dart
@@ -1,0 +1,101 @@
+import 'package:health_connector_core/health_connector_core.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('StepsRecord', () {
+    final now = DateTime(2026, 1, 11);
+    final startTime = now.subtract(const Duration(hours: 1));
+    final endTime = now;
+    final metadata = Metadata.manualEntry();
+    const validCount = Number(1000);
+
+    test('can be instantiated with valid parameters', () {
+      final record = StepsRecord(
+        startTime: startTime,
+        endTime: endTime,
+        count: validCount,
+        metadata: metadata,
+      );
+
+      expect(record.startTime, startTime);
+      expect(record.endTime, endTime);
+      expect(record.count, equals(validCount));
+      expect(record.metadata, metadata);
+    });
+
+    test('throws ArgumentError when count is negative', () {
+      expect(
+        () => StepsRecord(
+          startTime: startTime,
+          endTime: endTime,
+          count: const Number(-1),
+          metadata: metadata,
+        ),
+        throwsArgumentError,
+      );
+    });
+
+    test('throws ArgumentError when count is above maxSteps', () {
+      expect(
+        () => StepsRecord(
+          startTime: startTime,
+          endTime: endTime,
+          count: const Number(1000001),
+          metadata: metadata,
+        ),
+        throwsArgumentError,
+      );
+    });
+
+    test('copyWith updates all fields correctly', () {
+      final record = StepsRecord(
+        startTime: startTime,
+        endTime: endTime,
+        count: validCount,
+        metadata: metadata,
+      );
+
+      final newStartTime = startTime.subtract(const Duration(minutes: 10));
+      const newCount = Number(2000);
+      final newMetadata = Metadata.manualEntry();
+
+      final updatedRecord = record.copyWith(
+        startTime: newStartTime,
+        count: newCount,
+        metadata: newMetadata,
+      );
+
+      expect(updatedRecord.startTime, newStartTime);
+      expect(updatedRecord.count, newCount);
+      expect(updatedRecord.metadata, newMetadata);
+      expect(updatedRecord.endTime, endTime); // Unchanged
+    });
+
+    test('equality works correctly', () {
+      final record1 = StepsRecord(
+        startTime: startTime,
+        endTime: endTime,
+        count: validCount,
+        metadata: metadata,
+      );
+
+      final record2 = StepsRecord(
+        startTime: startTime,
+        endTime: endTime,
+        count: validCount,
+        metadata: metadata,
+      );
+
+      final record3 = StepsRecord(
+        startTime: startTime,
+        endTime: endTime,
+        count: const Number(500),
+        metadata: metadata,
+      );
+
+      expect(record1 == record2, isTrue);
+      expect(record1 == record3, isFalse);
+      expect(record1.hashCode == record2.hashCode, isTrue);
+    });
+  });
+}

--- a/packages/health_connector_core/test/src/models/health_records/temperature/basal_body_temperature_record_test.dart
+++ b/packages/health_connector_core/test/src/models/health_records/temperature/basal_body_temperature_record_test.dart
@@ -1,0 +1,90 @@
+import 'package:health_connector_core/health_connector_core.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('BasalBodyTemperatureRecord', () {
+    final now = DateTime(2026, 1, 11);
+    final metadata = Metadata.manualEntry();
+    final validTemp = Temperature.celsius(36.5);
+
+    test('can be instantiated with valid parameters', () {
+      final record = BasalBodyTemperatureRecord(
+        time: now,
+        temperature: validTemp,
+        metadata: metadata,
+      );
+
+      expect(record.time, now);
+      expect(record.temperature, equals(validTemp));
+      expect(record.metadata, metadata);
+    });
+
+    test('throws ArgumentError when temperature is below minTemperature', () {
+      expect(
+        () => BasalBodyTemperatureRecord(
+          time: now,
+          temperature: const Temperature.celsius(20.0),
+          metadata: metadata,
+        ),
+        throwsArgumentError,
+      );
+    });
+
+    test('throws ArgumentError when temperature is above maxTemperature', () {
+      expect(
+        () => BasalBodyTemperatureRecord(
+          time: now,
+          temperature: const Temperature.celsius(45.0),
+          metadata: metadata,
+        ),
+        throwsArgumentError,
+      );
+    });
+
+    test('copyWith updates all fields correctly', () {
+      final record = BasalBodyTemperatureRecord(
+        time: now,
+        temperature: validTemp,
+        metadata: metadata,
+      );
+
+      final newTime = now.add(const Duration(minutes: 5));
+      final newTemp = Temperature.celsius(37.0);
+      final newMetadata = Metadata.manualEntry();
+
+      final updated = record.copyWith(
+        time: newTime,
+        temperature: newTemp,
+        metadata: newMetadata,
+      );
+
+      expect(updated.time, newTime);
+      expect(updated.temperature, newTemp);
+      expect(updated.metadata, newMetadata);
+    });
+
+    test('equality works correctly', () {
+      final record1 = BasalBodyTemperatureRecord(
+        time: now,
+        temperature: validTemp,
+        metadata: metadata,
+      );
+
+      final record2 = BasalBodyTemperatureRecord(
+        time: now,
+        temperature: validTemp,
+        metadata: metadata,
+      );
+
+      final record3 = BasalBodyTemperatureRecord(
+        time: now,
+        temperature: const Temperature.celsius(37.0),
+        metadata: metadata,
+      );
+
+      expect(record1 == record2, isTrue);
+      expect(record1 == record3, isFalse);
+      expect(record1.hashCode == record2.hashCode, isTrue);
+    });
+  });
+}

--- a/packages/health_connector_core/test/src/models/health_records/temperature/body_temperature_record_test.dart
+++ b/packages/health_connector_core/test/src/models/health_records/temperature/body_temperature_record_test.dart
@@ -1,0 +1,90 @@
+import 'package:health_connector_core/health_connector_core.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('BodyTemperatureRecord', () {
+    final now = DateTime(2026, 1, 11);
+    final metadata = Metadata.manualEntry();
+    const validTemp = Temperature.celsius(37.0);
+
+    test('can be instantiated with valid parameters', () {
+      final record = BodyTemperatureRecord(
+        time: now,
+        temperature: validTemp,
+        metadata: metadata,
+      );
+
+      expect(record.time, now);
+      expect(record.temperature, equals(validTemp));
+      expect(record.metadata, metadata);
+    });
+
+    test('throws ArgumentError when temperature is below minTemperature', () {
+      expect(
+        () => BodyTemperatureRecord(
+          time: now,
+          temperature: Temperature.zero,
+          metadata: metadata,
+        ),
+        throwsArgumentError,
+      );
+    });
+
+    test('throws ArgumentError when temperature is above maxTemperature', () {
+      expect(
+        () => BodyTemperatureRecord(
+          time: now,
+          temperature: const Temperature.celsius(50.0),
+          metadata: metadata,
+        ),
+        throwsArgumentError,
+      );
+    });
+
+    test('copyWith updates all fields correctly', () {
+      final record = BodyTemperatureRecord(
+        time: now,
+        temperature: validTemp,
+        metadata: metadata,
+      );
+
+      final newTime = now.add(const Duration(minutes: 5));
+      const newTemp = Temperature.celsius(38.0);
+      final newMetadata = Metadata.manualEntry();
+
+      final updated = record.copyWith(
+        time: newTime,
+        temperature: newTemp,
+        metadata: newMetadata,
+      );
+
+      expect(updated.time, newTime);
+      expect(updated.temperature, newTemp);
+      expect(updated.metadata, newMetadata);
+    });
+
+    test('equality works correctly', () {
+      final record1 = BodyTemperatureRecord(
+        time: now,
+        temperature: validTemp,
+        metadata: metadata,
+      );
+
+      final record2 = BodyTemperatureRecord(
+        time: now,
+        temperature: validTemp,
+        metadata: metadata,
+      );
+
+      final record3 = BodyTemperatureRecord(
+        time: now,
+        temperature: const Temperature.celsius(38.0),
+        metadata: metadata,
+      );
+
+      expect(record1 == record2, isTrue);
+      expect(record1 == record3, isFalse);
+      expect(record1.hashCode == record2.hashCode, isTrue);
+    });
+  });
+}

--- a/packages/health_connector_core/test/src/models/health_records/vo2_max_record_test.dart
+++ b/packages/health_connector_core/test/src/models/health_records/vo2_max_record_test.dart
@@ -1,0 +1,109 @@
+import 'package:health_connector_core/health_connector_core.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('Vo2MaxRecord', () {
+    final now = DateTime(2026, 1, 11);
+    final metadata = Metadata.manualEntry();
+    const validVo2 = Number(45.0);
+    const testType = Vo2MaxTestType.cooperTest;
+
+    test('can be instantiated with valid parameters', () {
+      final record = Vo2MaxRecord(
+        time: now,
+        vo2MlPerMinPerKg: validVo2,
+        testType: testType,
+        metadata: metadata,
+      );
+
+      expect(record.time, now);
+      expect(record.vo2MlPerMinPerKg, validVo2);
+      expect(record.testType, testType);
+      expect(record.metadata, metadata);
+    });
+
+    test('can be instantiated without testType', () {
+      final record = Vo2MaxRecord(
+        time: now,
+        vo2MlPerMinPerKg: validVo2,
+        metadata: metadata,
+      );
+      expect(record.testType, isNull);
+    });
+
+    test('throws ArgumentError when vo2MlPerMinPerKg is below min', () {
+      expect(
+        () => Vo2MaxRecord(
+          time: now,
+          vo2MlPerMinPerKg: const Number(4.9),
+          metadata: metadata,
+        ),
+        throwsArgumentError,
+      );
+    });
+
+    test('throws ArgumentError when vo2MlPerMinPerKg is above max', () {
+      expect(
+        () => Vo2MaxRecord(
+          time: now,
+          vo2MlPerMinPerKg: const Number(100.1),
+          metadata: metadata,
+        ),
+        throwsArgumentError,
+      );
+    });
+
+    test('copyWith updates all fields correctly', () {
+      final record = Vo2MaxRecord(
+        time: now,
+        vo2MlPerMinPerKg: validVo2,
+        testType: testType,
+        metadata: metadata,
+      );
+
+      final newTime = now.add(const Duration(minutes: 5));
+      const newVo2 = Number(50.0);
+      const newTestType = Vo2MaxTestType.rockportFitnessTest;
+      final newMetadata = Metadata.manualEntry();
+
+      final updated = record.copyWith(
+        time: newTime,
+        vo2MlPerMinPerKg: newVo2,
+        testType: newTestType,
+        metadata: newMetadata,
+      );
+
+      expect(updated.time, newTime);
+      expect(updated.vo2MlPerMinPerKg, newVo2);
+      expect(updated.testType, newTestType);
+      expect(updated.metadata, newMetadata);
+    });
+
+    test('equality works correctly', () {
+      final record1 = Vo2MaxRecord(
+        time: now,
+        vo2MlPerMinPerKg: validVo2,
+        testType: testType,
+        metadata: metadata,
+      );
+
+      final record2 = Vo2MaxRecord(
+        time: now,
+        vo2MlPerMinPerKg: validVo2,
+        testType: testType,
+        metadata: metadata,
+      );
+
+      final record3 = Vo2MaxRecord(
+        time: now,
+        vo2MlPerMinPerKg: const Number(46.0),
+        testType: testType,
+        metadata: metadata,
+      );
+
+      expect(record1 == record2, isTrue);
+      expect(record1 == record3, isFalse);
+      expect(record1.hashCode == record2.hashCode, isTrue);
+    });
+  });
+}

--- a/packages/health_connector_core/test/src/models/health_records/waist_circumference_record_test.dart
+++ b/packages/health_connector_core/test/src/models/health_records/waist_circumference_record_test.dart
@@ -1,0 +1,96 @@
+import 'package:health_connector_core/health_connector_core.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('WaistCircumferenceRecord', () {
+    final now = DateTime(2026, 1, 11);
+    final metadata = Metadata.manualEntry();
+    const validCircumference = Length.centimeters(85.0);
+
+    test('can be instantiated with valid parameters', () {
+      final record = WaistCircumferenceRecord(
+        time: now,
+        circumference: validCircumference,
+        metadata: metadata,
+      );
+
+      expect(record.time, now);
+      expect(record.circumference, validCircumference);
+      expect(record.metadata, metadata);
+    });
+
+    test(
+      'throws ArgumentError when circumference is below minCircumference',
+      () {
+        expect(
+          () => WaistCircumferenceRecord(
+            time: now,
+            circumference: const Length.centimeters(19.9),
+            metadata: metadata,
+          ),
+          throwsArgumentError,
+        );
+      },
+    );
+
+    test(
+      'throws ArgumentError when circumference is above maxCircumference',
+      () {
+        expect(
+          () => WaistCircumferenceRecord(
+            time: now,
+            circumference: const Length.centimeters(200.1),
+            metadata: metadata,
+          ),
+          throwsArgumentError,
+        );
+      },
+    );
+
+    test('copyWith updates all fields correctly', () {
+      final record = WaistCircumferenceRecord(
+        time: now,
+        circumference: validCircumference,
+        metadata: metadata,
+      );
+
+      final newTime = now.add(const Duration(minutes: 5));
+      const newCircumference = Length.centimeters(86.0);
+      final newMetadata = Metadata.manualEntry();
+
+      final updated = record.copyWith(
+        time: newTime,
+        circumference: newCircumference,
+        metadata: newMetadata,
+      );
+
+      expect(updated.time, newTime);
+      expect(updated.circumference, newCircumference);
+      expect(updated.metadata, newMetadata);
+    });
+
+    test('equality works correctly', () {
+      final record1 = WaistCircumferenceRecord(
+        time: now,
+        circumference: validCircumference,
+        metadata: metadata,
+      );
+
+      final record2 = WaistCircumferenceRecord(
+        time: now,
+        circumference: validCircumference,
+        metadata: metadata,
+      );
+
+      final record3 = WaistCircumferenceRecord(
+        time: now,
+        circumference: const Length.centimeters(85.1),
+        metadata: metadata,
+      );
+
+      expect(record1 == record2, isTrue);
+      expect(record1 == record3, isFalse);
+      expect(record1.hashCode == record2.hashCode, isTrue);
+    });
+  });
+}

--- a/packages/health_connector_core/test/src/models/health_records/weight_record_test.dart
+++ b/packages/health_connector_core/test/src/models/health_records/weight_record_test.dart
@@ -1,0 +1,90 @@
+import 'package:health_connector_core/health_connector_core.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('WeightRecord', () {
+    final now = DateTime(2026, 1, 11);
+    final metadata = Metadata.manualEntry();
+    const validWeight = Mass.kilograms(70.0);
+
+    test('can be instantiated with valid parameters', () {
+      final record = WeightRecord(
+        time: now,
+        weight: validWeight,
+        metadata: metadata,
+      );
+
+      expect(record.time, now);
+      expect(record.weight, equals(validWeight));
+      expect(record.metadata, metadata);
+    });
+
+    test('throws ArgumentError when weight is below minWeight', () {
+      expect(
+        () => WeightRecord(
+          time: now,
+          weight: const Mass.kilograms(0.1),
+          metadata: metadata,
+        ),
+        throwsArgumentError,
+      );
+    });
+
+    test('throws ArgumentError when weight is above maxWeight', () {
+      expect(
+        () => WeightRecord(
+          time: now,
+          weight: const Mass.kilograms(701.0),
+          metadata: metadata,
+        ),
+        throwsArgumentError,
+      );
+    });
+
+    test('copyWith updates all fields correctly', () {
+      final record = WeightRecord(
+        time: now,
+        weight: validWeight,
+        metadata: metadata,
+      );
+
+      final newTime = now.add(const Duration(minutes: 5));
+      const newWeight = Mass.kilograms(75.0);
+      final newMetadata = Metadata.manualEntry();
+
+      final updated = record.copyWith(
+        time: newTime,
+        weight: newWeight,
+        metadata: newMetadata,
+      );
+
+      expect(updated.time, newTime);
+      expect(updated.weight, newWeight);
+      expect(updated.metadata, newMetadata);
+    });
+
+    test('equality works correctly', () {
+      final record1 = WeightRecord(
+        time: now,
+        weight: validWeight,
+        metadata: metadata,
+      );
+
+      final record2 = WeightRecord(
+        time: now,
+        weight: validWeight,
+        metadata: metadata,
+      );
+
+      final record3 = WeightRecord(
+        time: now,
+        weight: const Mass.kilograms(75.0),
+        metadata: metadata,
+      );
+
+      expect(record1 == record2, isTrue);
+      expect(record1 == record3, isFalse);
+      expect(record1.hashCode == record2.hashCode, isTrue);
+    });
+  });
+}

--- a/packages/health_connector_core/test/src/models/health_records/wheelchair_pushes_record_test.dart
+++ b/packages/health_connector_core/test/src/models/health_records/wheelchair_pushes_record_test.dart
@@ -1,0 +1,89 @@
+import 'package:health_connector_core/health_connector_core.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('WheelchairPushesRecord', () {
+    final now = DateTime(2026, 1, 11);
+    final startTime = now.subtract(const Duration(hours: 1));
+    final endTime = now;
+    final metadata = Metadata.manualEntry();
+    const validCount = Number(500);
+
+    test('can be instantiated with valid parameters', () {
+      final record = WheelchairPushesRecord(
+        startTime: startTime,
+        endTime: endTime,
+        count: validCount,
+        metadata: metadata,
+      );
+
+      expect(record.startTime, startTime);
+      expect(record.endTime, endTime);
+      expect(record.count, equals(validCount));
+      expect(record.metadata, metadata);
+    });
+
+    test('throws ArgumentError when count is negative', () {
+      expect(
+        () => WheelchairPushesRecord(
+          startTime: startTime,
+          endTime: endTime,
+          count: const Number(-1),
+          metadata: metadata,
+        ),
+        throwsArgumentError,
+      );
+    });
+
+    test('copyWith updates all fields correctly', () {
+      final record = WheelchairPushesRecord(
+        startTime: startTime,
+        endTime: endTime,
+        count: validCount,
+        metadata: metadata,
+      );
+
+      final newStartTime = startTime.subtract(const Duration(minutes: 10));
+      const newCount = Number(600);
+      final newMetadata = Metadata.manualEntry();
+
+      final updatedRecord = record.copyWith(
+        startTime: newStartTime,
+        count: newCount,
+        metadata: newMetadata,
+      );
+
+      expect(updatedRecord.startTime, newStartTime);
+      expect(updatedRecord.count, newCount);
+      expect(updatedRecord.metadata, newMetadata);
+      expect(updatedRecord.endTime, endTime); // Unchanged
+    });
+
+    test('equality works correctly', () {
+      final record1 = WheelchairPushesRecord(
+        startTime: startTime,
+        endTime: endTime,
+        count: validCount,
+        metadata: metadata,
+      );
+
+      final record2 = WheelchairPushesRecord(
+        startTime: startTime,
+        endTime: endTime,
+        count: validCount,
+        metadata: metadata,
+      );
+
+      final record3 = WheelchairPushesRecord(
+        startTime: startTime,
+        endTime: endTime,
+        count: const Number(600),
+        metadata: metadata,
+      );
+
+      expect(record1 == record2, isTrue);
+      expect(record1 == record3, isFalse);
+      expect(record1.hashCode == record2.hashCode, isTrue);
+    });
+  });
+}


### PR DESCRIPTION
### **User description**
Add strict validation ranges for all health records. Constructors now validate input values against physiologically reasonable ranges and throw `ArgumentError` for invalid data.

BREAKING CHANGE: Health record constructors now throw `ArgumentError` when values are outside valid ranges. Previously, any value was accepted without validation, which could lead to invalid data being stored.

Closes #102


___

### **PR Type**
Enhancement, Tests


___

### **Description**
- Add comprehensive validation range enforcement across all health record models with `ArgumentError` thrown for out-of-range values

- Implement validation in constructors for 50+ health record types including nutrition, heart rate, blood pressure, energy, sleep, and respiratory records

- Add static `min`/`max` constants defining physiologically reasonable ranges for each health metric

- Convert factory constructors to standard constructors with embedded validation logic using `require()` helper

- Add equality operators (`==`) and `hashCode` implementations for proper object comparison across multiple record types

- Create comprehensive test suites for 40+ health record models validating instantiation, boundary conditions, and error handling

- Fix documentation formatting in `ExerciseType` and improve line wrapping in various record documentation

- Validate cross-field constraints (e.g., systolic > diastolic in blood pressure, startTime < endTime in time-based records)


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Health Record Models"] -->|"Add min/max constants"| B["Validation Constants"]
  A -->|"Convert constructors"| C["Standard Constructors"]
  C -->|"Implement require()"| D["Range Validation"]
  D -->|"Throw ArgumentError"| E["Invalid Data Rejection"]
  A -->|"Add operators"| F["Equality Implementation"]
  G["Test Suites"] -->|"Validate ranges"| H["Boundary Testing"]
  G -->|"Test equality"| I["Operator Verification"]
  H -->|"Verify constraints"| J["Cross-field Validation"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><details><summary>47 files</summary><table>
<tr>
  <td>
    <details>
      <summary><strong>nutrition_record.dart</strong><dd><code>Add validation enforcement and equality operators to NutritionRecord</code></dd></summary>
<hr>

packages/health_connector_core/lib/src/models/health_records/nutrition/nutrition_record.dart

<ul><li>Added static <code>minEnergy</code> and <code>maxEnergy</code> constants for validation<br> <li> Implemented comprehensive validation in constructor for energy, <br>macronutrients, minerals, vitamins, and caffeine<br> <li> Added <code>operator==</code> and <code>hashCode</code> implementations for equality comparison<br> <li> Enhanced documentation with validation rationale and error conditions</ul>


</details>


  </td>
  <td><a href="https://github.com/fam-tung-lam/health_connector/pull/103/files#diff-872f880443d505bb5682981edbe14f4c9d528527fddfa2039a890512f21424c5">+215/-2</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>dietary_cholesterol_record.dart</strong><dd><code>Add validation and refactor constructor for DietaryCholesterolRecord</code></dd></summary>
<hr>

packages/health_connector_core/lib/src/models/health_records/nutrition/dietary_cholesterol_record.dart

<ul><li>Converted factory constructor to regular constructor with validation<br> <li> Added static <code>minMass</code> and <code>maxMass</code> constants<br> <li> Implemented mass range validation in constructor body<br> <li> Updated documentation with validation rationale</ul>


</details>


  </td>
  <td><a href="https://github.com/fam-tung-lam/health_connector/pull/103/files#diff-1e9992b7539338dfc4b75fffdbac926e2b130eeee787f98763bef6900f2234ba">+38/-36</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>dietary_calcium_record.dart</strong><dd><code>Add validation and refactor constructor for DietaryCalciumRecord</code></dd></summary>
<hr>

packages/health_connector_core/lib/src/models/health_records/nutrition/dietary_calcium_record.dart

<ul><li>Added static <code>minMass</code> and <code>maxMass</code> constants (0.0-100.0 g)<br> <li> Converted factory to regular constructor with validation<br> <li> Implemented mass range validation in constructor<br> <li> Enhanced documentation with validation rationale</ul>


</details>


  </td>
  <td><a href="https://github.com/fam-tung-lam/health_connector/pull/103/files#diff-9fbe069647bba96678ee6fb97cef7acd047528eff1cedf0aa75f59770264c73b">+36/-36</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>dietary_fiber_record.dart</strong><dd><code>Add validation and refactor constructor for DietaryFiberRecord</code></dd></summary>
<hr>

packages/health_connector_core/lib/src/models/health_records/nutrition/dietary_fiber_record.dart

<ul><li>Added static <code>minMass</code> and <code>maxMass</code> constants (0.0-1000.0 g)<br> <li> Converted factory to regular constructor with validation<br> <li> Implemented mass range validation in constructor body<br> <li> Updated documentation with validation rationale</ul>


</details>


  </td>
  <td><a href="https://github.com/fam-tung-lam/health_connector/pull/103/files#diff-9343bfbd34e0e5a00937fa162df91f173588540ca2179e7e67888295eb7be234">+36/-35</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>dietary_caffeine_record.dart</strong><dd><code>Add validation and equality operators to DietaryCaffeineRecord</code></dd></summary>
<hr>

packages/health_connector_core/lib/src/models/health_records/nutrition/dietary_caffeine_record.dart

<ul><li>Added static <code>minMass</code> and <code>maxMass</code> constants (0.0-10.0 g)<br> <li> Converted factory to regular constructor with validation<br> <li> Implemented mass range validation in constructor<br> <li> Added <code>operator==</code> and <code>hashCode</code> implementations</ul>


</details>


  </td>
  <td><a href="https://github.com/fam-tung-lam/health_connector/pull/103/files#diff-b3a3e31d32996c5e06ebf94c90fe794e9348cc47dc0aacd2b3dff4c18c92c5a1">+46/-30</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>dietary_iron_record.dart</strong><dd><code>Add validation and refactor constructor for DietaryIronRecord</code></dd></summary>
<hr>

packages/health_connector_core/lib/src/models/health_records/nutrition/dietary_iron_record.dart

<ul><li>Added static <code>minMass</code> and <code>maxMass</code> constants (0.0-100.0 g)<br> <li> Converted factory to regular constructor with validation<br> <li> Implemented mass range validation in constructor<br> <li> Enhanced documentation with validation rationale</ul>


</details>


  </td>
  <td><a href="https://github.com/fam-tung-lam/health_connector/pull/103/files#diff-a7ce251e90e2b7c949de9d316a3febc9f04fb5b4f4a5b036fb2db259a101375f">+36/-35</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>blood_pressure_record.dart</strong><dd><code>Add validation enforcement to BloodPressureRecord constructor</code></dd></summary>
<hr>

packages/health_connector_core/lib/src/models/health_records/blood_pressure/blood_pressure_record.dart

<ul><li>Added static constants for min/max systolic and diastolic pressure <br>ranges<br> <li> Implemented validation in constructor for systolic, diastolic, and <br>cross-field constraints<br> <li> Added validation that systolic must be greater than diastolic<br> <li> Enhanced documentation with validation rationale</ul>


</details>


  </td>
  <td><a href="https://github.com/fam-tung-lam/health_connector/pull/103/files#diff-e146704bc4123f7278369498b5c95215cb6f50a1fe5dc894a6be9b5b49a55dc2">+63/-2</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>dietary_polyunsaturated_fat_record.dart</strong><dd><code>Add validation and refactor constructor for </code><br><code>DietaryPolyunsaturatedFatRecord</code></dd></summary>
<hr>

packages/health_connector_core/lib/src/models/health_records/nutrition/dietary_polyunsaturated_fat_record.dart

<ul><li>Added static <code>minMass</code> and <code>maxMass</code> constants (0.0-1000.0 g)<br> <li> Converted factory to regular constructor with validation<br> <li> Implemented mass range validation in constructor<br> <li> Enhanced documentation with validation rationale</ul>


</details>


  </td>
  <td><a href="https://github.com/fam-tung-lam/health_connector/pull/103/files#diff-5e7a2452ece7b2f6d70ad34b7715d8b5e792eed23c8d9c4771ce60348841c0ba">+37/-38</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>dietary_pantothenic_acid_record.dart</strong><dd><code>Add validation and refactor constructor for </code><br><code>DietaryPantothenicAcidRecord</code></dd></summary>
<hr>

packages/health_connector_core/lib/src/models/health_records/nutrition/dietary_pantothenic_acid_record.dart

<ul><li>Added static <code>minMass</code> and <code>maxMass</code> constants (0.0-10.0 g)<br> <li> Converted factory to regular constructor with validation<br> <li> Implemented mass range validation in constructor<br> <li> Enhanced documentation with validation rationale</ul>


</details>


  </td>
  <td><a href="https://github.com/fam-tung-lam/health_connector/pull/103/files#diff-3d464acce177afa16174d8ee54ff71a9d9d1349407e0202cc2a0ee975e35811f">+36/-37</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>total_energy_burned_record.dart</strong><dd><code>Add validation enforcement to TotalEnergyBurnedRecord</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/health_connector_core/lib/src/models/health_records/energy_burned/total_energy_burned_record.dart

<ul><li>Added static <code>minEnergy</code> and <code>maxEnergy</code> constants (0.0-20000.0 kcal)<br> <li> Implemented energy range validation in constructor<br> <li> Enhanced documentation with validation rationale<br> <li> Fixed internal factory documentation references</ul>


</details>


  </td>
  <td><a href="https://github.com/fam-tung-lam/health_connector/pull/103/files#diff-1d859e5eb1918cf0dede5cccba9e11c1a05c546c6447c39143cc5fe8cc7f1efc">+38/-6</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>dietary_biotin_record.dart</strong><dd><code>Add validation and refactor constructor for DietaryBiotinRecord</code></dd></summary>
<hr>

packages/health_connector_core/lib/src/models/health_records/nutrition/dietary_biotin_record.dart

<ul><li>Added static <code>minMass</code> and <code>maxMass</code> constants (0.0-10.0 g)<br> <li> Converted factory to regular constructor with validation<br> <li> Implemented mass range validation in constructor<br> <li> Enhanced documentation with validation rationale</ul>


</details>


  </td>
  <td><a href="https://github.com/fam-tung-lam/health_connector/pull/103/files#diff-8f5310c6b3e121f0c69a00cb62771dd316d887c5d3140f2c782bcd988b265334">+35/-33</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>dietary_niacin_record.dart</strong><dd><code>Add validation and refactor constructor for DietaryNiacinRecord</code></dd></summary>
<hr>

packages/health_connector_core/lib/src/models/health_records/nutrition/dietary_niacin_record.dart

<ul><li>Added static <code>minMass</code> and <code>maxMass</code> constants (0.0-10.0 g)<br> <li> Converted factory to regular constructor with validation<br> <li> Implemented mass range validation in constructor<br> <li> Enhanced documentation with validation rationale</ul>


</details>


  </td>
  <td><a href="https://github.com/fam-tung-lam/health_connector/pull/103/files#diff-cb76dbd14768245803ce9d9b1cec0c79f397bfdb235e5c901f5a1115978d08ce">+35/-33</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>dietary_thiamin_record.dart</strong><dd><code>Add validation and refactor constructor for DietaryThiaminRecord</code></dd></summary>
<hr>

packages/health_connector_core/lib/src/models/health_records/nutrition/dietary_thiamin_record.dart

<ul><li>Added static <code>minMass</code> and <code>maxMass</code> constants (0.0-10.0 g)<br> <li> Converted factory to regular constructor with validation<br> <li> Implemented mass range validation in constructor<br> <li> Enhanced documentation with validation rationale</ul>


</details>


  </td>
  <td><a href="https://github.com/fam-tung-lam/health_connector/pull/103/files#diff-9ef87ee2dc96d027dfcb69c40c2596902bca3a0f84e20eac8e68fb718a3a9b38">+36/-36</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>dietary_manganese_record.dart</strong><dd><code>Add validation and refactor constructor for DietaryManganeseRecord</code></dd></summary>
<hr>

packages/health_connector_core/lib/src/models/health_records/nutrition/dietary_manganese_record.dart

<ul><li>Added static <code>minMass</code> and <code>maxMass</code> constants (0.0-100.0 g)<br> <li> Converted factory to regular constructor with validation<br> <li> Implemented mass range validation in constructor<br> <li> Enhanced documentation with validation rationale</ul>


</details>


  </td>
  <td><a href="https://github.com/fam-tung-lam/health_connector/pull/103/files#diff-e52a883ed0c66ad0e097dffb9fbf6aefce232d02a3ece72d7751b2607776a3d5">+35/-33</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>dietary_total_fat_record.dart</strong><dd><code>Add validation and refactor constructor for DietaryTotalFatRecord</code></dd></summary>
<hr>

packages/health_connector_core/lib/src/models/health_records/nutrition/dietary_total_fat_record.dart

<ul><li>Added static <code>minMass</code> and <code>maxMass</code> constants (0.0-1000.0 g)<br> <li> Converted factory to regular constructor with validation<br> <li> Implemented mass range validation in constructor<br> <li> Enhanced documentation with validation rationale</ul>


</details>


  </td>
  <td><a href="https://github.com/fam-tung-lam/health_connector/pull/103/files#diff-65ce8993dcb06b2ce064c24ec1b265088fb0eb32ab8b3c9d25c92c4288e4ad50">+36/-36</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>dietary_folate_record.dart</strong><dd><code>Add validation and refactor constructor for DietaryFolateRecord</code></dd></summary>
<hr>

packages/health_connector_core/lib/src/models/health_records/nutrition/dietary_folate_record.dart

<ul><li>Added static <code>minMass</code> and <code>maxMass</code> constants (0.0-10.0 g)<br> <li> Converted factory to regular constructor with validation<br> <li> Implemented mass range validation in constructor<br> <li> Enhanced documentation with validation rationale</ul>


</details>


  </td>
  <td><a href="https://github.com/fam-tung-lam/health_connector/pull/103/files#diff-075890731d9a555bbd307712d8e1b3b1d3210618bc8ac41311c9e0bc069cdc89">+35/-33</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>dietary_magnesium_record.dart</strong><dd><code>Add validation and refactor constructor for DietaryMagnesiumRecord</code></dd></summary>
<hr>

packages/health_connector_core/lib/src/models/health_records/nutrition/dietary_magnesium_record.dart

<ul><li>Added static <code>minMass</code> and <code>maxMass</code> constants (0.0-100.0 g)<br> <li> Converted factory to regular constructor with validation<br> <li> Implemented mass range validation in constructor<br> <li> Enhanced documentation with validation rationale</ul>


</details>


  </td>
  <td><a href="https://github.com/fam-tung-lam/health_connector/pull/103/files#diff-6495fdbc6cda3a702f98d60376036888516d51063f11996fc5c6cef1904a3072">+35/-33</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>dietary_vitamin_c_record.dart</strong><dd><code>Add validation and refactor constructor for DietaryVitaminCRecord</code></dd></summary>
<hr>

packages/health_connector_core/lib/src/models/health_records/nutrition/dietary_vitamin_c_record.dart

<ul><li>Added static <code>minMass</code> and <code>maxMass</code> constants (0.0-10.0 g)<br> <li> Converted factory to regular constructor with validation<br> <li> Implemented mass range validation in constructor<br> <li> Enhanced documentation with validation rationale</ul>


</details>


  </td>
  <td><a href="https://github.com/fam-tung-lam/health_connector/pull/103/files#diff-d382b600df4a729567e3f61b3bf1adface811ca93d5e6b9f51ff720beef14e56">+36/-36</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>dietary_vitamin_d_record.dart</strong><dd><code>Add validation and refactor constructor for DietaryVitaminDRecord</code></dd></summary>
<hr>

packages/health_connector_core/lib/src/models/health_records/nutrition/dietary_vitamin_d_record.dart

<ul><li>Added static <code>minMass</code> and <code>maxMass</code> constants (0.0-10.0 g)<br> <li> Converted factory to regular constructor with validation<br> <li> Implemented mass range validation in constructor<br> <li> Enhanced documentation with validation rationale</ul>


</details>


  </td>
  <td><a href="https://github.com/fam-tung-lam/health_connector/pull/103/files#diff-6230a1a08ca319f450bc2143bbfc63662d2638eec754aee9dffb78cf1662e0ff">+36/-36</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>dietary_vitamin_k_record.dart</strong><dd><code>Add validation and refactor constructor for DietaryVitaminKRecord</code></dd></summary>
<hr>

packages/health_connector_core/lib/src/models/health_records/nutrition/dietary_vitamin_k_record.dart

<ul><li>Added static <code>minMass</code> and <code>maxMass</code> constants (0.0-10.0 g)<br> <li> Converted factory to regular constructor with validation<br> <li> Implemented mass range validation in constructor<br> <li> Enhanced documentation with validation rationale</ul>


</details>


  </td>
  <td><a href="https://github.com/fam-tung-lam/health_connector/pull/103/files#diff-f4129506b3c818701bab773f16664494793d9c3d0090f8a6733fbe1b6d96b50b">+36/-36</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>dietary_vitamin_a_record.dart</strong><dd><code>Add validation and refactor constructor for DietaryVitaminARecord</code></dd></summary>
<hr>

packages/health_connector_core/lib/src/models/health_records/nutrition/dietary_vitamin_a_record.dart

<ul><li>Added static <code>minMass</code> and <code>maxMass</code> constants (0.0-10.0 g)<br> <li> Converted factory to regular constructor with validation<br> <li> Implemented mass range validation in constructor<br> <li> Enhanced documentation with validation rationale</ul>


</details>


  </td>
  <td><a href="https://github.com/fam-tung-lam/health_connector/pull/103/files#diff-83b1d22d0fa41892f6f1e8c5a190746b5c847ac80c8c2980b0b7e7faad2c3c53">+36/-36</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>dietary_monounsaturated_fat_record.dart</strong><dd><code>Simplify constructor pattern for DietaryMonounsaturatedFatRecord</code></dd></summary>
<hr>

packages/health_connector_core/lib/src/models/health_records/nutrition/dietary_monounsaturated_fat_record.dart

<ul><li>Simplified constructor by removing factory pattern and validation <br>delegation<br> <li> Converted to direct constructor with super parameter forwarding<br> <li> Removed unnecessary internal factory wrapper</ul>


</details>


  </td>
  <td><a href="https://github.com/fam-tung-lam/health_connector/pull/103/files#diff-e032cb2fb3c3bc67d0c3ef285a021cbf7cb0d33a94a8ec82c27e689970e6a6ed">+11/-32</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>dietary_vitamin_e_record.dart</strong><dd><code>Add mass validation to DietaryVitaminERecord constructor</code>&nbsp; </dd></summary>
<hr>

packages/health_connector_core/lib/src/models/health_records/nutrition/dietary_vitamin_e_record.dart

<ul><li>Converted factory constructor to standard constructor with validation <br>logic<br> <li> Added <code>minMass</code> and <code>maxMass</code> static constants (0.0-10.0 g)<br> <li> Implemented range validation using <code>require()</code> helper with detailed <br>error messages<br> <li> Updated internal factory to call public constructor instead of private <br><code>._</code> constructor<br> <li> Fixed documentation line wrapping for iOS HealthKit URL</ul>


</details>


  </td>
  <td><a href="https://github.com/fam-tung-lam/health_connector/pull/103/files#diff-535e65a97ef18fd66d9545b9964f02bc71a47c33cac6befe546f7695484256b9">+36/-36</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>dietary_selenium_record.dart</strong><dd><code>Add mass validation to DietarySeleniumRecord constructor</code>&nbsp; </dd></summary>
<hr>

packages/health_connector_core/lib/src/models/health_records/nutrition/dietary_selenium_record.dart

<ul><li>Converted factory constructor to standard constructor with validation <br>logic<br> <li> Added <code>minMass</code> and <code>maxMass</code> static constants (0.0-100.0 g)<br> <li> Implemented range validation using <code>require()</code> helper with detailed <br>error messages<br> <li> Updated internal factory to call public constructor instead of private <br><code>._</code> constructor<br> <li> Fixed documentation line wrapping for iOS HealthKit URL</ul>


</details>


  </td>
  <td><a href="https://github.com/fam-tung-lam/health_connector/pull/103/files#diff-7766c5475e75690ae01750b9d84d54ed0bddea773c101f31b243e41bd4c341e8">+36/-36</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>dietary_protein_record.dart</strong><dd><code>Add mass validation to DietaryProteinRecord constructor</code>&nbsp; &nbsp; </dd></summary>
<hr>

packages/health_connector_core/lib/src/models/health_records/nutrition/dietary_protein_record.dart

<ul><li>Converted factory constructor to standard constructor with validation <br>logic<br> <li> Added <code>minMass</code> and <code>maxMass</code> static constants (0.0-1000.0 g)<br> <li> Implemented range validation using <code>require()</code> helper with detailed <br>error messages<br> <li> Updated internal factory to call public constructor instead of private <br><code>._</code> constructor<br> <li> Fixed documentation line wrapping for iOS HealthKit URL</ul>


</details>


  </td>
  <td><a href="https://github.com/fam-tung-lam/health_connector/pull/103/files#diff-8e3ee63d9103d5969fc149c2a2ed5e1b25d227bdafa2d6872120b945599b2ce7">+36/-36</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>dietary_zinc_record.dart</strong><dd><code>Add mass validation to DietaryZincRecord constructor</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/health_connector_core/lib/src/models/health_records/nutrition/dietary_zinc_record.dart

<ul><li>Converted factory constructor to standard constructor with validation <br>logic<br> <li> Added <code>minMass</code> and <code>maxMass</code> static constants (0.0-100.0 g)<br> <li> Implemented range validation using <code>require()</code> helper with detailed <br>error messages<br> <li> Updated internal factory to call public constructor instead of private <br><code>._</code> constructor<br> <li> Fixed documentation line wrapping for iOS HealthKit URL</ul>


</details>


  </td>
  <td><a href="https://github.com/fam-tung-lam/health_connector/pull/103/files#diff-2e9604bf6e2ce6464abaeb04d5f5b96035eef5fbf29091498bb000d0ebe087af">+36/-35</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>resting_heart_rate_record.dart</strong><dd><code>Add heart rate validation to RestingHeartRateRecord constructor</code></dd></summary>
<hr>

packages/health_connector_core/lib/src/models/health_records/heart_rate/resting_heart_rate_record.dart

<ul><li>Added <code>minRate</code> and <code>maxRate</code> static constants (1.0-300.0 bpm)<br> <li> Converted const constructor to standard constructor with validation <br>logic<br> <li> Implemented range validation using <code>require()</code> helper with detailed <br>error messages<br> <li> Fixed internal factory documentation to reference correct class name</ul>


</details>


  </td>
  <td><a href="https://github.com/fam-tung-lam/health_connector/pull/103/files#diff-47b76d6d518a4f19fb363345d3a443b53cbd97b8eeaecd488d20f8cbe9d0a522">+50/-6</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>dietary_sugar_record.dart</strong><dd><code>Add mass validation to DietarySugarRecord constructor</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/health_connector_core/lib/src/models/health_records/nutrition/dietary_sugar_record.dart

<ul><li>Converted factory constructor to standard constructor with validation <br>logic<br> <li> Added <code>minMass</code> and <code>maxMass</code> static constants (0.0-1000.0 g)<br> <li> Implemented range validation using <code>require()</code> helper with detailed <br>error messages<br> <li> Updated internal factory to call public constructor instead of private <br><code>._</code> constructor<br> <li> Fixed documentation line wrapping for iOS HealthKit URL</ul>


</details>


  </td>
  <td><a href="https://github.com/fam-tung-lam/health_connector/pull/103/files#diff-a948d244716cbaf17216018a8fff15e10d4b221792ffbe23acb07f53f455268d">+36/-35</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>dietary_energy_consumed_record.dart</strong><dd><code>Add energy validation to DietaryEnergyConsumedRecord factory</code></dd></summary>
<hr>

packages/health_connector_core/lib/src/models/health_records/nutrition/dietary_energy_consumed_record.dart

<ul><li>Added <code>minEnergy</code> and <code>maxEnergy</code> static constants (0.0-10000.0 kcal)<br> <li> Implemented range validation in factory constructor using <code>require()</code> <br>helper<br> <li> Added <code>==</code> operator and <code>hashCode</code> override for proper equality comparison<br> <li> Added documentation for throws and validation rationale</ul>


</details>


  </td>
  <td><a href="https://github.com/fam-tung-lam/health_connector/pull/103/files#diff-2055bc5d4fef4798bc70ec06949bbb4dca19d275de0951efdbf6cfe4c9e373a0">+32/-2</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>heart_rate_variability_rmssd_record.dart</strong><dd><code>Add RMSSD range validation to HeartRateVariabilityRMSSDRecord</code></dd></summary>
<hr>

packages/health_connector_core/lib/src/models/health_records/heart_rate/heart_rate_variability_rmssd_record.dart

<ul><li>Added <code>minRmssdMs</code> and <code>maxRmssdMs</code> static constants (1.0-250.0 ms)<br> <li> Replaced simple negativity check with range validation using <code>require()</code> <br>helper<br> <li> Updated error message to include both min and max bounds with <br>rationale<br> <li> Fixed internal factory documentation to reference correct class name</ul>


</details>


  </td>
  <td><a href="https://github.com/fam-tung-lam/health_connector/pull/103/files#diff-181884f74e36e6b46e20837c30cdf1e82260badc4f897fe406cb2b12ca32e588">+40/-15</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>heart_rate_variability_sdnn_record.dart</strong><dd><code>Add SDNN range validation to HeartRateVariabilitySDNNRecord</code></dd></summary>
<hr>

packages/health_connector_core/lib/src/models/health_records/heart_rate/heart_rate_variability_sdnn_record.dart

<ul><li>Added <code>minSdnnMs</code> and <code>maxSdnnMs</code> static constants (1.0-300.0 ms)<br> <li> Replaced simple negativity check with range validation using <code>require()</code> <br>helper<br> <li> Updated error message to include both min and max bounds with <br>rationale<br> <li> Fixed internal factory documentation to reference correct class name</ul>


</details>


  </td>
  <td><a href="https://github.com/fam-tung-lam/health_connector/pull/103/files#diff-6bb1b0a0c24d22ddd942a6b030d1e5b6735ad31fb8ead5f4dbdec2330a79fea2">+39/-15</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>dietary_total_carbohydrate_record.dart</strong><dd><code>Add mass validation to DietaryTotalCarbohydrateRecord constructor</code></dd></summary>
<hr>

packages/health_connector_core/lib/src/models/health_records/nutrition/dietary_total_carbohydrate_record.dart

<ul><li>Converted factory constructor to standard constructor with validation <br>logic<br> <li> Added <code>minMass</code> and <code>maxMass</code> static constants (0.0-1000.0 g)<br> <li> Implemented range validation using <code>require()</code> helper with detailed <br>error messages<br> <li> Updated internal factory to call public constructor instead of private <br><code>._</code> constructor</ul>


</details>


  </td>
  <td><a href="https://github.com/fam-tung-lam/health_connector/pull/103/files#diff-7bd1e05397a92e5bd9065875c08c3b3dcc6a1bba779fe59694d9bc13dd91499a">+36/-36</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>respiratory_rate_record.dart</strong><dd><code>Add respiratory rate validation to RespiratoryRateRecord</code>&nbsp; </dd></summary>
<hr>

packages/health_connector_core/lib/src/models/health_records/respiratory_rate_record.dart

<ul><li>Added <code>minRate</code> and <code>maxRate</code> static constants (0.0-1000.0 breaths/min)<br> <li> Converted const constructor to standard constructor with validation <br>logic<br> <li> Implemented range validation using <code>require()</code> helper with detailed <br>error messages<br> <li> Improved <code>==</code> operator and <code>hashCode</code> implementation for proper equality</ul>


</details>


  </td>
  <td><a href="https://github.com/fam-tung-lam/health_connector/pull/103/files#diff-1f0000cc5e34a3c31899ae6bff5ac864bfcf50f9632079dc5c847985b71ab97a">+58/-4</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>dietary_riboflavin_record.dart</strong><dd><code>Add mass validation to DietaryRiboflavinRecord constructor</code></dd></summary>
<hr>

packages/health_connector_core/lib/src/models/health_records/nutrition/dietary_riboflavin_record.dart

<ul><li>Converted factory constructor to standard constructor with validation <br>logic<br> <li> Added <code>minMass</code> and <code>maxMass</code> static constants (0.0-10.0 g)<br> <li> Implemented range validation using <code>require()</code> helper with detailed <br>error messages<br> <li> Updated internal factory to call public constructor instead of private <br><code>._</code> constructor</ul>


</details>


  </td>
  <td><a href="https://github.com/fam-tung-lam/health_connector/pull/103/files#diff-9c82f2ce2fc478784734eda1e2daabe050970c23f5142f858183d97aff888a44">+35/-33</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>dietary_saturated_fat_record.dart</strong><dd><code>Add mass validation to DietarySaturatedFatRecord constructor</code></dd></summary>
<hr>

packages/health_connector_core/lib/src/models/health_records/nutrition/dietary_saturated_fat_record.dart

<ul><li>Converted factory constructor to standard constructor with validation <br>logic<br> <li> Added <code>minMass</code> and <code>maxMass</code> static constants (0.0-1000.0 g)<br> <li> Implemented range validation using <code>require()</code> helper with detailed <br>error messages<br> <li> Updated internal factory to call public constructor instead of private <br><code>._</code> constructor</ul>


</details>


  </td>
  <td><a href="https://github.com/fam-tung-lam/health_connector/pull/103/files#diff-640b6ad46f4dba12523ea0f322ea8b45d59a007b8dec4228429294122e5977bf">+35/-34</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>dietary_vitamin_b12_record.dart</strong><dd><code>Add mass validation to DietaryVitaminB12Record constructor</code></dd></summary>
<hr>

packages/health_connector_core/lib/src/models/health_records/nutrition/dietary_vitamin_b12_record.dart

<ul><li>Converted factory constructor to standard constructor with validation <br>logic<br> <li> Added <code>minMass</code> and <code>maxMass</code> static constants (0.0-10.0 g)<br> <li> Implemented range validation using <code>require()</code> helper with detailed <br>error messages<br> <li> Updated internal factory to call public constructor instead of private <br><code>._</code> constructor</ul>


</details>


  </td>
  <td><a href="https://github.com/fam-tung-lam/health_connector/pull/103/files#diff-1e5d2f9bce8366a5000247e6e43997039a65a68e80a395467f9cd97d6826891e">+35/-33</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>dietary_vitamin_b6_record.dart</strong><dd><code>Add mass validation to DietaryVitaminB6Record constructor</code></dd></summary>
<hr>

packages/health_connector_core/lib/src/models/health_records/nutrition/dietary_vitamin_b6_record.dart

<ul><li>Converted factory constructor to standard constructor with validation <br>logic<br> <li> Added <code>minMass</code> and <code>maxMass</code> static constants (0.0-10.0 g)<br> <li> Implemented range validation using <code>require()</code> helper with detailed <br>error messages<br> <li> Updated internal factory to call public constructor instead of private <br><code>._</code> constructor</ul>


</details>


  </td>
  <td><a href="https://github.com/fam-tung-lam/health_connector/pull/103/files#diff-9d41b4a2ba10ec548075a6416779c66d2855e1ba1587f7485cbc1a33d476f512">+35/-33</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>dietary_phosphorus_record.dart</strong><dd><code>Add mass validation to DietaryPhosphorusRecord constructor</code></dd></summary>
<hr>

packages/health_connector_core/lib/src/models/health_records/nutrition/dietary_phosphorus_record.dart

<ul><li>Converted factory constructor to standard constructor with validation <br>logic<br> <li> Added <code>minMass</code> and <code>maxMass</code> static constants (0.0-100.0 g)<br> <li> Implemented range validation using <code>require()</code> helper with detailed <br>error messages<br> <li> Updated internal factory to call public constructor instead of private <br><code>._</code> constructor</ul>


</details>


  </td>
  <td><a href="https://github.com/fam-tung-lam/health_connector/pull/103/files#diff-599f6b6a17665f43a3a5da650d9c8b556256eab2fe84330a87cd36202c3986db">+35/-33</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>blood_glucose_record.dart</strong><dd><code>Add blood glucose validation to BloodGlucoseRecord constructor</code></dd></summary>
<hr>

packages/health_connector_core/lib/src/models/health_records/blood_glucose/blood_glucose_record.dart

<ul><li>Added <code>minBloodGlucose</code> and <code>maxBloodGlucose</code> static constants (20.0-700.0 <br>mg/dL)<br> <li> Converted const constructor to standard constructor with validation <br>logic<br> <li> Implemented range validation using <code>require()</code> helper with detailed <br>error messages<br> <li> Added documentation for throws and validation rationale with mmol/L <br>conversion</ul>


</details>


  </td>
  <td><a href="https://github.com/fam-tung-lam/health_connector/pull/103/files#diff-75fe3eec631753624df31e82621cb4dc94793d49fd0cd2f2b11cf75d5bc3620a">+41/-2</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>dietary_potassium_record.dart</strong><dd><code>Add mass validation to DietaryPotassiumRecord constructor</code></dd></summary>
<hr>

packages/health_connector_core/lib/src/models/health_records/nutrition/dietary_potassium_record.dart

<ul><li>Converted factory constructor to standard constructor with validation <br>logic<br> <li> Added <code>minMass</code> and <code>maxMass</code> static constants (0.0-100.0 g)<br> <li> Implemented range validation using <code>require()</code> helper with detailed <br>error messages<br> <li> Updated internal factory to call public constructor instead of private <br><code>._</code> constructor</ul>


</details>


  </td>
  <td><a href="https://github.com/fam-tung-lam/health_connector/pull/103/files#diff-d81e2dffa1d67d58e6bc25801f40e76f5f880a2a06876ae89c8a0e8749c18201">+35/-33</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>dietary_sodium_record.dart</strong><dd><code>Add mass validation to DietarySodiumRecord constructor</code>&nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/health_connector_core/lib/src/models/health_records/nutrition/dietary_sodium_record.dart

<ul><li>Converted factory constructor to standard constructor with validation <br>logic<br> <li> Added <code>minMass</code> and <code>maxMass</code> static constants (0.0-100.0 g)<br> <li> Implemented range validation using <code>require()</code> helper with detailed <br>error messages<br> <li> Updated internal factory to call public constructor instead of private <br><code>._</code> constructor</ul>


</details>


  </td>
  <td><a href="https://github.com/fam-tung-lam/health_connector/pull/103/files#diff-6958b1c11b7e69694e40e47a5d3ab71093dbc1fefae04cd499d0ea422f4d9a95">+35/-33</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>sleep_session_record.dart</strong><dd><code>Sleep session and stage duration validation enforcement</code>&nbsp; &nbsp; </dd></summary>
<hr>

packages/health_connector_core/lib/src/models/health_records/sleep/sleep_session_record.dart

<ul><li>Added <code>minDuration</code> (1 minute) and <code>maxDuration</code> (24 hours) static <br>constants for sleep session validation<br> <li> Implemented constructor validation using <code>require()</code> to enforce duration <br>range constraints<br> <li> Added comprehensive documentation explaining validation rationale and <br>error conditions<br> <li> Changed <code>SleepStageSample</code> from <code>const</code> to regular constructor with <br>validation for <code>endTime</code> after <code>startTime</code></ul>


</details>


  </td>
  <td><a href="https://github.com/fam-tung-lam/health_connector/pull/103/files#diff-4568f5e06472f095c854d223e846e626c9613ed4a6365907e6cfd09241ac1df7">+49/-3</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>diastolic_blood_pressure_record.dart</strong><dd><code>Diastolic blood pressure range validation implementation</code>&nbsp; </dd></summary>
<hr>

packages/health_connector_core/lib/src/models/health_records/blood_pressure/diastolic_blood_pressure_record.dart

<ul><li>Added <code>minPressure</code> (30 mmHg) and <code>maxPressure</code> (300 mmHg) static <br>constants<br> <li> Implemented constructor validation with <code>require()</code> to enforce pressure <br>range<br> <li> Changed constructor from <code>const</code> to regular with validation logic<br> <li> Added detailed documentation with platform compatibility notes and <br>validation rationale</ul>


</details>


  </td>
  <td><a href="https://github.com/fam-tung-lam/health_connector/pull/103/files#diff-044de3feba960b254812b32991f250caafa9fdeadc231b26316b5dc435ae5ece">+37/-2</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>systolic_blood_pressure_record.dart</strong><dd><code>Systolic blood pressure range validation implementation</code>&nbsp; &nbsp; </dd></summary>
<hr>

packages/health_connector_core/lib/src/models/health_records/blood_pressure/systolic_blood_pressure_record.dart

<ul><li>Added <code>minPressure</code> (50 mmHg) and <code>maxPressure</code> (300 mmHg) static <br>constants<br> <li> Implemented constructor validation with <code>require()</code> to enforce pressure <br>range<br> <li> Changed constructor from <code>const</code> to regular with validation logic<br> <li> Added comprehensive documentation with platform compatibility <br>references</ul>


</details>


  </td>
  <td><a href="https://github.com/fam-tung-lam/health_connector/pull/103/files#diff-9b1985784fb1a27233079e5f865766a01f8e0311f8dd0dbaa828220af2622b3f">+37/-2</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>cycling_pedaling_cadence_record.dart</strong><dd><code>Cycling pedaling cadence range validation enforcement</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/health_connector_core/lib/src/models/health_records/cycling_pedaling_cadence/cycling_pedaling_cadence_record.dart

<ul><li>Added <code>minCadence</code> (0.0 RPM) and <code>maxCadence</code> (200.0 RPM) static constants<br> <li> Implemented constructor validation with <code>require()</code> to enforce cadence <br>range<br> <li> Changed constructor from <code>const</code> to regular with validation logic<br> <li> Added detailed documentation explaining validation rationale for <br>cycling cadence</ul>


</details>


  </td>
  <td><a href="https://github.com/fam-tung-lam/health_connector/pull/103/files#diff-956450e8d5f83c3efa6804f0c0bb845d05b39ef960ea5f852203c5662f6862c5">+38/-4</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>basal_energy_burned_record.dart</strong><dd><code>Basal energy burned range validation implementation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/health_connector_core/lib/src/models/health_records/energy_burned/basal_energy_burned_record.dart

<ul><li>Added <code>minEnergy</code> (0.0 kcal) and <code>maxEnergy</code> (5,000.0 kcal) static <br>constants<br> <li> Implemented constructor validation with <code>require()</code> to enforce energy <br>range<br> <li> Added comprehensive documentation with validation rationale for basal <br>energy<br> <li> Extended constructor documentation to include new energy validation <br>error conditions</ul>


</details>


  </td>
  <td><a href="https://github.com/fam-tung-lam/health_connector/pull/103/files#diff-9cf13f249c860b555bc2b4e7233bc94fc208d1dc9042fc387702d1fc2e387232">+32/-1</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>oxygen_saturation_record.dart</strong><dd><code>Oxygen saturation percentage range validation implementation</code></dd></summary>
<hr>

packages/health_connector_core/lib/src/models/health_records/oxygen_saturation_record.dart

<ul><li>Added <code>minSaturation</code> (0%) and <code>maxSaturation</code> (100%) static constants<br> <li> Implemented constructor validation with <code>require()</code> to enforce <br>saturation percentage range<br> <li> Changed constructor from <code>const</code> to regular with validation logic<br> <li> Fixed equality operator and hashCode implementation to explicitly <br>compare all fields instead of relying on super</ul>


</details>


  </td>
  <td><a href="https://github.com/fam-tung-lam/health_connector/pull/103/files#diff-e3d3e77a59cd084a4130a76ad4fc84b034c2f069673bc710289bf5d3437d4d29">+47/-4</a>&nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Tests</strong></td><td><details><summary>38 files</summary><table>
<tr>
  <td>
    <details>
      <summary><strong>sleep_session_record_test.dart</strong><dd><code>Add comprehensive test suite for SleepSessionRecord</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/health_connector_core/test/src/models/health_records/sleep/sleep_session_record_test.dart

<ul><li>New comprehensive test suite for <code>SleepSessionRecord</code> covering <br>instantiation, duration validation, and equality<br> <li> Tests for <code>SleepStageSample</code> including validation and equality checks<br> <li> Validates min/max duration constraints and <code>totalSleepDuration</code> <br>calculation</ul>


</details>


  </td>
  <td><a href="https://github.com/fam-tung-lam/health_connector/pull/103/files#diff-74909c65a5c27dda01ab4645ad5b79e25a768412e46490a3c89d6728265918a1">+223/-0</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>nutrition_record_test.dart</strong><dd><code>Add validation tests for NutritionRecord ranges</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/health_connector_core/test/src/models/health_records/nutrition/nutrition_record_test.dart

<ul><li>New test suite validating energy, macronutrient, vitamin, and mineral <br>ranges<br> <li> Tests for valid instantiation and <code>copyWith</code> functionality<br> <li> Validates that out-of-range values throw <code>ArgumentError</code></ul>


</details>


  </td>
  <td><a href="https://github.com/fam-tung-lam/health_connector/pull/103/files#diff-f9de4126c0847f15921ac991bb14ac2a7f74d67a8c53c584d43ab4595e9632e4">+170/-0</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>speed_series_record_test.dart</strong><dd><code>Add comprehensive test suite for SpeedSeriesRecord</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/health_connector_core/test/src/models/health_records/speed/speed_series_record_test.dart

<ul><li>New test suite for <code>SpeedSeriesRecord</code> with valid parameter <br>instantiation<br> <li> Tests for statistics calculation (avg, min, max speed)<br> <li> Validates empty samples handling and equality checks</ul>


</details>


  </td>
  <td><a href="https://github.com/fam-tung-lam/health_connector/pull/103/files#diff-60a6fe88b27ab6cfa0dd206a434c6ba3433d683bb03af12d41edf79231242fdf">+162/-0</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>power_series_record_test.dart</strong><dd><code>Add comprehensive test suite for PowerSeriesRecord</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/health_connector_core/test/src/models/health_records/power/power_series_record_test.dart

<ul><li>New test suite for <code>PowerSeriesRecord</code> with instantiation and statistics <br>validation<br> <li> Tests for power sample validation (min/max constraints)<br> <li> Validates <code>copyWith</code> functionality and equality checks</ul>


</details>


  </td>
  <td><a href="https://github.com/fam-tung-lam/health_connector/pull/103/files#diff-5c89841005d030c1055408ddab3a43e39375edd19fd2718732020b1ba032b749">+155/-0</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>cycling_pedaling_cadence_series_record_test.dart</strong><dd><code>Add comprehensive test suite for CyclingPedalingCadenceSeriesRecord</code></dd></summary>
<hr>

packages/health_connector_core/test/src/models/health_records/cycling_pedaling_cadence/cycling_pedaling_cadence_series_record_test.dart

<ul><li>New test suite for <code>CyclingPedalingCadenceSample</code> validation<br> <li> Tests for <code>CyclingPedalingCadenceSeriesRecord</code> statistics (avg, min, max <br>cadence)<br> <li> Validates empty samples handling and derived value calculations</ul>


</details>


  </td>
  <td><a href="https://github.com/fam-tung-lam/health_connector/pull/103/files#diff-b90f62d517443c79a4fb982eedd69e3832c6e17f7c815f668e1d87952aec3dd2">+141/-0</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>heart_rate_series_record_test.dart</strong><dd><code>Add comprehensive test suite for HeartRateSeriesRecord</code>&nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/health_connector_core/test/src/models/health_records/heart_rate/heart_rate_series_record_test.dart

<ul><li>New test suite for <code>HeartRateSeriesRecord</code> with statistics validation<br> <li> Tests for avg, min, max heart rate calculations<br> <li> Validates empty samples and single sample edge cases</ul>


</details>


  </td>
  <td><a href="https://github.com/fam-tung-lam/health_connector/pull/103/files#diff-d3dc2de59683e2d55fcd44ceee5a6cb99fd3dbaa50d5aef994d9c53e2e559dec">+136/-0</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>sleep_stage_record_test.dart</strong><dd><code>Add comprehensive test suite for SleepStageRecord</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/health_connector_core/test/src/models/health_records/sleep/sleep_stage_record_test.dart

<ul><li>New test suite for <code>SleepStageRecord</code> with instantiation and validation<br> <li> Tests for <code>isActualSleep</code> property logic<br> <li> Validates <code>copyWith</code> functionality and equality checks</ul>


</details>


  </td>
  <td><a href="https://github.com/fam-tung-lam/health_connector/pull/103/files#diff-abf2dddef0fb74b6fc543c799357c5f600cd1e2a0d8e225a308be70f42c41cf1">+127/-0</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>blood_pressure_record_test.dart</strong><dd><code>Add BloodPressureRecord validation tests</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/health_connector_core/test/src/models/health_records/blood_pressure/blood_pressure_record_test.dart

<ul><li>Created comprehensive test suite for <code>BloodPressureRecord</code> validation<br> <li> Tests cover valid instantiation, boundary conditions, and invalid <br>inputs<br> <li> Validates systolic/diastolic range enforcement and systolic > <br>diastolic constraint<br> <li> Tests <code>copyWith</code> method and equality operations</ul>


</details>


  </td>
  <td><a href="https://github.com/fam-tung-lam/health_connector/pull/103/files#diff-59f3f420fed829899424660e4812bcc29b2ea63b6f4d53e43d2217ebe8d21b48">+111/-0</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>vo2_max_record_test.dart</strong><dd><code>Add Vo2MaxRecord validation tests</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/health_connector_core/test/src/models/health_records/vo2_max_record_test.dart

<ul><li>Created comprehensive test suite for <code>Vo2MaxRecord</code> validation<br> <li> Tests cover valid instantiation, optional testType parameter, and <br>boundary conditions<br> <li> Validates VO2 range enforcement (5.0-100.0 ml/min/kg)<br> <li> Tests <code>copyWith</code> method, equality, and hashCode operations</ul>


</details>


  </td>
  <td><a href="https://github.com/fam-tung-lam/health_connector/pull/103/files#diff-6e1bfcde4cad2ca5da27866f512900fb893d16a1d4611fb6694c1f1f0f875878">+109/-0</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>mindfulness_session_record_test.dart</strong><dd><code>Add MindfulnessSessionRecord validation tests</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/health_connector_core/test/src/models/health_records/mindfulness/mindfulness_session_record_test.dart

<ul><li>Created comprehensive test suite for <code>MindfulnessSessionRecord</code> <br>validation<br> <li> Tests cover valid instantiation with optional parameters and time <br>ordering<br> <li> Validates startTime < endTime constraint enforcement<br> <li> Tests <code>copyWith</code> method, equality, and hashCode operations</ul>


</details>


  </td>
  <td><a href="https://github.com/fam-tung-lam/health_connector/pull/103/files#diff-6118fd9941c24e29a245e6aa77b5231e2234c24c033f619e2c04db880c9828f8">+111/-0</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>hydration_record_test.dart</strong><dd><code>Add HydrationRecord validation tests</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/health_connector_core/test/src/models/health_records/hydration_record_test.dart

<ul><li>Created comprehensive test suite for <code>HydrationRecord</code> validation<br> <li> Tests cover valid instantiation, volume range enforcement, and time <br>ordering<br> <li> Validates volume bounds (0.0-20.0 liters) and startTime < endTime <br>constraint<br> <li> Tests <code>copyWith</code> method, equality, and hashCode operations</ul>


</details>


  </td>
  <td><a href="https://github.com/fam-tung-lam/health_connector/pull/103/files#diff-642bd72a4b670edd9d60eb5023f009894d176f332b4fddb13a61bd26d78bbcea">+115/-0</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>exercise_session_record_test.dart</strong><dd><code>Add ExerciseSessionRecord validation tests</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/health_connector_core/test/src/models/health_records/exercise/exercise_session_record_test.dart

<ul><li>Created comprehensive test suite for <code>ExerciseSessionRecord</code> validation<br> <li> Tests cover valid instantiation with optional parameters and time <br>ordering<br> <li> Validates startTime < endTime constraint enforcement<br> <li> Tests <code>copyWith</code> method, equality, and hashCode operations</ul>


</details>


  </td>
  <td><a href="https://github.com/fam-tung-lam/health_connector/pull/103/files#diff-bf15a0c0fe8ae9040c15218fca8c7dc17bfaf7b7409b85bce5a57eec7aceb7b1">+111/-0</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>heart_rate_record_test.dart</strong><dd><code>Add HeartRateRecord validation tests</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/health_connector_core/test/src/models/health_records/heart_rate/heart_rate_record_test.dart

<ul><li>Created comprehensive test suite for <code>HeartRateRecord</code> validation<br> <li> Tests cover valid instantiation and updated range bounds (1.0-300.0 <br>bpm)<br> <li> Validates minimum and maximum rate enforcement with boundary tests<br> <li> Tests <code>copyWith</code> method, equality, and hashCode operations</ul>


</details>


  </td>
  <td><a href="https://github.com/fam-tung-lam/health_connector/pull/103/files#diff-19a6c97ecac89d666e056163a40d0fde36305b2fe3d311cc0e5c008deed9108c">+113/-0</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>active_energy_burned_record_test.dart</strong><dd><code>Add ActiveEnergyBurnedRecord validation tests</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/health_connector_core/test/src/models/health_records/energy_burned/active_energy_burned_record_test.dart

<ul><li>Created comprehensive test suite for <code>ActiveEnergyBurnedRecord</code> <br>validation<br> <li> Tests cover valid instantiation and energy range enforcement <br>(0.0-15000.0 kcal)<br> <li> Validates boundary conditions for minimum and maximum energy values<br> <li> Tests <code>copyWith</code> method, equality, and hashCode operations</ul>


</details>


  </td>
  <td><a href="https://github.com/fam-tung-lam/health_connector/pull/103/files#diff-2db8221bdbab2b01e8210879f86858571b5fd598e95e6de61573897b44c63648">+103/-0</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>respiratory_rate_record_test.dart</strong><dd><code>Add RespiratoryRateRecord validation tests</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/health_connector_core/test/src/models/health_records/respiratory_rate_record_test.dart

<ul><li>Created comprehensive test suite for <code>RespiratoryRateRecord</code> validation<br> <li> Tests cover valid instantiation and updated range bounds (0.0-1000.0 <br>breaths/min)<br> <li> Validates minimum and maximum rate enforcement with boundary tests<br> <li> Tests <code>copyWith</code> method, equality, and hashCode operations</ul>


</details>


  </td>
  <td><a href="https://github.com/fam-tung-lam/health_connector/pull/103/files#diff-decc2f32b9f4e6c80a06be192a6998de7c2ac340f8033601b425e080f3b41084">+110/-0</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>blood_glucose_record_test.dart</strong><dd><code>Blood glucose record validation test suite</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/health_connector_core/test/src/models/health_records/blood_glucose/blood_glucose_record_test.dart

<ul><li>Created comprehensive test suite for <code>BloodGlucoseRecord</code> with 5 test <br>cases<br> <li> Tests cover valid instantiation, boundary violations (min/max), <br>copyWith functionality, and equality<br> <li> Validates that <code>ArgumentError</code> is thrown for glucose levels outside <br>valid ranges</ul>


</details>


  </td>
  <td><a href="https://github.com/fam-tung-lam/health_connector/pull/103/files#diff-2596f28cfa4063102e11167a85793d7d87fb8130f549f2070d8527a4bb8990fe">+94/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>oxygen_saturation_record_test.dart</strong><dd><code>Oxygen saturation record validation test suite</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/health_connector_core/test/src/models/health_records/oxygen_saturation_record_test.dart

<ul><li>Created comprehensive test suite for <code>OxygenSaturationRecord</code> with 5 <br>test cases<br> <li> Tests cover valid instantiation, boundary violations (min/max), <br>copyWith functionality, and equality<br> <li> Validates that <code>ArgumentError</code> is thrown for saturation values outside <br>0-100% range</ul>


</details>


  </td>
  <td><a href="https://github.com/fam-tung-lam/health_connector/pull/103/files#diff-884f25edeff14835ff8cbc83ee357498f5b99af31f495445fe3917b11e16d0f0">+94/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>waist_circumference_record_test.dart</strong><dd><code>Waist circumference record validation test suite</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/health_connector_core/test/src/models/health_records/waist_circumference_record_test.dart

<ul><li>Created comprehensive test suite for <code>WaistCircumferenceRecord</code> with 5 <br>test cases<br> <li> Tests cover valid instantiation, boundary violations (min/max), <br>copyWith functionality, and equality<br> <li> Validates that <code>ArgumentError</code> is thrown for circumference values <br>outside valid range</ul>


</details>


  </td>
  <td><a href="https://github.com/fam-tung-lam/health_connector/pull/103/files#diff-2df53a08c7378f80fb6216f2c91325ebc8179bb0e5962ab17060e1179f0a6a25">+96/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>steps_record_test.dart</strong><dd><code>Steps record validation test suite</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/health_connector_core/test/src/models/health_records/steps_record_test.dart

<ul><li>Created comprehensive test suite for <code>StepsRecord</code> with 5 test cases<br> <li> Tests cover valid instantiation, negative count rejection, max steps <br>boundary, copyWith, and equality<br> <li> Validates that <code>ArgumentError</code> is thrown for invalid step counts</ul>


</details>


  </td>
  <td><a href="https://github.com/fam-tung-lam/health_connector/pull/103/files#diff-c0583e15c1984c960d950357b3f826bd1393f3949b08774ef715ea3b58476924">+101/-0</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>floors_climbed_record_test.dart</strong><dd><code>Floors climbed record validation test suite</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/health_connector_core/test/src/models/health_records/floors_climbed_record_test.dart

<ul><li>Created comprehensive test suite for <code>FloorsClimbedRecord</code> with 5 test <br>cases<br> <li> Tests cover valid instantiation, negative count rejection, max floors <br>boundary, copyWith, and equality<br> <li> Validates that <code>ArgumentError</code> is thrown for invalid floor counts</ul>


</details>


  </td>
  <td><a href="https://github.com/fam-tung-lam/health_connector/pull/103/files#diff-3758a3902d9e19dd99d6b5f6c5fb49a1fd71455dbe550885a8d669a75e1fdac8">+101/-0</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>wheelchair_pushes_record_test.dart</strong><dd><code>Wheelchair pushes record validation test suite</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/health_connector_core/test/src/models/health_records/wheelchair_pushes_record_test.dart

<ul><li>Created test suite for <code>WheelchairPushesRecord</code> with 4 test cases<br> <li> Tests cover valid instantiation, negative count rejection, copyWith <br>functionality, and equality<br> <li> Validates that <code>ArgumentError</code> is thrown for negative wheelchair push <br>counts</ul>


</details>


  </td>
  <td><a href="https://github.com/fam-tung-lam/health_connector/pull/103/files#diff-1a070fcb2d95b7b1ea10bcba6445bcf1bd27eab5f9c454458d8d4df18a8e0038">+89/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>resting_heart_rate_record_test.dart</strong><dd><code>Resting heart rate record validation test suite</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/health_connector_core/test/src/models/health_records/heart_rate/resting_heart_rate_record_test.dart

<ul><li>Created comprehensive test suite for <code>RestingHeartRateRecord</code> with 6 <br>test cases<br> <li> Tests cover valid instantiation, boundary violations (min/max), <br>copyWith functionality, and equality<br> <li> Validates that <code>ArgumentError</code> is thrown for heart rates outside 1.0-300 <br>bpm range</ul>


</details>


  </td>
  <td><a href="https://github.com/fam-tung-lam/health_connector/pull/103/files#diff-8d81d3d16e7e0b3d1dc07c074be1e44e842f9e4709568babcf91abcfbaf0b35b">+104/-0</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>total_energy_burned_record_test.dart</strong><dd><code>Total energy burned record validation test suite</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/health_connector_core/test/src/models/health_records/energy_burned/total_energy_burned_record_test.dart

<ul><li>Created comprehensive test suite for <code>TotalEnergyBurnedRecord</code> with 5 <br>test cases<br> <li> Tests cover valid instantiation, boundary violations (min/max), <br>copyWith functionality, and equality<br> <li> Validates that <code>ArgumentError</code> is thrown for energy values outside valid <br>range</ul>


</details>


  </td>
  <td><a href="https://github.com/fam-tung-lam/health_connector/pull/103/files#diff-a72a72724f9ff7ab1f5dc43c3056438fdc37b80a892ca22e312a1e30c272aa98">+100/-0</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>dietary_energy_consumed_record_test.dart</strong><dd><code>Dietary energy consumed record validation test suite</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/health_connector_core/test/src/models/health_records/nutrition/dietary_energy_consumed_record_test.dart

<ul><li>Created comprehensive test suite for <code>DietaryEnergyConsumedRecord</code> with <br>5 test cases<br> <li> Tests cover valid instantiation, boundary violations (min/max), <br>copyWith functionality, and equality<br> <li> Validates that <code>ArgumentError</code> is thrown for energy values outside valid <br>range</ul>


</details>


  </td>
  <td><a href="https://github.com/fam-tung-lam/health_connector/pull/103/files#diff-6de30d74b60c8261cd92fc20a46baef16a1c2f1046a965211b46efdc588141e0">+102/-0</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>dietary_protein_record_test.dart</strong><dd><code>Dietary protein record validation test suite</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/health_connector_core/test/src/models/health_records/nutrition/dietary_protein_record_test.dart

<ul><li>Created comprehensive test suite for <code>DietaryProteinRecord</code> with 5 test <br>cases<br> <li> Tests cover valid instantiation, boundary violations (min/max), <br>copyWith functionality, and equality<br> <li> Validates that <code>ArgumentError</code> is thrown for protein mass values outside <br>valid range</ul>


</details>


  </td>
  <td><a href="https://github.com/fam-tung-lam/health_connector/pull/103/files#diff-e9be6ef4e4727a9b5ac739c1275bef12c07081613ff097d94c0cf2fc3efca3c8">+102/-0</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>dietary_total_fat_record_test.dart</strong><dd><code>Dietary total fat record validation test suite</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/health_connector_core/test/src/models/health_records/nutrition/dietary_total_fat_record_test.dart

<ul><li>Created comprehensive test suite for <code>DietaryTotalFatRecord</code> with 5 test <br>cases<br> <li> Tests cover valid instantiation, boundary violations (min/max), <br>copyWith functionality, and equality<br> <li> Validates that <code>ArgumentError</code> is thrown for fat mass values outside <br>valid range</ul>


</details>


  </td>
  <td><a href="https://github.com/fam-tung-lam/health_connector/pull/103/files#diff-5d9316531646a21555b0c16d6f3bde5c9cac8205a498c91125882a0573c92285">+100/-0</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>dietary_saturated_fat_record_test.dart</strong><dd><code>Dietary saturated fat record validation test suite</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/health_connector_core/test/src/models/health_records/nutrition/dietary_saturated_fat_record_test.dart

<ul><li>Created comprehensive test suite for <code>DietarySaturatedFatRecord</code> with 5 <br>test cases<br> <li> Tests cover valid instantiation, boundary violations (min/max), <br>copyWith functionality, and equality<br> <li> Validates that <code>ArgumentError</code> is thrown for saturated fat mass values <br>outside valid range</ul>


</details>


  </td>
  <td><a href="https://github.com/fam-tung-lam/health_connector/pull/103/files#diff-f9fc6b56e9a0003d69361dd11187154624f374b469f6a2cf1957b06065a01a0a">+100/-0</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>dietary_cholesterol_record_test.dart</strong><dd><code>Dietary cholesterol record validation test suite</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/health_connector_core/test/src/models/health_records/nutrition/dietary_cholesterol_record_test.dart

<ul><li>Created comprehensive test suite for <code>DietaryCholesterolRecord</code> with 5 <br>test cases<br> <li> Tests cover valid instantiation, boundary violations (min/max), <br>copyWith functionality, and equality<br> <li> Validates that <code>ArgumentError</code> is thrown for cholesterol mass values <br>outside valid range</ul>


</details>


  </td>
  <td><a href="https://github.com/fam-tung-lam/health_connector/pull/103/files#diff-b0114010397fcbb845c17ab1bf8dac0ab07d0b8d43339bf8422056166f0a081a">+100/-0</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>dietary_fiber_record_test.dart</strong><dd><code>Dietary fiber record validation test suite</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/health_connector_core/test/src/models/health_records/nutrition/dietary_fiber_record_test.dart

<ul><li>Created comprehensive test suite for <code>DietaryFiberRecord</code> with 5 test <br>cases<br> <li> Tests cover valid instantiation, boundary violations (min/max), <br>copyWith functionality, and equality<br> <li> Validates that <code>ArgumentError</code> is thrown for fiber mass values outside <br>valid range</ul>


</details>


  </td>
  <td><a href="https://github.com/fam-tung-lam/health_connector/pull/103/files#diff-458e1ca5f3a2ec0acc32066fed01de98399475d93f94bc599baa7cb9044986bf">+100/-0</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>dietary_sugar_record_test.dart</strong><dd><code>Dietary sugar record validation test suite</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/health_connector_core/test/src/models/health_records/nutrition/dietary_sugar_record_test.dart

<ul><li>Created comprehensive test suite for <code>DietarySugarRecord</code> with 5 test <br>cases<br> <li> Tests cover valid instantiation, boundary violations (min/max), <br>copyWith functionality, and equality<br> <li> Validates that <code>ArgumentError</code> is thrown for sugar mass values outside <br>valid range</ul>


</details>


  </td>
  <td><a href="https://github.com/fam-tung-lam/health_connector/pull/103/files#diff-865b9868e36854653cd9b2f92be26a58ed130e97a398907b1489139dde7af78d">+100/-0</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>dietary_calcium_record_test.dart</strong><dd><code>Dietary calcium record validation test suite</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/health_connector_core/test/src/models/health_records/nutrition/dietary_calcium_record_test.dart

<ul><li>Created comprehensive test suite for <code>DietaryCalciumRecord</code> with 5 test <br>cases<br> <li> Tests cover valid instantiation, boundary violations (min/max), <br>copyWith functionality, and equality<br> <li> Validates that <code>ArgumentError</code> is thrown for calcium mass values outside <br>valid range</ul>


</details>


  </td>
  <td><a href="https://github.com/fam-tung-lam/health_connector/pull/103/files#diff-bca3b45abfef8b3a3442b0c86782ce1d31cf5e13bed2e82ce76533626678ce31">+100/-0</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>dietary_phosphorus_record_test.dart</strong><dd><code>Dietary phosphorus record validation test suite</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/health_connector_core/test/src/models/health_records/nutrition/dietary_phosphorus_record_test.dart

<ul><li>Created comprehensive test suite for <code>DietaryPhosphorusRecord</code> with 5 <br>test cases<br> <li> Tests cover valid instantiation, boundary violations (min/max), <br>copyWith functionality, and equality<br> <li> Validates that <code>ArgumentError</code> is thrown for phosphorus mass values <br>outside valid range</ul>


</details>


  </td>
  <td><a href="https://github.com/fam-tung-lam/health_connector/pull/103/files#diff-5115006e6f9fd9ed3e1c28967712d617b87b1dd22b0e3fd8f899c2b6c04fce25">+100/-0</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>dietary_magnesium_record_test.dart</strong><dd><code>Dietary magnesium record validation test suite</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/health_connector_core/test/src/models/health_records/nutrition/dietary_magnesium_record_test.dart

<ul><li>Created comprehensive test suite for <code>DietaryMagnesiumRecord</code> with 5 <br>test cases<br> <li> Tests cover valid instantiation, boundary violations (min/max), <br>copyWith functionality, and equality<br> <li> Validates that <code>ArgumentError</code> is thrown for magnesium mass values <br>outside valid range</ul>


</details>


  </td>
  <td><a href="https://github.com/fam-tung-lam/health_connector/pull/103/files#diff-665d00687eb6dc78c1c7c9d9b224622289abb58e40317e3076ff0fdd7a319114">+100/-0</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>dietary_sodium_record_test.dart</strong><dd><code>Dietary sodium record validation test suite</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/health_connector_core/test/src/models/health_records/nutrition/dietary_sodium_record_test.dart

<ul><li>Created comprehensive test suite for <code>DietarySodiumRecord</code> with 5 test <br>cases<br> <li> Tests cover valid instantiation, boundary violations (min/max), <br>copyWith functionality, and equality<br> <li> Validates that <code>ArgumentError</code> is thrown for sodium mass values outside <br>valid range</ul>


</details>


  </td>
  <td><a href="https://github.com/fam-tung-lam/health_connector/pull/103/files#diff-26c597f30dadf05ea26622b17c8063f797d938da6bbce49b18613205b47560a9">+100/-0</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>dietary_potassium_record_test.dart</strong><dd><code>Dietary potassium record validation test suite</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/health_connector_core/test/src/models/health_records/nutrition/dietary_potassium_record_test.dart

<ul><li>Created comprehensive test suite for <code>DietaryPotassiumRecord</code> with 5 <br>test cases<br> <li> Tests cover valid instantiation, boundary violations (min/max), <br>copyWith functionality, and equality<br> <li> Validates that <code>ArgumentError</code> is thrown for potassium mass values <br>outside valid range</ul>


</details>


  </td>
  <td><a href="https://github.com/fam-tung-lam/health_connector/pull/103/files#diff-553b95f264fb83859cb6088d37f06b0b8d57e00b9394d30609d669e717236013">+100/-0</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>dietary_iron_record_test.dart</strong><dd><code>Dietary iron record validation test suite</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/health_connector_core/test/src/models/health_records/nutrition/dietary_iron_record_test.dart

<ul><li>Created comprehensive test suite for <code>DietaryIronRecord</code> with 5 test <br>cases<br> <li> Tests cover valid instantiation, boundary violations (min/max), <br>copyWith functionality, and equality<br> <li> Validates that <code>ArgumentError</code> is thrown for iron mass values outside <br>valid range</ul>


</details>


  </td>
  <td><a href="https://github.com/fam-tung-lam/health_connector/pull/103/files#diff-9bf9a5e3bdd5664fb5a5c9cd3c37cfb20433a75a31297b225695e2627ba72ec9">+100/-0</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>dietary_zinc_record_test.dart</strong><dd><code>Dietary zinc record validation test suite</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/health_connector_core/test/src/models/health_records/nutrition/dietary_zinc_record_test.dart

<ul><li>Created comprehensive test suite for <code>DietaryZincRecord</code> with 5 test <br>cases<br> <li> Tests cover valid instantiation, boundary violations (min/max), <br>copyWith functionality, and equality<br> <li> Validates that <code>ArgumentError</code> is thrown for zinc mass values outside <br>valid range</ul>


</details>


  </td>
  <td><a href="https://github.com/fam-tung-lam/health_connector/pull/103/files#diff-bedb970969454bceef27f48040d4edadc469394bef933df3bb97629e073a7576">+100/-0</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>dietary_selenium_record_test.dart</strong><dd><code>Dietary selenium record validation test suite</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/health_connector_core/test/src/models/health_records/nutrition/dietary_selenium_record_test.dart

<ul><li>Created comprehensive test suite for <code>DietarySeleniumRecord</code> with 5 test <br>cases<br> <li> Tests cover valid instantiation, boundary violations (min/max), <br>copyWith functionality, and equality<br> <li> Validates that <code>ArgumentError</code> is thrown for selenium mass values <br>outside valid range</ul>


</details>


  </td>
  <td><a href="https://github.com/fam-tung-lam/health_connector/pull/103/files#diff-1584d61fde7b538c3191c21e5ed6539f8d7dcab8efc317fb6700e885d7e13e80">+100/-0</a>&nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Documentation</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td>
    <details>
      <summary><strong>exercise_type.dart</strong><dd><code>Fix documentation formatting and clarity in ExerciseType</code>&nbsp; </dd></summary>
<hr>

packages/health_connector_core/lib/src/models/health_records/exercise/exercise_type.dart

<ul><li>Fixed line wrapping in documentation comments for better readability<br> <li> Corrected platform mapping descriptions for swimming and skiing types<br> <li> Improved clarity of unsupported operation notes</ul>


</details>


  </td>
  <td><a href="https://github.com/fam-tung-lam/health_connector/pull/103/files#diff-8ba91338bc4297abf8d4951f5f5d0d8dc49f46b40617becfae7e7c08383b0c25">+13/-8</a>&nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Additional files</strong></td><td><details><summary>95 files</summary><table>
<tr>
  <td><strong>body_fat_percentage_record.dart</strong></td>
  <td><a href="https://github.com/fam-tung-lam/health_connector/pull/103/files#diff-e051d733889eda43c6e204c00d70e697316a88367307695410bc4e2fa7436a0f">+36/-2</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>body_mass_index_record.dart</strong></td>
  <td><a href="https://github.com/fam-tung-lam/health_connector/pull/103/files#diff-25ba7aa894c6f1d903036f0cc11426ec62792dbc209f74e8971199dd77ec37a2">+27/-8</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>body_water_mass_record.dart</strong></td>
  <td><a href="https://github.com/fam-tung-lam/health_connector/pull/103/files#diff-ca4fe7232b7e1db969fee15a9c1ac87b71adf5a886f1dd01bb1adb18c26fc4c2">+40/-2</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>bone_mass_record.dart</strong></td>
  <td><a href="https://github.com/fam-tung-lam/health_connector/pull/103/files#diff-e14a61d2a314712954092541e90385a6c1703e743cbdd899b056693e9005fb13">+40/-2</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>cycling_pedaling_cadence_series_record.dart</strong></td>
  <td><a href="https://github.com/fam-tung-lam/health_connector/pull/103/files#diff-fe7d1814a699749b91291df967af7878f551b86be8130b712af3b092d4ce6fd3">+30/-2</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>distance_activity_record.dart</strong></td>
  <td><a href="https://github.com/fam-tung-lam/health_connector/pull/103/files#diff-30a9f62b534e0c73efb19900e7d6cfbec098e31b571d55987862e12d7fc9daf7">+18/-1</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>distance_record.dart</strong></td>
  <td><a href="https://github.com/fam-tung-lam/health_connector/pull/103/files#diff-c389f70b705aab01e588e62ed6ba6db21d7ec9e5d223a7abc517e97255af5816">+30/-1</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>active_energy_burned_record.dart</strong></td>
  <td><a href="https://github.com/fam-tung-lam/health_connector/pull/103/files#diff-4a0146bfbed0a89758f6a708dd27dac2c37451061c4376f2223685844b2cf96c">+31/-1</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>exercise_session_record.dart</strong></td>
  <td><a href="https://github.com/fam-tung-lam/health_connector/pull/103/files#diff-b86f113e9d1dd051b8e0a4760e345200a22a410aab28181c11b0561abedf6b07">+5/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>floors_climbed_record.dart</strong></td>
  <td><a href="https://github.com/fam-tung-lam/health_connector/pull/103/files#diff-ce9131c33cc3c72d41a25f942e37ed3317b79558d9dd3b58c66cf6baf55925c3">+33/-1</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>heart_rate_series_record.dart</strong></td>
  <td><a href="https://github.com/fam-tung-lam/health_connector/pull/103/files#diff-02a3765618d966ab52b61e777b2c4509fd67d988f72ea7eaa6288dbd9970c2ff">+36/-2</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>height_record.dart</strong></td>
  <td><a href="https://github.com/fam-tung-lam/health_connector/pull/103/files#diff-66f9b03f9ee7cd6e9e7a48b812300655666709d1c58c18379a88ada41cdf2d23">+35/-3</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>hydration_record.dart</strong></td>
  <td><a href="https://github.com/fam-tung-lam/health_connector/pull/103/files#diff-7fa3a0c37882b00538fb9688ff839c7ce59edcb8a9352417ee68abc33bfef5f6">+23/-4</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>lean_body_mass_record.dart</strong></td>
  <td><a href="https://github.com/fam-tung-lam/health_connector/pull/103/files#diff-ad580c8c8ff4d9fe2958b790bac3b60587f2e3f20443d0b54c828c1133f3f009">+40/-2</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>cervical_mucus_appearance.dart</strong></td>
  <td><a href="https://github.com/fam-tung-lam/health_connector/pull/103/files#diff-5bb5a41806aa695b6989587adf31d0ca6ac19212e94e4ecfbc14bd992a93f8bb">+5/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>intermenstrual_bleeding_record.dart</strong></td>
  <td><a href="https://github.com/fam-tung-lam/health_connector/pull/103/files#diff-c7dd1f76ebb371419cbda70fdb6b18123684fb967640405d7dd7ce2507f7d632">+8/-7</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>menstrual_flow.dart</strong></td>
  <td><a href="https://github.com/fam-tung-lam/health_connector/pull/103/files#diff-59a57f5aa7cbacf196e90f60a6efdf2ee6b9b107bd6c7ddb622a9caa154448fb">+4/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>menstrual_flow_instant_record.dart</strong></td>
  <td><a href="https://github.com/fam-tung-lam/health_connector/pull/103/files#diff-ef4aeccadc6cdf13ad63fef5919fd887e418339aea9a09c4b1838c570cdb082b">+8/-7</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>menstrual_flow_record.dart</strong></td>
  <td><a href="https://github.com/fam-tung-lam/health_connector/pull/103/files#diff-79c4a62a60646b817af0b0231a8e778b365a2fa081414144d9e7d60d996c57f2">+5/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>ovulation_test_record.dart</strong></td>
  <td><a href="https://github.com/fam-tung-lam/health_connector/pull/103/files#diff-490663806e7d42670d77675cd3a512f732a9d1b8ae457ba7adb8a7061d1d2bde">+3/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>ovulation_test_result.dart</strong></td>
  <td><a href="https://github.com/fam-tung-lam/health_connector/pull/103/files#diff-47a7214e980765706f0ce34856e2a914f606d4fcced56af7021c43566b005f14">+4/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>mindfulness_session_record.dart</strong></td>
  <td><a href="https://github.com/fam-tung-lam/health_connector/pull/103/files#diff-a50cc304ddf77ecc5aa7602b638e2b742b02344d0d8fc96df41f81f4ce37b3be">+9/-6</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>dietary_macronutrient_record.dart</strong></td>
  <td><a href="https://github.com/fam-tung-lam/health_connector/pull/103/files#diff-26eb4fdd4effdaf105a747c1e31302b6091ca5b3742749ec02c3e6701fe8e4bc">+29/-2</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>dietary_mineral_records.dart</strong></td>
  <td><a href="https://github.com/fam-tung-lam/health_connector/pull/103/files#diff-bd231f84a103e4183388bbbe2d193a959e6fcd0708654659f13b22d7138fe9e2">+29/-2</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>dietary_nutrient_record.dart</strong></td>
  <td><a href="https://github.com/fam-tung-lam/health_connector/pull/103/files#diff-97c65b8cfbd9125980336ad71c9a92c678421e4e02b1144f9a76eebd4e05b163">+21/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>dietary_vitamin_record.dart</strong></td>
  <td><a href="https://github.com/fam-tung-lam/health_connector/pull/103/files#diff-9536ac8a5fc774596eb5872a1360288eab0a1d6134070cc3a1786712ddcac166">+29/-2</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>cycling_power_record.dart</strong></td>
  <td><a href="https://github.com/fam-tung-lam/health_connector/pull/103/files#diff-e7dc7ef7f3e1f300ac64762fe3e1a369fa600457d1a1df6f36a7317c14e32291">+36/-2</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>power_series_record.dart</strong></td>
  <td><a href="https://github.com/fam-tung-lam/health_connector/pull/103/files#diff-3849f4f1a83ce7f8364f115cfc04dcf72837058dc099c02146dde6c8d6b6d8c4">+30/-2</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>sexual_activity_protection_used.dart</strong></td>
  <td><a href="https://github.com/fam-tung-lam/health_connector/pull/103/files#diff-775db02a67496bab997a137e22d6ed58c59c5a74cef7f14fd19b93d50608eb2d">+6/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>sleep_stage.dart</strong></td>
  <td><a href="https://github.com/fam-tung-lam/health_connector/pull/103/files#diff-4e01d4c55545f7712f31e0feeba7f466b404a76e3621986a443fd67214092bac">+2/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>running_speed_record.dart</strong></td>
  <td><a href="https://github.com/fam-tung-lam/health_connector/pull/103/files#diff-2529df73f1c3258902aacecd839200b4adf2b2869ca34b25a53788cbee785b40">+38/-2</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>speed_series_record.dart</strong></td>
  <td><a href="https://github.com/fam-tung-lam/health_connector/pull/103/files#diff-54dd3f2432dcdfb0ed48c75aaf8dae26be27d3a05ef5acc355aeb974c8b5b889">+39/-3</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>stair_ascent_speed_record.dart</strong></td>
  <td><a href="https://github.com/fam-tung-lam/health_connector/pull/103/files#diff-793283e80d59daaf0fff9618ed6079180554dd9e10b54a5e78bec33cee7baf82">+38/-2</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>stair_descent_speed_record.dart</strong></td>
  <td><a href="https://github.com/fam-tung-lam/health_connector/pull/103/files#diff-aed980284656050e495887f0935deb8c7b17f994b24c91c63384e3e1f2871ae4">+38/-2</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>walking_speed_record.dart</strong></td>
  <td><a href="https://github.com/fam-tung-lam/health_connector/pull/103/files#diff-9364280614254c1eb8a3c7b85b341a79f51d88b7eadd5806c47004f500069a55">+37/-2</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>steps_record.dart</strong></td>
  <td><a href="https://github.com/fam-tung-lam/health_connector/pull/103/files#diff-38dc9b9840b35372e840cc938cbd153d5fccdc6e1cff3177c01cf570e2e14b83">+17/-2</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>basal_body_temperature_record.dart</strong></td>
  <td><a href="https://github.com/fam-tung-lam/health_connector/pull/103/files#diff-4ea0b38a556ef6f1e1d9e64f286b9a2006741dd0d144945e2f93ba28bd30788d">+37/-2</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>body_temperature_record.dart</strong></td>
  <td><a href="https://github.com/fam-tung-lam/health_connector/pull/103/files#diff-68a32b767940c6db6ee125ca726c878e391d8f21b4c23d3c24aa6edde7260b4b">+37/-2</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>vo2_max_record.dart</strong></td>
  <td><a href="https://github.com/fam-tung-lam/health_connector/pull/103/files#diff-bbfbc7df2aa65681c07f2368eba1356a0b352307be8849023b1b2ea42cb75d46">+37/-2</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>waist_circumference_record.dart</strong></td>
  <td><a href="https://github.com/fam-tung-lam/health_connector/pull/103/files#diff-001494b9d69e778af55e8a61bd570ec28e9bc76f4316888be0f17fdd56990f98">+29/-8</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>weight_record.dart</strong></td>
  <td><a href="https://github.com/fam-tung-lam/health_connector/pull/103/files#diff-744aeae5ec60a8a8186355fb529a0f7375be56bb0cbd0b291c269a459c49127b">+40/-2</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>wheelchair_pushes_record.dart</strong></td>
  <td><a href="https://github.com/fam-tung-lam/health_connector/pull/103/files#diff-5325f541334527076b4b3d6254edaa3da58dd8ef1d15dca5ffc1dcaed332fd88">+33/-1</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>diastolic_blood_pressure_record_test.dart</strong></td>
  <td><a href="https://github.com/fam-tung-lam/health_connector/pull/103/files#diff-f58eeba970311e65441074f0026dffcd1d50d4f34e0153b1dcf495347ca47914">+76/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>systolic_blood_pressure_record_test.dart</strong></td>
  <td><a href="https://github.com/fam-tung-lam/health_connector/pull/103/files#diff-ca704732231854e62d1d99e0fc0a06f8e3ff202d3e64fa4dad71f325f89504dc">+76/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>body_fat_percentage_record_test.dart</strong></td>
  <td><a href="https://github.com/fam-tung-lam/health_connector/pull/103/files#diff-1d72337e02b1a63cb596796440c1e1c7abcdc1d9bc20305bc77314084a760ce2">+90/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>body_mass_index_record_test.dart</strong></td>
  <td><a href="https://github.com/fam-tung-lam/health_connector/pull/103/files#diff-ebd0153e2860f1256b6d91e2a622dc4248a6e534fdda1e80566b874b08ed9673">+90/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>body_water_mass_record_test.dart</strong></td>
  <td><a href="https://github.com/fam-tung-lam/health_connector/pull/103/files#diff-bd9b26f223fe3e454b618ec6828c12782451734228efec08d27821e537e9a7eb">+90/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>bone_mass_record_test.dart</strong></td>
  <td><a href="https://github.com/fam-tung-lam/health_connector/pull/103/files#diff-0f628b84645ce1e45eb7e7b14d80da8f14e6e8c08c50af2e98173978607e9251">+90/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>cycling_pedaling_cadence_record_test.dart</strong></td>
  <td><a href="https://github.com/fam-tung-lam/health_connector/pull/103/files#diff-2fcea62759717e2e23a8bbbff2b167ea7e2970297664b5c78cc23aa10f9b03b9">+70/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>cross_country_skiing_distance_record_test.dart</strong></td>
  <td><a href="https://github.com/fam-tung-lam/health_connector/pull/103/files#diff-439069a3618ebb95f6d4cc850dc32fbbf025cdd835a503ddf3c9e8314c1e6bb5">+40/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>cycling_distance_record_test.dart</strong></td>
  <td><a href="https://github.com/fam-tung-lam/health_connector/pull/103/files#diff-70c4a5bb98903634954b3e2078fa91e47b33aa45fe9c366203ebb17e022dbf58">+40/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>distance_record_test.dart</strong></td>
  <td><a href="https://github.com/fam-tung-lam/health_connector/pull/103/files#diff-6a1d0f702d505f9f4da64859bd46072045d020c488fe3b088f3fc8ca53d712ab">+88/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>downhill_snow_sports_distance_record_test.dart</strong></td>
  <td><a href="https://github.com/fam-tung-lam/health_connector/pull/103/files#diff-e5fed0e5205bf2800c3218c5d806a74f7ab86be10d5b0ceb8b12185ae8cbb1fa">+40/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>paddle_sports_distance_record_test.dart</strong></td>
  <td><a href="https://github.com/fam-tung-lam/health_connector/pull/103/files#diff-b3fe38a41bf1d7dc8c92797e7e81b52d2d8ec2f2210ad2fd87af0e8d3312c34c">+40/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>rowing_distance_record_test.dart</strong></td>
  <td><a href="https://github.com/fam-tung-lam/health_connector/pull/103/files#diff-a54a0fc8bcf0e4c4a06ff252307d6608a4805f1a30c6d74f2da2651c664d9b14">+40/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>six_minute_walk_test_distance_record_test.dart</strong></td>
  <td><a href="https://github.com/fam-tung-lam/health_connector/pull/103/files#diff-445dfb3db600db424e3f886d24705d4ae0bcbec9819349a2491d755b44c1b9c8">+40/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>skating_sports_distance_record_test.dart</strong></td>
  <td><a href="https://github.com/fam-tung-lam/health_connector/pull/103/files#diff-4ae79816d81f611bd0fd0022571822b8502ca32e0651a847965f43baec359a0c">+40/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>swimming_distance_record_test.dart</strong></td>
  <td><a href="https://github.com/fam-tung-lam/health_connector/pull/103/files#diff-f3ca9c145fd0d2c858b172a46fd6109270423075c6a611533421452abb033250">+40/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>walking_running_distance_record_test.dart</strong></td>
  <td><a href="https://github.com/fam-tung-lam/health_connector/pull/103/files#diff-a0b17cef3f513691b01840e815fe3a795e5dbb1448b8671fbbd7b61ac1a27fbb">+40/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>wheelchair_distance_record_test.dart</strong></td>
  <td><a href="https://github.com/fam-tung-lam/health_connector/pull/103/files#diff-13102bacd2a02e9e3c96a7f934cc00a7800983e10a743f1db00a0b78a6e75854">+40/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>basal_energy_burned_record_test.dart</strong></td>
  <td><a href="https://github.com/fam-tung-lam/health_connector/pull/103/files#diff-2c91ec5c0d012d21e109569114ed6f3ce4e5720167b1b9587ffe64abfd16c2cf">+100/-0</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>heart_rate_variability_rmssd_record_test.dart</strong></td>
  <td><a href="https://github.com/fam-tung-lam/health_connector/pull/103/files#diff-8f5d8460f3d64b17996f80ef945a1a6398b630b719460302326c9a18268eee88">+83/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>heart_rate_variability_sdnn_record_test.dart</strong></td>
  <td><a href="https://github.com/fam-tung-lam/health_connector/pull/103/files#diff-b14effac3b42c7c1dd064ee6d1f1e988ebc17232fc419a712aa02ea4430617e0">+83/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>height_record_test.dart</strong></td>
  <td><a href="https://github.com/fam-tung-lam/health_connector/pull/103/files#diff-f9a410625fc8e46691cbbcb14c917bd185dbf4d41481376da3f1d679cf4e2955">+90/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>lean_body_mass_record_test.dart</strong></td>
  <td><a href="https://github.com/fam-tung-lam/health_connector/pull/103/files#diff-acb361b95916aae0dd4ff3fe2d944986363b79399d7caa423c74ac7aacf76a40">+90/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>cervical_mucus_record_test.dart</strong></td>
  <td><a href="https://github.com/fam-tung-lam/health_connector/pull/103/files#diff-8411b7d4cfa24701bc11877e99cccc704d5f72cb4b05353c4c906a7a956f64bb">+75/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>intermenstrual_bleeding_record_test.dart</strong></td>
  <td><a href="https://github.com/fam-tung-lam/health_connector/pull/103/files#diff-ae3038dc8b6771ca4c2867073b2f9140846121768c1f577e2ae8baa689e9e178">+59/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>menstrual_flow_instant_record_test.dart</strong></td>
  <td><a href="https://github.com/fam-tung-lam/health_connector/pull/103/files#diff-87d343a894dcc63c36509ccabb8a4b40da543b09e01ac18ac49ed7faa94c0339">+59/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>menstrual_flow_record_test.dart</strong></td>
  <td><a href="https://github.com/fam-tung-lam/health_connector/pull/103/files#diff-90de98e9fb990f8eeb99c235d5747e94c564ae0253e43f23e025b88eb8a4af53">+72/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>ovulation_test_record_test.dart</strong></td>
  <td><a href="https://github.com/fam-tung-lam/health_connector/pull/103/files#diff-91e8dcdf15884782fdab9d1148c707081293784a08a636d602c3ce9ddedae798">+59/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>dietary_biotin_record_test.dart</strong></td>
  <td><a href="https://github.com/fam-tung-lam/health_connector/pull/103/files#diff-b153dee19b62db22a2d4894ad78f23fadc4388c63184e788cac96dde33124949">+100/-0</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>dietary_caffeine_record_test.dart</strong></td>
  <td><a href="https://github.com/fam-tung-lam/health_connector/pull/103/files#diff-be7d66e6482d26e62f2ad94094005794cb3ce2e1a5662f860f6f4c031c33f6e7">+100/-0</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>dietary_folate_record_test.dart</strong></td>
  <td><a href="https://github.com/fam-tung-lam/health_connector/pull/103/files#diff-e74fe1d664d8b6a22bfbd35b8c560874e92b7e706b407d962eb3e00a1105770f">+100/-0</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>dietary_manganese_record_test.dart</strong></td>
  <td><a href="https://github.com/fam-tung-lam/health_connector/pull/103/files#diff-b9282cc6c6d3d324117125a57ea7a4c08ee9a49bfef2e9024d220fb289854399">+100/-0</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>dietary_monounsaturated_fat_record_test.dart</strong></td>
  <td><a href="https://github.com/fam-tung-lam/health_connector/pull/103/files#diff-5dfaa55ff5e6dff0201ee0af2fe4fde8b578f16c84bc1e7ca3d081d6e34a3e6f">+100/-0</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>dietary_niacin_record_test.dart</strong></td>
  <td><a href="https://github.com/fam-tung-lam/health_connector/pull/103/files#diff-0ea186554ae4220e5244b08bf9ac46fc5261e6903d4fdc6aaea21ec32f1d1b53">+100/-0</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>dietary_pantothenic_acid_record_test.dart</strong></td>
  <td><a href="https://github.com/fam-tung-lam/health_connector/pull/103/files#diff-59a2010abc8dfa580f8d6210f3b2586179388329b131ea01c6b27761f194136e">+100/-0</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>dietary_polyunsaturated_fat_record_test.dart</strong></td>
  <td><a href="https://github.com/fam-tung-lam/health_connector/pull/103/files#diff-131b947fba5efe94530ac69cf6b27ba188d1fd58e65416d637de64fa30238b42">+100/-0</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>dietary_riboflavin_record_test.dart</strong></td>
  <td><a href="https://github.com/fam-tung-lam/health_connector/pull/103/files#diff-766cc7b55cba7a972fed1b53964d691d1d988432cd2bf6c749e582a2b710883e">+100/-0</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>dietary_thiamin_record_test.dart</strong></td>
  <td><a href="https://github.com/fam-tung-lam/health_connector/pull/103/files#diff-5ea9056fc257316ec52e7a793804ed85222c47dabe1a1d1d11f5ea07dd669d25">+100/-0</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>dietary_total_carbohydrate_record_test.dart</strong></td>
  <td><a href="https://github.com/fam-tung-lam/health_connector/pull/103/files#diff-7e155d1a0fcafe595e437be47428f39bbb56c25324b74084c85be860f5457b83">+100/-0</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>dietary_vitamin_b12_record_test.dart</strong></td>
  <td><a href="https://github.com/fam-tung-lam/health_connector/pull/103/files#diff-bd156f26a8a80f0225dc2fd0c82bbc09bbffafd2ac15a0a1d8500cad1ccae40a">+100/-0</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>dietary_vitamin_b6_record_test.dart</strong></td>
  <td><a href="https://github.com/fam-tung-lam/health_connector/pull/103/files#diff-ab78dd0043abf6684055c2046623b88b9105d8259a0b0bd6410ea9c5a32163ab">+100/-0</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>dietary_vitamin_c_record_test.dart</strong></td>
  <td><a href="https://github.com/fam-tung-lam/health_connector/pull/103/files#diff-1dd55e77106cea0a7798f7ad5031161c5a81b44b20608e45690d757cce12498b">+100/-0</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>dietary_vitamin_d_record_test.dart</strong></td>
  <td><a href="https://github.com/fam-tung-lam/health_connector/pull/103/files#diff-b909d5aa2d5a309b21f118ebbae0c27343fee9910d77c040eead545b5803c171">+100/-0</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>dietary_vitamin_e_record_test.dart</strong></td>
  <td><a href="https://github.com/fam-tung-lam/health_connector/pull/103/files#diff-06b88cd212c418728d66869837ffc91addfd015ab262afaa9827e22899a2fd53">+100/-0</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>dietary_vitamin_k_record_test.dart</strong></td>
  <td><a href="https://github.com/fam-tung-lam/health_connector/pull/103/files#diff-87a25611b758d2beb19dec7174ea498d6893342e1b848de5ad6d12fa3576aae8">+100/-0</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>cycling_power_record_test.dart</strong></td>
  <td><a href="https://github.com/fam-tung-lam/health_connector/pull/103/files#diff-416df22ca707cbbcaeb89a45ba3ad6a832b245f321b2ac99129580cb926d0596">+90/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>running_speed_record_test.dart</strong></td>
  <td><a href="https://github.com/fam-tung-lam/health_connector/pull/103/files#diff-a50e480757a73fd5a367d27de2f1326300ac3d9b7df19f9835d880641396ca92">+90/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>stair_ascent_speed_record_test.dart</strong></td>
  <td><a href="https://github.com/fam-tung-lam/health_connector/pull/103/files#diff-a1b5d94598abe4ace4a78915321ba1e8e2f2646f4b6142e33012d5b489df8376">+90/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>stair_descent_speed_record_test.dart</strong></td>
  <td><a href="https://github.com/fam-tung-lam/health_connector/pull/103/files#diff-fbdc07e5d95b610378084f2339a2c9bfff63cbe46f181c839b8002eba909d953">+90/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>walking_speed_record_test.dart</strong></td>
  <td><a href="https://github.com/fam-tung-lam/health_connector/pull/103/files#diff-0ee66d7c65a4d822d477670176bb47c49d5bcdd3d4df27c98578ad6d8e1a4100">+90/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>basal_body_temperature_record_test.dart</strong></td>
  <td><a href="https://github.com/fam-tung-lam/health_connector/pull/103/files#diff-dac6851c835624721f78658ee4bd8c66a6847f7eb208f1b8470e86b19ec9aa82">+90/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>body_temperature_record_test.dart</strong></td>
  <td><a href="https://github.com/fam-tung-lam/health_connector/pull/103/files#diff-556c641e50883d68ae1e953c1653681c67fa040abfe2c8420ac0ffc149ec3dd2">+90/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>weight_record_test.dart</strong></td>
  <td><a href="https://github.com/fam-tung-lam/health_connector/pull/103/files#diff-5d4098e922e7e9fb1773c1e143fa732d75740c18dc9099a9ece5f8cd17d1ef46">+90/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></details></td></tr></tbody></table>

</details>

___

