### PR TITLE
docs: update Felipe Valtl de Mello role

### DIFF
--- a/webapp/.vitepress/theme/components/UsedBy.vue
+++ b/webapp/.vitepress/theme/components/UsedBy.vue
@@ -8,7 +8,7 @@ const apps = [
       "A nutrition app that turns meal photos into calorie and macro estimates, with health data synchronization.",
     creator: {
       name: "Felipe Valtl de Mello",
-      role: "Staff Engineer at Transfeera",
+      role: "Principal Software Engineer at Transfeera",
       url: "https://www.linkedin.com/in/felipevaltldemello/",
     },
   },


### PR DESCRIPTION
## Summary

- update Felipe Valtl de Mello's attribution from Staff Engineer to Principal Software Engineer at Transfeera
- keep the existing LinkedIn profile link unchanged
- align the website with Felipe's current title as published by [Transfeera](https://transfeera.com/blog/gestao-de-alta-performance-tech-leads/)

## Why

The role shown in the **Built with Health Connector** section became outdated after Felipe moved from Staff Software Engineer to Principal Software Engineer.

## Verification

- `npm run site:build`
  - checked 681 SDK files with no unknown documentation symbols
  - checked 209 internal links across 39 pages
  - built the VitePress client, server bundle, pages, and sitemap
- visually checked the updated card at 1280×720 and 390×844
- confirmed the longer title causes no card or page overflow

## Platform notes

This changes only website copy. It does not change Dart APIs or Android and iOS behavior.
