### PR TITLE
docs: add security and conduct policies

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,149 @@
+# Contributor Covenant 3.0 Code of Conduct
+
+## Our pledge
+
+We pledge to make our community welcoming, safe, and equitable for all.
+
+We are committed to fostering an environment that respects and promotes the dignity, rights, and
+contributions of all individuals, regardless of characteristics including race, ethnicity, caste,
+color, age, physical characteristics, neurodiversity, disability, sex or gender, gender identity
+or expression, sexual orientation, language, philosophy or religion, national or social origin,
+socio-economic position, level of education, or other status. The same privileges of participation
+are extended to everyone who participates in good faith and in accordance with this Covenant.
+
+## Encouraged behaviors
+
+While acknowledging differences in social norms, we all strive to meet our community's
+expectations for positive behavior. We also understand that our words and actions may be
+interpreted differently than we intend based on culture, background, or native language.
+
+With these considerations in mind, we agree to behave mindfully toward each other and act in ways
+that center our shared values, including:
+
+1. Respecting the **purpose of our community**, our activities, and our ways of gathering.
+1. Engaging **kindly and honestly** with others.
+1. Respecting **different viewpoints** and experiences.
+1. **Taking responsibility** for our actions and contributions.
+1. Gracefully giving and accepting **constructive feedback**.
+1. Committing to **repairing harm** when it occurs.
+1. Behaving in other ways that promote and sustain the **well-being of our community**.
+
+## Restricted behaviors
+
+We agree to restrict the following behaviors in our community. Instances, threats, and promotion
+of these behaviors are violations of this Code of Conduct.
+
+1. **Harassment.** Violating explicitly expressed boundaries or engaging in unnecessary personal
+   attention after any clear request to stop.
+1. **Character attacks.** Making insulting, demeaning, or pejorative comments directed at a
+   community member or group of people.
+1. **Stereotyping or discrimination.** Characterizing anyone's personality or behavior on the
+   basis of immutable identities or traits.
+1. **Sexualization.** Behaving in a way that would generally be considered inappropriately intimate
+   in the context or purpose of the community.
+1. **Violating confidentiality.** Sharing or acting on someone's personal or private information
+   without their permission.
+1. **Endangerment.** Causing, encouraging, or threatening violence or other harm toward any person
+   or group.
+1. Behaving in other ways that **threaten the well-being** of our community.
+
+### Other restrictions
+
+1. **Misleading identity.** Impersonating someone else for any reason, or pretending to be someone
+   else to evade enforcement actions.
+1. **Failing to credit sources.** Not properly crediting the sources of content you contribute.
+1. **Promotional materials.** Sharing marketing or other commercial content in a way that is
+   outside the norms of the community.
+1. **Irresponsible communication.** Failing to responsibly present content which includes, links,
+   or describes any other restricted behaviors.
+
+## Reporting an issue
+
+Tensions can occur between community members even when they are trying their best to collaborate.
+Not every conflict represents a code of conduct violation, and this Code of Conduct reinforces
+encouraged behaviors and norms that can help avoid conflicts and minimize harm.
+
+Report a possible violation privately by emailing
+[fam.tung.lam@gmail.com](mailto:fam.tung.lam@gmail.com) with `health_connector code of conduct` in
+the subject line. Do not disclose the incident in a public GitHub issue, discussion, or pull
+request.
+
+Project maintainers take reports of violations seriously and will make every effort to respond in
+a timely manner. They will investigate all reports of code of conduct violations, reviewing
+messages, logs, and recordings, or interviewing witnesses and other participants. Project
+maintainers will keep investigation and enforcement actions as transparent as possible while
+prioritizing safety and confidentiality. Enforcement actions are carried out in private with the
+involved parties, but communicating to the whole community may be part of a mutually agreed upon
+resolution.
+
+## Addressing and repairing harm
+
+If an investigation by the project maintainers finds that this Code of Conduct has been violated,
+the following enforcement ladder may be used to determine how best to repair harm, based on the
+incident's impact on the individuals involved and the community as a whole. Depending on the
+severity of a violation, lower rungs on the ladder may be skipped.
+
+### Warning
+
+- **Event:** A violation involving a single incident or series of incidents.
+- **Consequence:** A private, written warning from the project maintainers.
+- **Repair:** Examples include a private written apology, acknowledgement of responsibility, and
+  seeking clarification on expectations.
+
+### Temporarily limited activities
+
+- **Event:** A repeated incidence of a violation that previously resulted in a warning, or the
+  first incidence of a more serious violation.
+- **Consequence:** A private, written warning with a time-limited cooldown period designed to
+  underscore the seriousness of the situation and give the community members involved time to
+  process the incident. The cooldown period may be limited to particular communication channels
+  or interactions with particular community members.
+- **Repair:** Examples include making an apology, using the cooldown period to reflect on actions
+  and impact, and being thoughtful about re-entering community spaces after the period is over.
+
+### Temporary suspension
+
+- **Event:** A pattern of repeated violations which the project maintainers have tried to address
+  with warnings, or a single serious violation.
+- **Consequence:** A private written warning with conditions for return from suspension. Temporary
+  suspensions give the person being suspended time to reflect upon their behavior and possible
+  corrective actions.
+- **Repair:** Examples include respecting the spirit of the suspension, meeting the specified
+  conditions for return, and being thoughtful about how to reintegrate with the community when the
+  suspension is lifted.
+
+### Permanent ban
+
+- **Event:** A pattern of repeated code of conduct violations that other steps on the ladder have
+  failed to resolve, or a violation so serious that the project maintainers determine there is no
+  way to keep the community safe with this person as a member.
+- **Consequence:** Access to all community spaces, tools, and communication channels is removed.
+  Permanent bans should be rarely used, should have strong reasoning behind them, and should only
+  be used if other remedies have failed to change the behavior.
+- **Repair:** There is no possible repair in cases of this severity.
+
+This enforcement ladder is intended as a guideline. It does not limit the ability of project
+maintainers to use their discretion and judgment in keeping with the best interests of the
+community.
+
+## Scope
+
+This Code of Conduct applies within all community spaces and when an individual is officially
+representing the community in public or other spaces. Examples of representing our community
+include using an official email address, posting via an official social media account, or acting as
+an appointed representative at an online or offline event.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant, version 3.0](https://www.contributor-covenant.org/version/3/0/).
+
+Contributor Covenant is stewarded by the Organization for Ethical Source and licensed under
+[CC BY-SA 4.0](https://creativecommons.org/licenses/by-sa/4.0/).
+
+For answers to common questions about Contributor Covenant, see the
+[FAQ](https://www.contributor-covenant.org/faq). Translations are available on the
+[translations page](https://www.contributor-covenant.org/translations). Additional enforcement and
+community guidelines are available in the
+[Contributor Covenant resources](https://www.contributor-covenant.org/resources). The enforcement
+ladder was inspired by the work of [Mozilla's code of conduct
+team](https://github.com/mozilla/inclusion).

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,29 @@
+# Security Policy
+
+## Supported versions
+
+Security updates are provided for the latest published release of Health Connector.
+
+| Version | Supported |
+|---|---|
+| Latest published release | Yes |
+| Earlier releases | No |
+
+## Reporting a vulnerability
+
+Report suspected vulnerabilities privately by emailing
+[fam.tung.lam@gmail.com](mailto:fam.tung.lam@gmail.com) with `health_connector security` in the
+subject line. Do not disclose the vulnerability in a public GitHub issue, discussion, or pull
+request.
+
+Include the following details when possible:
+
+- The affected package and version
+- The affected platforms
+- Steps or proof of concept needed to reproduce the issue
+- The potential impact
+- Any suggested mitigation
+
+The maintainer will acknowledge the report, investigate it, and coordinate a fix and disclosure
+with the reporter. Please keep the vulnerability confidential until a fix is available or a
+disclosure date has been agreed upon.


### PR DESCRIPTION
## Summary

- add a security policy with supported-version guidance and a private reporting channel
- adopt Contributor Covenant 3.0 with a private conduct-reporting channel

## Why

The repository did not define how contributors should report vulnerabilities or conduct incidents,
or which community behavior and enforcement standards apply.

## Impact

GitHub can surface both community health files, and contributors now have clear private reporting
paths and participation expectations. This documentation-only change does not affect package APIs
or runtime behavior.

## Validation

- `npx --yes markdownlint-cli SECURITY.md CODE_OF_CONDUCT.md --config .markdownlint.yaml`
- `git diff --cached --check`

The repository-wide `melos run analyze:md` command could not complete because `markdownlint` is not
installed globally. Running the same configuration through `npx` reports only pre-existing errors
in `README.md` and package changelogs; the two new files pass when checked directly.
