### PR TITLE
chore(quality): enforce native analysis before publish

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -41,8 +41,7 @@ melos:
 
     publish:
       hooks:
-        # pre: melos run analyze:strict // Use it when fix all native lint errors
-        pre: melos run analyze:dart:strict
+        pre: melos run analyze:strict
 
     version:
       # Only allow versioning to happen on main branch.
@@ -97,7 +96,7 @@ melos:
 
     analyze:swift:
       description: Analyze Swift code for the health_connector_hk_ios package
-      run: cd packages/health_connector_hk_ios/ios && swiftlint lint .
+      run: cd packages/health_connector_hk_ios/ios && swiftlint lint --strict --baseline swiftlint-baseline.json .
 
     baseline:swift:
       description: Generate SwiftLint baseline


### PR DESCRIPTION
## Summary

- Run the full `analyze:strict` suite before Melos publishes packages, covering Dart, Swift, and Kotlin instead of Dart only.
- Make the local Melos Swift analysis match CI by enabling strict mode and applying the checked-in SwiftLint baseline.
- Keep native source and baseline files unchanged because both platform checks are clean against their existing baselines.

## Why

The publish pre-hook previously ran only strict Dart analysis. Switching it directly to `analyze:strict` exposed a configuration mismatch: the Melos Swift command ignored `swiftlint-baseline.json`, while CI already used it. That caused local full analysis to report 190 known, already-baselined Swift findings.

This change aligns Melos with the CI command so the full publish gate is deterministic and covers all three languages.

## Validation

Using the repository-pinned FVM Flutter 3.35.7:

- [x] `fvm dart run melos run analyze:strict --no-select`
  - Dart: all 10 workspace packages passed with no issues.
  - Swift: 0 violations, 0 serious findings across 271 files.
  - Kotlin: Detekt passed.
- [x] Android forced fresh check: `./gradlew detekt --rerun-tasks` passed with an empty Detekt report.
- [x] Existing Android Detekt baseline remained unchanged.
- [x] Existing iOS SwiftLint baseline remained unchanged.
- [x] No Dart, Kotlin, Swift, Gradle, or Xcode source files changed.

## Notes

A general Gradle 10 deprecation warning remains, but it is not a Detekt finding and is outside this baseline-only native-quality scope.