### PR TITLE
fix(health_connector): allow `DistanceActivityRecord` and subclasses instantenous (startTime = endTime) records

### DIFF
--- a/packages/health_connector_core/lib/src/models/health_records/distance/cross_country_skiing_distance_record.dart
+++ b/packages/health_connector_core/lib/src/models/health_records/distance/cross_country_skiing_distance_record.dart
@@ -62,15 +62,27 @@ final class CrossCountrySkiingDistanceRecord extends DistanceActivityRecord {
     );
   }
 
+  // Explicit `super._(...)` is required to chain to the no-validation
+  // parent constructor; `super.<field>` forwarding always targets the
+  // unnamed (validating) super constructor.
+  // ignore: use_super_parameters
   CrossCountrySkiingDistanceRecord._({
-    required super.id,
-    required super.startTime,
-    required super.endTime,
-    required super.metadata,
-    required super.distance,
-    super.startZoneOffsetSeconds,
-    super.endZoneOffsetSeconds,
-  });
+    required HealthRecordId id,
+    required DateTime startTime,
+    required DateTime endTime,
+    required Metadata metadata,
+    required Length distance,
+    int? startZoneOffsetSeconds,
+    int? endZoneOffsetSeconds,
+  }) : super._(
+         id: id,
+         startTime: startTime,
+         endTime: endTime,
+         metadata: metadata,
+         distance: distance,
+         startZoneOffsetSeconds: startZoneOffsetSeconds,
+         endZoneOffsetSeconds: endZoneOffsetSeconds,
+       );
 
   /// Creates a copy with the given fields replaced with the new values.
   CrossCountrySkiingDistanceRecord copyWith({

--- a/packages/health_connector_core/lib/src/models/health_records/distance/cycling_distance_record.dart
+++ b/packages/health_connector_core/lib/src/models/health_records/distance/cycling_distance_record.dart
@@ -60,15 +60,27 @@ final class CyclingDistanceRecord extends DistanceActivityRecord {
     );
   }
 
+  // Explicit `super._(...)` is required to chain to the no-validation
+  // parent constructor; `super.<field>` forwarding always targets the
+  // unnamed (validating) super constructor.
+  // ignore: use_super_parameters
   CyclingDistanceRecord._({
-    required super.id,
-    required super.startTime,
-    required super.endTime,
-    required super.metadata,
-    required super.distance,
-    super.startZoneOffsetSeconds,
-    super.endZoneOffsetSeconds,
-  });
+    required HealthRecordId id,
+    required DateTime startTime,
+    required DateTime endTime,
+    required Metadata metadata,
+    required Length distance,
+    int? startZoneOffsetSeconds,
+    int? endZoneOffsetSeconds,
+  }) : super._(
+         id: id,
+         startTime: startTime,
+         endTime: endTime,
+         metadata: metadata,
+         distance: distance,
+         startZoneOffsetSeconds: startZoneOffsetSeconds,
+         endZoneOffsetSeconds: endZoneOffsetSeconds,
+       );
 
   /// Creates a copy with the given fields replaced with the new values.
   CyclingDistanceRecord copyWith({

--- a/packages/health_connector_core/lib/src/models/health_records/distance/distance_activity_record.dart
+++ b/packages/health_connector_core/lib/src/models/health_records/distance/distance_activity_record.dart
@@ -64,6 +64,24 @@ sealed class DistanceActivityRecord extends IntervalHealthRecord {
     );
   }
 
+  /// Internal constructor that skips all validation.
+  ///
+  /// Used by subclass `.internal` factories to map platform-sourced DTOs
+  /// (e.g. instantaneous HealthKit samples where `startTime == endTime`)
+  /// into domain models without triggering the public constructor's checks.
+  ///
+  /// **⚠️ Warning**: Not for public use.
+  @internalUse
+  DistanceActivityRecord._({
+    required super.startTime,
+    required super.endTime,
+    required super.metadata,
+    required this.distance,
+    super.id = HealthRecordId.none,
+    super.startZoneOffsetSeconds,
+    super.endZoneOffsetSeconds,
+  });
+
   /// The distance measurement value.
   final Length distance;
 }

--- a/packages/health_connector_core/lib/src/models/health_records/distance/downhill_snow_sports_distance_record.dart
+++ b/packages/health_connector_core/lib/src/models/health_records/distance/downhill_snow_sports_distance_record.dart
@@ -62,15 +62,27 @@ final class DownhillSnowSportsDistanceRecord extends DistanceActivityRecord {
     );
   }
 
+  // Explicit `super._(...)` is required to chain to the no-validation
+  // parent constructor; `super.<field>` forwarding always targets the
+  // unnamed (validating) super constructor.
+  // ignore: use_super_parameters
   DownhillSnowSportsDistanceRecord._({
-    required super.id,
-    required super.startTime,
-    required super.endTime,
-    required super.metadata,
-    required super.distance,
-    super.startZoneOffsetSeconds,
-    super.endZoneOffsetSeconds,
-  });
+    required HealthRecordId id,
+    required DateTime startTime,
+    required DateTime endTime,
+    required Metadata metadata,
+    required Length distance,
+    int? startZoneOffsetSeconds,
+    int? endZoneOffsetSeconds,
+  }) : super._(
+         id: id,
+         startTime: startTime,
+         endTime: endTime,
+         metadata: metadata,
+         distance: distance,
+         startZoneOffsetSeconds: startZoneOffsetSeconds,
+         endZoneOffsetSeconds: endZoneOffsetSeconds,
+       );
 
   /// Creates a copy with the given fields replaced with the new values.
   DownhillSnowSportsDistanceRecord copyWith({

--- a/packages/health_connector_core/lib/src/models/health_records/distance/paddle_sports_distance_record.dart
+++ b/packages/health_connector_core/lib/src/models/health_records/distance/paddle_sports_distance_record.dart
@@ -63,15 +63,27 @@ final class PaddleSportsDistanceRecord extends DistanceActivityRecord {
     );
   }
 
+  // Explicit `super._(...)` is required to chain to the no-validation
+  // parent constructor; `super.<field>` forwarding always targets the
+  // unnamed (validating) super constructor.
+  // ignore: use_super_parameters
   PaddleSportsDistanceRecord._({
-    required super.id,
-    required super.startTime,
-    required super.endTime,
-    required super.metadata,
-    required super.distance,
-    super.startZoneOffsetSeconds,
-    super.endZoneOffsetSeconds,
-  });
+    required HealthRecordId id,
+    required DateTime startTime,
+    required DateTime endTime,
+    required Metadata metadata,
+    required Length distance,
+    int? startZoneOffsetSeconds,
+    int? endZoneOffsetSeconds,
+  }) : super._(
+         id: id,
+         startTime: startTime,
+         endTime: endTime,
+         metadata: metadata,
+         distance: distance,
+         startZoneOffsetSeconds: startZoneOffsetSeconds,
+         endZoneOffsetSeconds: endZoneOffsetSeconds,
+       );
 
   /// Creates a copy with the given fields replaced with the new values.
   PaddleSportsDistanceRecord copyWith({

--- a/packages/health_connector_core/lib/src/models/health_records/distance/rowing_distance_record.dart
+++ b/packages/health_connector_core/lib/src/models/health_records/distance/rowing_distance_record.dart
@@ -62,15 +62,27 @@ final class RowingDistanceRecord extends DistanceActivityRecord {
     );
   }
 
+  // Explicit `super._(...)` is required to chain to the no-validation
+  // parent constructor; `super.<field>` forwarding always targets the
+  // unnamed (validating) super constructor.
+  // ignore: use_super_parameters
   RowingDistanceRecord._({
-    required super.id,
-    required super.startTime,
-    required super.endTime,
-    required super.metadata,
-    required super.distance,
-    super.startZoneOffsetSeconds,
-    super.endZoneOffsetSeconds,
-  });
+    required HealthRecordId id,
+    required DateTime startTime,
+    required DateTime endTime,
+    required Metadata metadata,
+    required Length distance,
+    int? startZoneOffsetSeconds,
+    int? endZoneOffsetSeconds,
+  }) : super._(
+         id: id,
+         startTime: startTime,
+         endTime: endTime,
+         metadata: metadata,
+         distance: distance,
+         startZoneOffsetSeconds: startZoneOffsetSeconds,
+         endZoneOffsetSeconds: endZoneOffsetSeconds,
+       );
 
   /// Creates a copy with the given fields replaced with the new values.
   RowingDistanceRecord copyWith({

--- a/packages/health_connector_core/lib/src/models/health_records/distance/six_minute_walk_test_distance_record.dart
+++ b/packages/health_connector_core/lib/src/models/health_records/distance/six_minute_walk_test_distance_record.dart
@@ -63,15 +63,27 @@ final class SixMinuteWalkTestDistanceRecord extends DistanceActivityRecord {
     );
   }
 
+  // Explicit `super._(...)` is required to chain to the no-validation
+  // parent constructor; `super.<field>` forwarding always targets the
+  // unnamed (validating) super constructor.
+  // ignore: use_super_parameters
   SixMinuteWalkTestDistanceRecord._({
-    required super.id,
-    required super.startTime,
-    required super.endTime,
-    required super.metadata,
-    required super.distance,
-    super.startZoneOffsetSeconds,
-    super.endZoneOffsetSeconds,
-  });
+    required HealthRecordId id,
+    required DateTime startTime,
+    required DateTime endTime,
+    required Metadata metadata,
+    required Length distance,
+    int? startZoneOffsetSeconds,
+    int? endZoneOffsetSeconds,
+  }) : super._(
+         id: id,
+         startTime: startTime,
+         endTime: endTime,
+         metadata: metadata,
+         distance: distance,
+         startZoneOffsetSeconds: startZoneOffsetSeconds,
+         endZoneOffsetSeconds: endZoneOffsetSeconds,
+       );
 
   /// Creates a copy with the given fields replaced with the new values.
   SixMinuteWalkTestDistanceRecord copyWith({

--- a/packages/health_connector_core/lib/src/models/health_records/distance/skating_sports_distance_record.dart
+++ b/packages/health_connector_core/lib/src/models/health_records/distance/skating_sports_distance_record.dart
@@ -62,15 +62,27 @@ final class SkatingSportsDistanceRecord extends DistanceActivityRecord {
     );
   }
 
+  // Explicit `super._(...)` is required to chain to the no-validation
+  // parent constructor; `super.<field>` forwarding always targets the
+  // unnamed (validating) super constructor.
+  // ignore: use_super_parameters
   SkatingSportsDistanceRecord._({
-    required super.id,
-    required super.startTime,
-    required super.endTime,
-    required super.metadata,
-    required super.distance,
-    super.startZoneOffsetSeconds,
-    super.endZoneOffsetSeconds,
-  });
+    required HealthRecordId id,
+    required DateTime startTime,
+    required DateTime endTime,
+    required Metadata metadata,
+    required Length distance,
+    int? startZoneOffsetSeconds,
+    int? endZoneOffsetSeconds,
+  }) : super._(
+         id: id,
+         startTime: startTime,
+         endTime: endTime,
+         metadata: metadata,
+         distance: distance,
+         startZoneOffsetSeconds: startZoneOffsetSeconds,
+         endZoneOffsetSeconds: endZoneOffsetSeconds,
+       );
 
   /// Creates a copy with the given fields replaced with the new values.
   SkatingSportsDistanceRecord copyWith({

--- a/packages/health_connector_core/lib/src/models/health_records/distance/swimming_distance_record.dart
+++ b/packages/health_connector_core/lib/src/models/health_records/distance/swimming_distance_record.dart
@@ -60,15 +60,27 @@ final class SwimmingDistanceRecord extends DistanceActivityRecord {
     );
   }
 
+  // Explicit `super._(...)` is required to chain to the no-validation
+  // parent constructor; `super.<field>` forwarding always targets the
+  // unnamed (validating) super constructor.
+  // ignore: use_super_parameters
   SwimmingDistanceRecord._({
-    required super.id,
-    required super.startTime,
-    required super.endTime,
-    required super.metadata,
-    required super.distance,
-    super.startZoneOffsetSeconds,
-    super.endZoneOffsetSeconds,
-  });
+    required HealthRecordId id,
+    required DateTime startTime,
+    required DateTime endTime,
+    required Metadata metadata,
+    required Length distance,
+    int? startZoneOffsetSeconds,
+    int? endZoneOffsetSeconds,
+  }) : super._(
+         id: id,
+         startTime: startTime,
+         endTime: endTime,
+         metadata: metadata,
+         distance: distance,
+         startZoneOffsetSeconds: startZoneOffsetSeconds,
+         endZoneOffsetSeconds: endZoneOffsetSeconds,
+       );
 
   /// Creates a copy with the given fields replaced with the new values.
   SwimmingDistanceRecord copyWith({

--- a/packages/health_connector_core/lib/src/models/health_records/distance/walking_running_distance_record.dart
+++ b/packages/health_connector_core/lib/src/models/health_records/distance/walking_running_distance_record.dart
@@ -60,15 +60,27 @@ final class WalkingRunningDistanceRecord extends DistanceActivityRecord {
     );
   }
 
+  // Explicit `super._(...)` is required to chain to the no-validation
+  // parent constructor; `super.<field>` forwarding always targets the
+  // unnamed (validating) super constructor.
+  // ignore: use_super_parameters
   WalkingRunningDistanceRecord._({
-    required super.id,
-    required super.startTime,
-    required super.endTime,
-    required super.metadata,
-    required super.distance,
-    super.startZoneOffsetSeconds,
-    super.endZoneOffsetSeconds,
-  });
+    required HealthRecordId id,
+    required DateTime startTime,
+    required DateTime endTime,
+    required Metadata metadata,
+    required Length distance,
+    int? startZoneOffsetSeconds,
+    int? endZoneOffsetSeconds,
+  }) : super._(
+         id: id,
+         startTime: startTime,
+         endTime: endTime,
+         metadata: metadata,
+         distance: distance,
+         startZoneOffsetSeconds: startZoneOffsetSeconds,
+         endZoneOffsetSeconds: endZoneOffsetSeconds,
+       );
 
   /// Creates a copy with the given fields replaced with the new values.
   WalkingRunningDistanceRecord copyWith({

--- a/packages/health_connector_core/lib/src/models/health_records/distance/walking_running_distance_record.dart
+++ b/packages/health_connector_core/lib/src/models/health_records/distance/walking_running_distance_record.dart
@@ -24,7 +24,7 @@ part of '../health_record.dart';
 @supportedOnAppleHealth
 @immutable
 final class WalkingRunningDistanceRecord extends DistanceActivityRecord {
-  /// Creates a swimming distance record.
+  /// Creates a walking/running distance record.
   WalkingRunningDistanceRecord({
     required super.startTime,
     required super.endTime,

--- a/packages/health_connector_core/lib/src/models/health_records/distance/wheelchair_distance_record.dart
+++ b/packages/health_connector_core/lib/src/models/health_records/distance/wheelchair_distance_record.dart
@@ -60,15 +60,27 @@ final class WheelchairDistanceRecord extends DistanceActivityRecord {
     );
   }
 
+  // Explicit `super._(...)` is required to chain to the no-validation
+  // parent constructor; `super.<field>` forwarding always targets the
+  // unnamed (validating) super constructor.
+  // ignore: use_super_parameters
   WheelchairDistanceRecord._({
-    required super.id,
-    required super.startTime,
-    required super.endTime,
-    required super.metadata,
-    required super.distance,
-    super.startZoneOffsetSeconds,
-    super.endZoneOffsetSeconds,
-  });
+    required HealthRecordId id,
+    required DateTime startTime,
+    required DateTime endTime,
+    required Metadata metadata,
+    required Length distance,
+    int? startZoneOffsetSeconds,
+    int? endZoneOffsetSeconds,
+  }) : super._(
+         id: id,
+         startTime: startTime,
+         endTime: endTime,
+         metadata: metadata,
+         distance: distance,
+         startZoneOffsetSeconds: startZoneOffsetSeconds,
+         endZoneOffsetSeconds: endZoneOffsetSeconds,
+       );
 
   /// Creates a copy with the given fields replaced with the new values.
   WheelchairDistanceRecord copyWith({

--- a/packages/health_connector_core/test/src/models/health_records/distance/cross_country_skiing_distance_record_test.dart
+++ b/packages/health_connector_core/test/src/models/health_records/distance/cross_country_skiing_distance_record_test.dart
@@ -1,4 +1,4 @@
-import 'package:health_connector_core/health_connector_core.dart';
+import 'package:health_connector_core/health_connector_core_internal.dart';
 import 'package:test/test.dart';
 
 void main() {
@@ -21,6 +21,32 @@ void main() {
       expect(record.endTime, endTime.toUtc());
       expect(record.distance, equals(validValue));
       expect(record.metadata, metadata);
+    });
+
+    test('throws ArgumentError when endTime equals startTime', () {
+      expect(
+        () => CrossCountrySkiingDistanceRecord(
+          startTime: startTime,
+          endTime: startTime,
+          distance: validValue,
+          metadata: metadata,
+        ),
+        throwsArgumentError,
+      );
+    });
+
+    test('.internal allows instantaneous samples (endTime == startTime)', () {
+      final record = CrossCountrySkiingDistanceRecord.internal(
+        id: HealthRecordId.none,
+        startTime: startTime,
+        endTime: startTime,
+        distance: validValue,
+        metadata: metadata,
+      );
+
+      expect(record.startTime, startTime.toUtc());
+      expect(record.endTime, startTime.toUtc());
+      expect(record.distance, equals(validValue));
     });
 
     test('copyWith updates fields correctly', () {

--- a/packages/health_connector_core/test/src/models/health_records/distance/cycling_distance_record_test.dart
+++ b/packages/health_connector_core/test/src/models/health_records/distance/cycling_distance_record_test.dart
@@ -1,4 +1,4 @@
-import 'package:health_connector_core/health_connector_core.dart';
+import 'package:health_connector_core/health_connector_core_internal.dart';
 import 'package:test/test.dart';
 
 void main() {
@@ -21,6 +21,32 @@ void main() {
       expect(record.endTime, endTime.toUtc());
       expect(record.distance, equals(validValue));
       expect(record.metadata, metadata);
+    });
+
+    test('throws ArgumentError when endTime equals startTime', () {
+      expect(
+        () => CyclingDistanceRecord(
+          startTime: startTime,
+          endTime: startTime,
+          distance: validValue,
+          metadata: metadata,
+        ),
+        throwsArgumentError,
+      );
+    });
+
+    test('.internal allows instantaneous samples (endTime == startTime)', () {
+      final record = CyclingDistanceRecord.internal(
+        id: HealthRecordId.none,
+        startTime: startTime,
+        endTime: startTime,
+        distance: validValue,
+        metadata: metadata,
+      );
+
+      expect(record.startTime, startTime.toUtc());
+      expect(record.endTime, startTime.toUtc());
+      expect(record.distance, equals(validValue));
     });
 
     test('copyWith updates fields correctly', () {

--- a/packages/health_connector_core/test/src/models/health_records/distance/downhill_snow_sports_distance_record_test.dart
+++ b/packages/health_connector_core/test/src/models/health_records/distance/downhill_snow_sports_distance_record_test.dart
@@ -1,4 +1,4 @@
-import 'package:health_connector_core/health_connector_core.dart';
+import 'package:health_connector_core/health_connector_core_internal.dart';
 import 'package:test/test.dart';
 
 void main() {
@@ -21,6 +21,32 @@ void main() {
       expect(record.endTime, endTime.toUtc());
       expect(record.distance, equals(validValue));
       expect(record.metadata, metadata);
+    });
+
+    test('throws ArgumentError when endTime equals startTime', () {
+      expect(
+        () => DownhillSnowSportsDistanceRecord(
+          startTime: startTime,
+          endTime: startTime,
+          distance: validValue,
+          metadata: metadata,
+        ),
+        throwsArgumentError,
+      );
+    });
+
+    test('.internal allows instantaneous samples (endTime == startTime)', () {
+      final record = DownhillSnowSportsDistanceRecord.internal(
+        id: HealthRecordId.none,
+        startTime: startTime,
+        endTime: startTime,
+        distance: validValue,
+        metadata: metadata,
+      );
+
+      expect(record.startTime, startTime.toUtc());
+      expect(record.endTime, startTime.toUtc());
+      expect(record.distance, equals(validValue));
     });
 
     test('copyWith updates fields correctly', () {

--- a/packages/health_connector_core/test/src/models/health_records/distance/paddle_sports_distance_record_test.dart
+++ b/packages/health_connector_core/test/src/models/health_records/distance/paddle_sports_distance_record_test.dart
@@ -1,4 +1,4 @@
-import 'package:health_connector_core/health_connector_core.dart';
+import 'package:health_connector_core/health_connector_core_internal.dart';
 import 'package:test/test.dart';
 
 void main() {
@@ -21,6 +21,32 @@ void main() {
       expect(record.endTime, endTime.toUtc());
       expect(record.distance, equals(validValue));
       expect(record.metadata, metadata);
+    });
+
+    test('throws ArgumentError when endTime equals startTime', () {
+      expect(
+        () => PaddleSportsDistanceRecord(
+          startTime: startTime,
+          endTime: startTime,
+          distance: validValue,
+          metadata: metadata,
+        ),
+        throwsArgumentError,
+      );
+    });
+
+    test('.internal allows instantaneous samples (endTime == startTime)', () {
+      final record = PaddleSportsDistanceRecord.internal(
+        id: HealthRecordId.none,
+        startTime: startTime,
+        endTime: startTime,
+        distance: validValue,
+        metadata: metadata,
+      );
+
+      expect(record.startTime, startTime.toUtc());
+      expect(record.endTime, startTime.toUtc());
+      expect(record.distance, equals(validValue));
     });
 
     test('copyWith updates fields correctly', () {

--- a/packages/health_connector_core/test/src/models/health_records/distance/rowing_distance_record_test.dart
+++ b/packages/health_connector_core/test/src/models/health_records/distance/rowing_distance_record_test.dart
@@ -1,4 +1,4 @@
-import 'package:health_connector_core/health_connector_core.dart';
+import 'package:health_connector_core/health_connector_core_internal.dart';
 import 'package:test/test.dart';
 
 void main() {
@@ -21,6 +21,32 @@ void main() {
       expect(record.endTime, endTime.toUtc());
       expect(record.distance, equals(validValue));
       expect(record.metadata, metadata);
+    });
+
+    test('throws ArgumentError when endTime equals startTime', () {
+      expect(
+        () => RowingDistanceRecord(
+          startTime: startTime,
+          endTime: startTime,
+          distance: validValue,
+          metadata: metadata,
+        ),
+        throwsArgumentError,
+      );
+    });
+
+    test('.internal allows instantaneous samples (endTime == startTime)', () {
+      final record = RowingDistanceRecord.internal(
+        id: HealthRecordId.none,
+        startTime: startTime,
+        endTime: startTime,
+        distance: validValue,
+        metadata: metadata,
+      );
+
+      expect(record.startTime, startTime.toUtc());
+      expect(record.endTime, startTime.toUtc());
+      expect(record.distance, equals(validValue));
     });
 
     test('copyWith updates fields correctly', () {

--- a/packages/health_connector_core/test/src/models/health_records/distance/six_minute_walk_test_distance_record_test.dart
+++ b/packages/health_connector_core/test/src/models/health_records/distance/six_minute_walk_test_distance_record_test.dart
@@ -1,4 +1,4 @@
-import 'package:health_connector_core/health_connector_core.dart';
+import 'package:health_connector_core/health_connector_core_internal.dart';
 import 'package:test/test.dart';
 
 void main() {
@@ -21,6 +21,32 @@ void main() {
       expect(record.endTime, endTime.toUtc());
       expect(record.distance, equals(validValue));
       expect(record.metadata, metadata);
+    });
+
+    test('throws ArgumentError when endTime equals startTime', () {
+      expect(
+        () => SixMinuteWalkTestDistanceRecord(
+          startTime: startTime,
+          endTime: startTime,
+          distance: validValue,
+          metadata: metadata,
+        ),
+        throwsArgumentError,
+      );
+    });
+
+    test('.internal allows instantaneous samples (endTime == startTime)', () {
+      final record = SixMinuteWalkTestDistanceRecord.internal(
+        id: HealthRecordId.none,
+        startTime: startTime,
+        endTime: startTime,
+        distance: validValue,
+        metadata: metadata,
+      );
+
+      expect(record.startTime, startTime.toUtc());
+      expect(record.endTime, startTime.toUtc());
+      expect(record.distance, equals(validValue));
     });
 
     test('copyWith updates fields correctly', () {

--- a/packages/health_connector_core/test/src/models/health_records/distance/skating_sports_distance_record_test.dart
+++ b/packages/health_connector_core/test/src/models/health_records/distance/skating_sports_distance_record_test.dart
@@ -1,4 +1,4 @@
-import 'package:health_connector_core/health_connector_core.dart';
+import 'package:health_connector_core/health_connector_core_internal.dart';
 import 'package:test/test.dart';
 
 void main() {
@@ -21,6 +21,32 @@ void main() {
       expect(record.endTime, endTime.toUtc());
       expect(record.distance, equals(validValue));
       expect(record.metadata, metadata);
+    });
+
+    test('throws ArgumentError when endTime equals startTime', () {
+      expect(
+        () => SkatingSportsDistanceRecord(
+          startTime: startTime,
+          endTime: startTime,
+          distance: validValue,
+          metadata: metadata,
+        ),
+        throwsArgumentError,
+      );
+    });
+
+    test('.internal allows instantaneous samples (endTime == startTime)', () {
+      final record = SkatingSportsDistanceRecord.internal(
+        id: HealthRecordId.none,
+        startTime: startTime,
+        endTime: startTime,
+        distance: validValue,
+        metadata: metadata,
+      );
+
+      expect(record.startTime, startTime.toUtc());
+      expect(record.endTime, startTime.toUtc());
+      expect(record.distance, equals(validValue));
     });
 
     test('copyWith updates fields correctly', () {

--- a/packages/health_connector_core/test/src/models/health_records/distance/swimming_distance_record_test.dart
+++ b/packages/health_connector_core/test/src/models/health_records/distance/swimming_distance_record_test.dart
@@ -1,4 +1,4 @@
-import 'package:health_connector_core/health_connector_core.dart';
+import 'package:health_connector_core/health_connector_core_internal.dart';
 import 'package:test/test.dart';
 
 void main() {
@@ -21,6 +21,32 @@ void main() {
       expect(record.endTime, endTime.toUtc());
       expect(record.distance, equals(validValue));
       expect(record.metadata, metadata);
+    });
+
+    test('throws ArgumentError when endTime equals startTime', () {
+      expect(
+        () => SwimmingDistanceRecord(
+          startTime: startTime,
+          endTime: startTime,
+          distance: validValue,
+          metadata: metadata,
+        ),
+        throwsArgumentError,
+      );
+    });
+
+    test('.internal allows instantaneous samples (endTime == startTime)', () {
+      final record = SwimmingDistanceRecord.internal(
+        id: HealthRecordId.none,
+        startTime: startTime,
+        endTime: startTime,
+        distance: validValue,
+        metadata: metadata,
+      );
+
+      expect(record.startTime, startTime.toUtc());
+      expect(record.endTime, startTime.toUtc());
+      expect(record.distance, equals(validValue));
     });
 
     test('copyWith updates fields correctly', () {

--- a/packages/health_connector_core/test/src/models/health_records/distance/walking_running_distance_record_test.dart
+++ b/packages/health_connector_core/test/src/models/health_records/distance/walking_running_distance_record_test.dart
@@ -1,4 +1,4 @@
-import 'package:health_connector_core/health_connector_core.dart';
+import 'package:health_connector_core/health_connector_core_internal.dart';
 import 'package:test/test.dart';
 
 void main() {
@@ -21,6 +21,56 @@ void main() {
       expect(record.endTime, endTime.toUtc());
       expect(record.distance, equals(validValue));
       expect(record.metadata, metadata);
+    });
+
+    test('throws ArgumentError when endTime is not after startTime', () {
+      expect(
+        () => WalkingRunningDistanceRecord(
+          startTime: endTime,
+          endTime: startTime,
+          distance: validValue,
+          metadata: metadata,
+        ),
+        throwsArgumentError,
+      );
+    });
+
+    test('throws ArgumentError when endTime equals startTime', () {
+      expect(
+        () => WalkingRunningDistanceRecord(
+          startTime: startTime,
+          endTime: startTime,
+          distance: validValue,
+          metadata: metadata,
+        ),
+        throwsArgumentError,
+      );
+    });
+
+    test('.internal allows instantaneous samples (endTime == startTime)', () {
+      final record = WalkingRunningDistanceRecord.internal(
+        id: HealthRecordId.none,
+        startTime: startTime,
+        endTime: startTime,
+        distance: validValue,
+        metadata: metadata,
+      );
+
+      expect(record.startTime, startTime.toUtc());
+      expect(record.endTime, startTime.toUtc());
+      expect(record.distance, equals(validValue));
+    });
+
+    test('.internal skips distance bounds validation', () {
+      final record = WalkingRunningDistanceRecord.internal(
+        id: HealthRecordId.none,
+        startTime: startTime,
+        endTime: endTime,
+        distance: const Length.kilometers(5000),
+        metadata: metadata,
+      );
+
+      expect(record.distance, equals(const Length.kilometers(5000)));
     });
 
     test('copyWith updates fields correctly', () {

--- a/packages/health_connector_core/test/src/models/health_records/distance/wheelchair_distance_record_test.dart
+++ b/packages/health_connector_core/test/src/models/health_records/distance/wheelchair_distance_record_test.dart
@@ -1,4 +1,4 @@
-import 'package:health_connector_core/health_connector_core.dart';
+import 'package:health_connector_core/health_connector_core_internal.dart';
 import 'package:test/test.dart';
 
 void main() {
@@ -21,6 +21,32 @@ void main() {
       expect(record.endTime, endTime.toUtc());
       expect(record.distance, equals(validValue));
       expect(record.metadata, metadata);
+    });
+
+    test('throws ArgumentError when endTime equals startTime', () {
+      expect(
+        () => WheelchairDistanceRecord(
+          startTime: startTime,
+          endTime: startTime,
+          distance: validValue,
+          metadata: metadata,
+        ),
+        throwsArgumentError,
+      );
+    });
+
+    test('.internal allows instantaneous samples (endTime == startTime)', () {
+      final record = WheelchairDistanceRecord.internal(
+        id: HealthRecordId.none,
+        startTime: startTime,
+        endTime: startTime,
+        distance: validValue,
+        metadata: metadata,
+      );
+
+      expect(record.startTime, startTime.toUtc());
+      expect(record.endTime, startTime.toUtc());
+      expect(record.distance, equals(validValue));
     });
 
     test('copyWith updates fields correctly', () {


### PR DESCRIPTION
* Skip validation for internal factory `DistanceActivityRecord.internal`
* Rewire subclasses to the super internal factory
* Add tests

Fixes #149