### PR TITLE
fix(health_connector_hk_ios): remove invalid NSPrivacyAccessedAPICategoryHealthKit and fix podspec resource_bundles path

### DIFF
--- a/packages/health_connector_hk_ios/ios/health_connector_hk_ios.podspec
+++ b/packages/health_connector_hk_ios/ios/health_connector_hk_ios.podspec
@@ -22,5 +22,5 @@ A new Flutter plugin project.
   s.swift_version = '5.9'
 
   # Privacy manifest for HealthKit usage
-  s.resource_bundles = {'health_connector_privacy' => ['health_connector/Sources/health_connector/PrivacyInfo.xcprivacy']}
+  s.resource_bundles = {'health_connector_hk_ios_privacy' => ['health_connector_hk_ios/Sources/health_connector_hk_ios/PrivacyInfo.xcprivacy']}
 end

--- a/packages/health_connector_hk_ios/ios/health_connector_hk_ios/Sources/health_connector_hk_ios/PrivacyInfo.xcprivacy
+++ b/packages/health_connector_hk_ios/ios/health_connector_hk_ios/Sources/health_connector_hk_ios/PrivacyInfo.xcprivacy
@@ -2,19 +2,10 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>NSPrivacyTracking</key>
+	<false/>
 	<key>NSPrivacyTrackingDomains</key>
 	<array/>
-	<key>NSPrivacyAccessedAPITypes</key>
-	<array>
-		<dict>
-			<key>NSPrivacyAccessedAPIType</key>
-			<string>NSPrivacyAccessedAPICategoryHealthKit</string>
-			<key>NSPrivacyAccessedAPITypeReasons</key>
-			<array>
-				<string>Check HealthKit availability on device</string>
-			</array>
-		</dict>
-	</array>
 	<key>NSPrivacyCollectedDataTypes</key>
 	<array>
 		<dict>
@@ -30,7 +21,5 @@
 			</array>
 		</dict>
 	</array>
-	<key>NSPrivacyTracking</key>
-	<false/>
 </dict>
 </plist>


### PR DESCRIPTION
Fixes #151

- Removes the invalid `NSPrivacyAccessedAPICategoryHealthKit` entry from `NSPrivacyAccessedAPITypes` in `PrivacyInfo.xcprivacy`. This key is not part of Apple's Required Reason API spec and caused ITMS-91054 rejection when uploading to App Store Connect with SPM.
- Fixes the `resource_bundles` path in `health_connector_hk_ios.podspec`, which pointed to `health_connector/Sources/health_connector/` (a different package) instead of the correct `health_connector_hk_ios/Sources/health_connector_hk_ios/` path. This silently omitted the privacy manifest from CocoaPods builds, masking the validation failure.