### PR TITLE
fix(health_connector_core): expose deleteByIds and deleteInTimeRange on NutritionDataType

### DIFF
--- a/packages/health_connector/CHANGELOG.md
+++ b/packages/health_connector/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 3.9.3
+
+- **FIX**: Expose `deleteByIds` and `deleteInTimeRange` factory methods on `HealthDataType.nutrition` so callers can delete nutrition records after writing them. Both platform handlers (`HealthConnectorHCClient` on Android, `HealthConnectorHKClient` on iOS) already implement the underlying delete logic, so no native code changes were required.
+
 ## 3.9.2
 
 - **FIX**: Allow `DistanceActivityRecord` to have `startTime == endTime` when getting data from health platforms, accommodating instantaneous records from iOS HealthKit where a zero-duration interval is considered valid. ([250f30ec](https://github.com/fam-tung-lam/health_connector/commit/250f30ec1be148162b8fbc2a3a078ceaddfa5d88))

--- a/packages/health_connector/pubspec.yaml
+++ b/packages/health_connector/pubspec.yaml
@@ -12,7 +12,7 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  health_connector_core: ^3.9.1
+  health_connector_core: ^3.9.2
   health_connector_hc_android: ^3.6.1
   health_connector_hk_ios: ^3.9.1
   health_connector_logger: ^4.0.0

--- a/packages/health_connector/pubspec.yaml
+++ b/packages/health_connector/pubspec.yaml
@@ -1,7 +1,7 @@
 name: health_connector
 resolution: workspace
 description: The most comprehensive Flutter health SDK for seamless iOS HealthKit and Android Health Connect integration.
-version: 3.9.2
+version: 3.9.3
 homepage: https://github.com/fam-tung-lam/health_connector
 repository: https://github.com/fam-tung-lam/health_connector/tree/main/packages/health_connector
 

--- a/packages/health_connector_core/CHANGELOG.md
+++ b/packages/health_connector_core/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 3.9.2
+
+- **FIX**: Expose `deleteByIds` and `deleteInTimeRange` factory methods on `HealthDataType.nutrition` so callers can delete nutrition records after writing them. Both platform handlers (`HealthConnectorHCClient` on Android, `HealthConnectorHKClient` on iOS) already implement the underlying delete logic, so no native code changes were required.
+
 ## 3.9.1
 
 - **FIX**: Allow `DistanceActivityRecord` to have `startTime == endTime` when getting data from health platforms, accommodating instantaneous records from iOS HealthKit where a zero-duration interval is considered valid. ([250f30ec](https://github.com/fam-tung-lam/health_connector/commit/250f30ec1be148162b8fbc2a3a078ceaddfa5d88))

--- a/packages/health_connector_core/lib/src/models/health_data_types/nutrition/nutrition_data_type.dart
+++ b/packages/health_connector_core/lib/src/models/health_data_types/nutrition/nutrition_data_type.dart
@@ -14,8 +14,9 @@ part of '../health_data_type.dart';
 ///
 /// ## Capabilities
 ///
-/// - Readable: Query nutrition records
-/// - Writeable: Write nutrition records
+/// - Read: Query historical nutrition records
+/// - Write: Create new nutrition records
+/// - Deletable: Delete records by IDs or time range
 /// - Not aggregatable (use individual data types for aggregation)
 ///
 /// {@category Health Records}
@@ -26,7 +27,9 @@ final class NutritionDataType
     implements
         ReadableByIdHealthDataType<NutritionRecord>,
         ReadableInTimeRangeHealthDataType<NutritionRecord>,
-        WriteableHealthDataType<NutritionRecord> {
+        WriteableHealthDataType<NutritionRecord>,
+        DeletableByIdsHealthDataType<NutritionRecord>,
+        DeletableInTimeRangeHealthDataType<NutritionRecord> {
   /// Creates a nutrition data type.
   ///
   /// This is a constant constructor used internally. To reference this data
@@ -75,6 +78,23 @@ final class NutritionDataType
       endTime: endTime,
       pageSize: pageSize,
       pageToken: pageToken,
+    );
+  }
+
+  @override
+  DeleteRecordsByIdsRequest deleteByIds(List<HealthRecordId> recordIds) {
+    return DeleteRecordsByIdsRequest(dataType: this, recordIds: recordIds);
+  }
+
+  @override
+  DeleteRecordsInTimeRangeRequest deleteInTimeRange({
+    required DateTime startTime,
+    required DateTime endTime,
+  }) {
+    return DeleteRecordsInTimeRangeRequest(
+      dataType: this,
+      startTime: startTime,
+      endTime: endTime,
     );
   }
 }

--- a/packages/health_connector_core/pubspec.yaml
+++ b/packages/health_connector_core/pubspec.yaml
@@ -1,7 +1,7 @@
 name: health_connector_core
 resolution: workspace
 description: Core models, utilities, and platform interface for Health Connector
-version: 3.9.1
+version: 3.9.2
 repository: https://github.com/fam-tung-lam/health_connector/tree/main/packages/health_connector_core
 
 environment:

--- a/packages/health_connector_core/test/src/models/health_data_types/nutrition/dietary_nutrition_data_type_test.dart
+++ b/packages/health_connector_core/test/src/models/health_data_types/nutrition/dietary_nutrition_data_type_test.dart
@@ -13,7 +13,11 @@ void main() {
         () {
           expect(dataType, isA<NutritionDataType>());
           expect(dataType, isA<ReadableHealthDataType>());
+          expect(dataType, isA<ReadableByIdHealthDataType>());
+          expect(dataType, isA<ReadableInTimeRangeHealthDataType>());
           expect(dataType, isA<WriteableHealthDataType>());
+          expect(dataType, isA<DeletableByIdsHealthDataType>());
+          expect(dataType, isA<DeletableInTimeRangeHealthDataType>());
         },
       );
 

--- a/packages/health_connector_core/test/src/models/health_data_types/nutrition/nutrition_data_type_test.dart
+++ b/packages/health_connector_core/test/src/models/health_data_types/nutrition/nutrition_data_type_test.dart
@@ -20,7 +20,11 @@ void main() {
         () {
           expect(dataType, isA<NutritionDataType>());
           expect(dataType, isA<ReadableHealthDataType>());
+          expect(dataType, isA<ReadableByIdHealthDataType>());
+          expect(dataType, isA<ReadableInTimeRangeHealthDataType>());
           expect(dataType, isA<WriteableHealthDataType>());
+          expect(dataType, isA<DeletableByIdsHealthDataType>());
+          expect(dataType, isA<DeletableInTimeRangeHealthDataType>());
           expect(dataType, isNot(isA<SumAggregatableHealthDataType>()));
         },
       );
@@ -78,6 +82,31 @@ void main() {
             dataType.category,
             equals(HealthDataTypeCategory.nutrition),
           );
+        },
+      );
+
+      test(
+        'deleteByIds returns correct request',
+        () {
+          final recordIds = [HealthRecordId('id1')];
+          final request = dataType.deleteByIds(recordIds);
+          expect(request.dataType, equals(dataType));
+          expect(request.recordIds, equals(recordIds));
+        },
+      );
+
+      test(
+        'deleteInTimeRange returns correct request',
+        () {
+          final startTime = DateTime(2026);
+          final endTime = DateTime(2026, 1, 2);
+          final request = dataType.deleteInTimeRange(
+            startTime: startTime,
+            endTime: endTime,
+          );
+          expect(request.dataType, equals(dataType));
+          expect(request.startTime, equals(startTime));
+          expect(request.endTime, equals(endTime));
         },
       );
     },


### PR DESCRIPTION
## What changed and why

`HealthDataType.nutrition` did not implement `DeletableByIdsHealthDataType` or `DeletableInTimeRangeHealthDataType`, even though both platform handlers (`HealthConnectorHCClient` on Android and `HealthConnectorHKClient` on iOS) already implement the underlying delete logic. This made it impossible to delete a nutrition record from Dart after writing it via `connector.writeRecord(...)`, breaking the documented "write → delete" loop that works for `HealthDataType.hydration`.

This change adds the two missing capability interfaces to `NutritionDataType` along with the `deleteByIds` and `deleteInTimeRange` factory methods, matching the pattern already used by `HydrationDataType`. No native code changes are required — both platform handlers already expose the matching delete logic.

### Before

```dart
// Compiler error: 'deleteByIds' isn't defined for the type 'NutritionDataType'.
await connector.deleteRecords(
  HealthDataType.nutrition.deleteByIds([id]),
);
```

### After

```dart
// Compiles and runs end-to-end on both Android and iOS.
await connector.deleteRecords(
  HealthDataType.nutrition.deleteByIds([id]),
);
```

## How to test

1. `dart pub get` at the repo root.
2. From `packages/health_connector_core`: `dart test test/src/models/health_data_types/nutrition/nutrition_data_type_test.dart` — both new test cases (`deleteByIds returns correct request`, `deleteInTimeRange returns correct request`) pass.
3. `dart test` in `packages/health_connector_core` — full suite (2509 tests) passes.
4. Reproduce the snippet from the issue on a real device/simulator; it now compiles and the round-trip `writeRecord → deleteRecords` succeeds.

## Platform-specific behaviour / limitations

- **iOS**: `HealthConnectorHKClient` deletes the underlying `HKCorrelation` via `DeletableCorrelationHealthRecordHandler`, which is already used by the SDK's read-modify-delete flow.
- **Android**: `HealthConnectorHCClient` deletes via `DeletableHealthRecordHandler`, which uses `HealthConnectClient.deleteRecords(...)` directly. The existing Kotlin handler in `NutritionHandler.kt` already implements this interface, so no Kotlin changes are required.
- As with all `DeletableHealthDataType` records, apps can only delete records they created.

Fixes #153