### PR TITLE
chore(release): publish health_connector 3.9.4

### DIFF
--- a/examples/health_connector_toolbox/pubspec.yaml
+++ b/examples/health_connector_toolbox/pubspec.yaml
@@ -10,7 +10,7 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  health_connector: ^3.9.3
+  health_connector: ^3.9.4
   intl: ^0.19.0
   provider: ^6.1.5+1
   shared_preferences: ^2.5.4

--- a/packages/health_connector/CHANGELOG.md
+++ b/packages/health_connector/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 3.9.4
+
+- **REFACTOR**: Remove unused native Android and iOS modules from the Dart facade. Native platform registration remains owned by `health_connector_hc_android` and `health_connector_hk_ios`. ([c4eb3848](https://github.com/fam-tung-lam/health_connector/commit/c4eb3848d64ea9a6e62111179e6811cd27050dfe))
+
 ## 3.9.3
 
 - **FIX**: Expose `deleteByIds` and `deleteInTimeRange` APIs for `NutritionDataType`. ([54afe082](https://github.com/fam-tung-lam/health_connector/commit/54afe08239f6c100bc1c833a2e00cc8ee3d2e76a))

--- a/packages/health_connector/pubspec.yaml
+++ b/packages/health_connector/pubspec.yaml
@@ -1,7 +1,7 @@
 name: health_connector
 resolution: workspace
 description: The most comprehensive Flutter health SDK for seamless iOS HealthKit and Android Health Connect integration.
-version: 3.9.3
+version: 3.9.4
 homepage: https://github.com/fam-tung-lam/health_connector
 repository: https://github.com/fam-tung-lam/health_connector/tree/main/packages/health_connector
 

--- a/packages/health_connector/pubspec.yaml
+++ b/packages/health_connector/pubspec.yaml
@@ -4,6 +4,7 @@ description: The most comprehensive Flutter health SDK for seamless iOS HealthKi
 version: 3.9.4
 homepage: https://github.com/fam-tung-lam/health_connector
 repository: https://github.com/fam-tung-lam/health_connector/tree/main/packages/health_connector
+issue_tracker: https://github.com/fam-tung-lam/health_connector/issues?q=is%3Aissue%20is%3Aopen
 
 environment:
   sdk: ^3.9.2
@@ -27,3 +28,8 @@ dev_dependencies:
 platforms:
   android:
   ios:
+
+topics:
+  - health
+  - android-health-connect
+  - ios-healthkit

--- a/packages/health_connector_core/pubspec.yaml
+++ b/packages/health_connector_core/pubspec.yaml
@@ -3,6 +3,7 @@ resolution: workspace
 description: Core models, utilities, and platform interface for Health Connector
 version: 3.9.2
 repository: https://github.com/fam-tung-lam/health_connector/tree/main/packages/health_connector_core
+issue_tracker: https://github.com/fam-tung-lam/health_connector/issues?q=is%3Aissue%20is%3Aopen
 
 environment:
   sdk: ^3.9.2
@@ -25,3 +26,6 @@ platforms:
   macos:
   web:
   windows:
+
+topics:
+  - health

--- a/packages/health_connector_hc_android/pubspec.yaml
+++ b/packages/health_connector_hc_android/pubspec.yaml
@@ -3,6 +3,7 @@ resolution: workspace
 description: Android implementation of health_connector using Health Connect
 version: 3.6.2
 repository: https://github.com/fam-tung-lam/health_connector/tree/main/packages/health_connector_hc_android
+issue_tracker: https://github.com/fam-tung-lam/health_connector/issues?q=is%3Aissue%20is%3Aopen
 
 environment:
   sdk: ^3.9.2
@@ -29,3 +30,7 @@ flutter:
       android:
         package: com.phamtunglam.health_connector_hc_android
         pluginClass: HealthConnectorHCAndroidPlugin
+
+topics:
+  - health
+  - android-health-connect

--- a/packages/health_connector_hk_ios/pubspec.yaml
+++ b/packages/health_connector_hk_ios/pubspec.yaml
@@ -3,6 +3,7 @@ resolution: workspace
 description: iOS implementation of health_connector using HealthKit
 version: 3.9.2
 repository: https://github.com/fam-tung-lam/health_connector/tree/main/packages/health_connector_hk_ios
+issue_tracker: https://github.com/fam-tung-lam/health_connector/issues?q=is%3Aissue%20is%3Aopen
 
 environment:
   sdk: ^3.9.2
@@ -28,3 +29,7 @@ flutter:
     platforms:
       ios:
         pluginClass: HealthConnectorHkIosPlugin
+
+topics:
+  - health
+  - ios-healthkit

--- a/packages/health_connector_lint/pubspec.yaml
+++ b/packages/health_connector_lint/pubspec.yaml
@@ -3,9 +3,7 @@ resolution: workspace
 description: Lint rules for health_connector packages
 version: 1.2.0
 repository: https://github.com/fam-tung-lam/health_connector/tree/main/packages/health_connector_lint
-
-topics:
-  - lints
+issue_tracker: https://github.com/fam-tung-lam/health_connector/issues?q=is%3Aissue%20is%3Aopen
 
 environment:
   sdk: ^3.9.2
@@ -20,3 +18,6 @@ platforms:
   macos:
   web:
   windows:
+
+topics:
+  - lints

--- a/packages/health_connector_logger/pubspec.yaml
+++ b/packages/health_connector_logger/pubspec.yaml
@@ -3,6 +3,7 @@ resolution: workspace
 description: Structured logging utility for Health Connector packages
 version: 4.0.0
 repository: https://github.com/fam-tung-lam/health_connector/tree/main/packages/health_connector_logger
+issue_tracker: https://github.com/fam-tung-lam/health_connector/issues?q=is%3Aissue%20is%3Aopen
 
 environment:
   sdk: ^3.9.2
@@ -23,3 +24,6 @@ platforms:
   macos:
   web:
   windows:
+
+topics:
+  - logging


### PR DESCRIPTION
## Summary

Prepare the patch release of `health_connector 3.9.4` following the removal of the facade's unused native Android and iOS modules in #160.

- Bump `packages/health_connector/pubspec.yaml` from `3.9.3` to `3.9.4`.
- Add the `3.9.4` changelog entry with a link to the landed cleanup commit.
- Update the private toolbox dependency from `health_connector: ^3.9.3` to `^3.9.4`.
- Add the shared open-issues URL as `issue_tracker` to all six publishable package manifests.
- Add package-specific pub.dev topics:
  - `health_connector`: `health`, `android-health-connect`, `ios-healthkit`
  - `health_connector_core`: `health`
  - `health_connector_hc_android`: `health`, `android-health-connect`
  - `health_connector_hk_ios`: `health`, `ios-healthkit`
  - `health_connector_lint`: `lints`
  - `health_connector_logger`: `logging`
- Leave `health_connector_core`, `health_connector_hc_android`, and `health_connector_hk_ios` versions unchanged.

## Release classification

This is a patch release because the facade's public Dart interface, behavior, supported platforms, SDK constraints, and implementation-package dependencies remain compatible. The release removes native modules that Flutter did not register or consume and adds package metadata only.

Related to #159 and #160.

## Validation

Run with the repository-pinned FVM Flutter 3.35.7:

- [x] `fvm spawn 3.35.7 pub publish --dry-run` — `health_connector`, core, iOS, lint, and logger passed with 0 warnings.
- [x] `health_connector_hc_android` metadata validated; its dry-run reports one pre-existing warning because three committed example Gradle wrapper files are also matched by the example's `.gitignore`.
- [x] `fvm dart run melos run analyze:dart:strict --no-select` — all 10 workspace packages passed.
- [x] `fvm spawn 3.35.7 analyze --fatal-infos --fatal-warnings .` — workspace passed with no issues after the metadata commit.
- [x] `fvm spawn 3.35.7 test packages/health_connector` — all 38 tests passed.
- [x] Release branch is exactly two commits ahead of current `main`, with the package metadata isolated in its own commit.
- [x] `health_connector 3.9.4` is not yet published on pub.dev.
- [x] `health_connector-v3.9.4` does not yet exist locally or remotely.

## Post-merge release procedure

The release tag is intentionally not created or pushed from this PR branch. In this repository, pushing `health_connector-v3.9.4` immediately triggers the CD workflow that runs quality checks, tests, Android/iOS builds, and publishes to pub.dev.

After this PR lands:

1. Resolve the exact landed release commit on `main`.
2. Create the annotated tag `health_connector-v3.9.4` at that commit with message `health_connector v3.9.4`.
3. Push only that tag.
4. Monitor the `CD - health_connector` workflow through successful pub.dev publication.
5. Verify `health_connector 3.9.4` is live on pub.dev and the tag points to the landed release commit.