### PR TITLE
ci: automate guarded package releases

### DIFF
--- a/.github/workflows/_reusable-publish.yaml
+++ b/.github/workflows/_reusable-publish.yaml
@@ -9,19 +9,42 @@ on:
         required: true
 
 jobs:
+  validate-release-tag:
+    name: Validate release tag
+    permissions:
+      contents: read
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+
+      - name: Match tag to package version
+        env:
+          PACKAGE_PATH: ${{ inputs.package-path }}
+          RELEASE_TAG: ${{ github.ref_name }}
+        run: node scripts/validate-release-tag.mjs "$PACKAGE_PATH" "$RELEASE_TAG"
+
+  wait-for-pub-dependencies:
+    name: Wait for pub.dev dependencies
+    needs: validate-release-tag
+    permissions:
+      contents: read
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+
+      - name: Wait for release dependencies
+        env:
+          PACKAGE_PATH: ${{ inputs.package-path }}
+        run: node scripts/wait-for-pub-dependencies.mjs "$PACKAGE_PATH"
+
   publish:
     name: Publish to pub.dev
+    needs: wait-for-pub-dependencies
     permissions:
-      # Required for OIDC-based authentication to pub.dev
-      # NOTE: This declaration alone is NOT sufficient - the caller workflow
-      # must also explicitly grant 'id-token: write' at the top level.
-      # 
-      # Why both are needed:
-      # - Effective permissions = intersection of caller's grants AND callee's declarations
-      # - The caller must explicitly grant id-token: write (repository identity permission)
-      # - This job-level declaration specifies what this specific job needs
-      # - If the caller doesn't grant it, this job cannot obtain the OIDC token
       id-token: write
     uses: dart-lang/setup-dart/.github/workflows/publish.yml@631075bc7d06a1ef11a42118142ba9148e41727c
     with:
+      environment: pub.dev
       working-directory: ${{ inputs.package-path }}

--- a/.github/workflows/_reusable-publish.yaml
+++ b/.github/workflows/_reusable-publish.yaml
@@ -27,6 +27,7 @@ jobs:
   wait-for-pub-dependencies:
     name: Wait for pub.dev dependencies
     needs: validate-release-tag
+    timeout-minutes: 360
     permissions:
       contents: read
     runs-on: ubuntu-latest

--- a/.github/workflows/cd-health-connector-core.yaml
+++ b/.github/workflows/cd-health-connector-core.yaml
@@ -6,9 +6,7 @@ on:
       - 'health_connector_core-v[0-9]+.[0-9]+.[0-9]+'
 
 permissions:
-  contents: write
-  # Required for OIDC-based authentication to pub.dev (see _reusable-publish.yaml)
-  # Must be explicitly granted at caller level even though reusable workflow declares it
+  contents: read
   id-token: write
 
 concurrency:

--- a/.github/workflows/cd-health-connector-hc-android.yaml
+++ b/.github/workflows/cd-health-connector-hc-android.yaml
@@ -6,11 +6,8 @@ on:
       - 'health_connector_hc_android-v[0-9]+.[0-9]+.[0-9]+'
 
 permissions:
-  contents: write
+  contents: read
   security-events: write
-
-  # Required for OIDC-based authentication to pub.dev (see _reusable-publish.yaml)
-  # Must be explicitly granted at caller level even though reusable workflow declares it
   id-token: write
 
 concurrency:

--- a/.github/workflows/cd-health-connector-hk-ios.yaml
+++ b/.github/workflows/cd-health-connector-hk-ios.yaml
@@ -6,9 +6,7 @@ on:
       - 'health_connector_hk_ios-v[0-9]+.[0-9]+.[0-9]+'
 
 permissions:
-  contents: write
-  # Required for OIDC-based authentication to pub.dev (see _reusable-publish.yaml)
-  # Must be explicitly granted at caller level even though reusable workflow declares it
+  contents: read
   id-token: write
 
 concurrency:
@@ -33,7 +31,7 @@ jobs:
       package-scope: health_connector_hk_ios
 
   build-ios:
-    needs: [ dart-tests, swift-quality ]
+    needs: [dart-tests, swift-quality]
     uses: ./.github/workflows/_reusable-build-ios.yaml
     with:
       package-path: packages/health_connector_hk_ios

--- a/.github/workflows/cd-health-connector-lint.yaml
+++ b/.github/workflows/cd-health-connector-lint.yaml
@@ -1,0 +1,26 @@
+name: CD - health_connector_lint
+
+on:
+  push:
+    tags:
+      - 'health_connector_lint-v[0-9]+.[0-9]+.[0-9]+'
+
+permissions:
+  contents: read
+  id-token: write
+
+concurrency:
+  group: cd-health_connector_lint-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  dart-quality:
+    uses: ./.github/workflows/_reusable-dart-quality.yaml
+    with:
+      package-scope: health_connector_lint
+
+  publish:
+    needs: dart-quality
+    uses: ./.github/workflows/_reusable-publish.yaml
+    with:
+      package-path: packages/health_connector_lint

--- a/.github/workflows/cd-health-connector-logger.yaml
+++ b/.github/workflows/cd-health-connector-logger.yaml
@@ -6,9 +6,7 @@ on:
       - 'health_connector_logger-v[0-9]+.[0-9]+.[0-9]+'
 
 permissions:
-  contents: write
-  # Required for OIDC-based authentication to pub.dev (see _reusable-publish.yaml)
-  # Must be explicitly granted at caller level even though reusable workflow declares it
+  contents: read
   id-token: write
 
 concurrency:
@@ -26,7 +24,7 @@ jobs:
     uses: ./.github/workflows/_reusable-dart-tests.yaml
     with:
       package-scope: health_connector_logger
-  
+
   publish:
     needs: dart-tests
     uses: ./.github/workflows/_reusable-publish.yaml

--- a/.github/workflows/cd-health-connector.yaml
+++ b/.github/workflows/cd-health-connector.yaml
@@ -6,10 +6,7 @@ on:
       - 'health_connector-v[0-9]+.[0-9]+.[0-9]+'
 
 permissions:
-  contents: write
-  security-events: write
-  # Required for OIDC-based authentication to pub.dev (see _reusable-publish.yaml)
-  # Must be explicitly granted at caller level even though reusable workflow declares it
+  contents: read
   id-token: write
 
 concurrency:

--- a/.github/workflows/cd-release-packages.yaml
+++ b/.github/workflows/cd-release-packages.yaml
@@ -1,0 +1,43 @@
+name: CD - release packages
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'packages/health_connector/pubspec.yaml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: cd-release-packages
+  cancel-in-progress: false
+
+jobs:
+  create-release-tags:
+    name: Create package release tags
+    runs-on: ubuntu-latest
+    steps:
+      - name: Require release token
+        env:
+          RELEASE_TOKEN: ${{ secrets.RELEASE_TOKEN }}
+        run: |
+          if [[ -z "$RELEASE_TOKEN" ]]; then
+            echo "::error::RELEASE_TOKEN must be a fine-grained token with Contents: write access to this repository."
+            exit 1
+          fi
+
+      - name: Check out repository
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        with:
+          fetch-depth: 0
+          token: ${{ secrets.RELEASE_TOKEN }}
+
+      - name: Configure tag author
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+      - name: Create and push package tags
+        run: node scripts/release-package-tags.mjs --push

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -362,7 +362,9 @@ Your pull request description should answer:
 
 ### Creating a release
 
-Each package in the monorepo is released independently. Follow these steps:
+Each package has its own `package-v<version>` release tag and pub.dev publication. A new
+`health_connector` version starts a coordinated release for every package version that does not
+already have a tag.
 
 1. **Remove deprecated symbols** — search the codebase for `@Deprecated` annotations and remove
    any that are marked for removal in the version you intend to release. Open a dedicated PR for
@@ -384,12 +386,17 @@ Each package in the monorepo is released independently. Follow these steps:
    melos publish
    ```
 
-4. **Publish** — once satisfied with the dry run output:
+4. **Preview release tags** — verify which package versions the release workflow will tag:
 
    ```bash
-   melos publish --no-dry-run
+   node scripts/release-package-tags.mjs
    ```
 
 5. **Open a release PR** — create a PR to `main` containing the updated `CHANGELOG.md` and
-   `pubspec.yaml` files. After merge, the CD workflow publishes the packages to
-   [pub.dev](https://pub.dev).
+   `pubspec.yaml` files. After merge, changing the facade version creates the missing package tags.
+   Each tag runs that package's quality checks and waits for approval in the `pub.dev` GitHub
+   Environment before publishing with OIDC.
+
+Repository setup requires a `RELEASE_TOKEN` secret with Contents write access. Configure every
+package on pub.dev with repository `fam-tung-lam/health_connector`, tag pattern
+`<package>-v{{version}}`, and required GitHub Actions environment `pub.dev`.

--- a/packages/health_connector_hc_android/example/android/.gitignore
+++ b/packages/health_connector_hc_android/example/android/.gitignore
@@ -1,8 +1,5 @@
-gradle-wrapper.jar
 /.gradle
 /captures/
-/gradlew
-/gradlew.bat
 /local.properties
 GeneratedPluginRegistrant.java
 .cxx/

--- a/packages/health_connector_lint/lib/analysis_options.yaml
+++ b/packages/health_connector_lint/lib/analysis_options.yaml
@@ -75,7 +75,6 @@ linter:
     - empty_catches
     - empty_constructor_bodies
     - empty_statements
-    - enable_null_safety
     - exhaustive_cases
     - file_names
     - flutter_style_todos

--- a/scripts/release-package-tags.mjs
+++ b/scripts/release-package-tags.mjs
@@ -1,0 +1,73 @@
+import { execFileSync, spawnSync } from 'node:child_process';
+import { readFile } from 'node:fs/promises';
+import { resolve } from 'node:path';
+
+const publish = process.argv.includes('--push');
+const packages = [
+  'packages/health_connector_lint',
+  'packages/health_connector_logger',
+  'packages/health_connector_core',
+  'packages/health_connector_hc_android',
+  'packages/health_connector_hk_ios',
+  'packages/health_connector',
+];
+
+if (publish && process.env.GITHUB_ACTIONS === 'true' && process.env.GITHUB_REF !== 'refs/heads/main') {
+  throw new Error(`Package releases must run from refs/heads/main, not ${process.env.GITHUB_REF}`);
+}
+
+function git(args, options = {}) {
+  return execFileSync('git', args, {
+    cwd: resolve('.'),
+    encoding: 'utf8',
+    stdio: options.stdio ?? ['ignore', 'pipe', 'pipe'],
+  }).trim();
+}
+
+function tagExists(tag) {
+  return spawnSync('git', ['show-ref', '--verify', '--quiet', `refs/tags/${tag}`], {
+    cwd: resolve('.'),
+  }).status === 0;
+}
+
+async function packageRelease(packagePath) {
+  const pubspec = await readFile(resolve(packagePath, 'pubspec.yaml'), 'utf8');
+
+  function readTopLevelScalar(key) {
+    const match = pubspec.match(new RegExp(`^${key}:\\s*['"]?([^'"#\\s]+)['"]?`, 'm'));
+    if (!match) {
+      throw new Error(`${packagePath}/pubspec.yaml has no top-level ${key} field`);
+    }
+
+    return match[1];
+  }
+
+  const name = readTopLevelScalar('name');
+  const version = readTopLevelScalar('version');
+  return { name, packagePath, tag: `${name}-v${version}`, version };
+}
+
+git(['rev-parse', '--show-toplevel']);
+const releases = await Promise.all(packages.map(packageRelease));
+const facadeRelease = releases.find(({ name }) => name === 'health_connector');
+
+if (tagExists(facadeRelease.tag)) {
+  console.log(`${facadeRelease.tag} already exists; no coordinated release is required.`);
+  process.exit(0);
+}
+
+const pending = releases.filter(({ tag }) => !tagExists(tag));
+
+for (const { name, version, tag } of pending) {
+  console.log(`${publish ? 'Releasing' : 'Would release'} ${name} ${version} as ${tag}`);
+}
+
+if (!publish) {
+  console.log('Dry run only. Pass --push to create and push the tags.');
+  process.exit(0);
+}
+
+for (const { name, version, tag } of pending) {
+  git(['tag', '--annotate', tag, '--message', `${name} ${version}`], { stdio: 'inherit' });
+  git(['push', 'origin', `refs/tags/${tag}`], { stdio: 'inherit' });
+}

--- a/scripts/validate-release-tag.mjs
+++ b/scripts/validate-release-tag.mjs
@@ -1,0 +1,33 @@
+import { readFile } from 'node:fs/promises';
+import { resolve } from 'node:path';
+
+const [packagePath, releaseTag] = process.argv.slice(2);
+
+if (!packagePath || !releaseTag) {
+  throw new Error(
+    'Usage: node scripts/validate-release-tag.mjs <package-path> <release-tag>',
+  );
+}
+
+const pubspec = await readFile(resolve(packagePath, 'pubspec.yaml'), 'utf8');
+
+function readTopLevelScalar(key) {
+  const match = pubspec.match(new RegExp(`^${key}:\\s*['"]?([^'"#\\s]+)['"]?`, 'm'));
+  if (!match) {
+    throw new Error(`pubspec.yaml has no top-level ${key} field`);
+  }
+
+  return match[1];
+}
+
+const packageName = readTopLevelScalar('name');
+const packageVersion = readTopLevelScalar('version');
+const expectedTag = `${packageName}-v${packageVersion}`;
+
+if (releaseTag !== expectedTag) {
+  throw new Error(
+    `Release tag ${releaseTag} does not match ${packageName} version ${packageVersion}; expected ${expectedTag}`,
+  );
+}
+
+console.log(`${releaseTag} matches ${packagePath}/pubspec.yaml`);

--- a/scripts/wait-for-pub-dependencies.mjs
+++ b/scripts/wait-for-pub-dependencies.mjs
@@ -2,8 +2,9 @@ import { readFile } from 'node:fs/promises';
 import { resolve } from 'node:path';
 
 const [packagePath] = process.argv.slice(2);
-const maxAttempts = Number(process.env.PUB_DEPENDENCY_ATTEMPTS ?? 90);
-const retryDelayMs = Number(process.env.PUB_DEPENDENCY_RETRY_MS ?? 10_000);
+const maxAttempts = Number(process.env.PUB_DEPENDENCY_ATTEMPTS ?? 700);
+const retryDelayMs = Number(process.env.PUB_DEPENDENCY_RETRY_MS ?? 30_000);
+const retryableStatuses = new Set([408, 425, 429]);
 
 if (!packagePath) {
   throw new Error('Usage: node scripts/wait-for-pub-dependencies.mjs <package-path>');
@@ -31,12 +32,26 @@ for (const line of pubspec.split(/\r?\n/)) {
 }
 
 async function isPublished(name, version) {
-  const response = await fetch(`https://pub.dev/api/packages/${name}/versions/${version}`);
+  let response;
+
+  try {
+    response = await fetch(`https://pub.dev/api/packages/${name}/versions/${version}`);
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    console.warn(`pub.dev lookup failed for ${name} ${version}: ${message}; retrying`);
+    return false;
+  }
+
   if (response.ok) {
     return true;
   }
 
   if (response.status === 404) {
+    return false;
+  }
+
+  if (retryableStatuses.has(response.status) || response.status >= 500) {
+    console.warn(`pub.dev returned ${response.status} while checking ${name} ${version}; retrying`);
     return false;
   }
 

--- a/scripts/wait-for-pub-dependencies.mjs
+++ b/scripts/wait-for-pub-dependencies.mjs
@@ -1,0 +1,70 @@
+import { readFile } from 'node:fs/promises';
+import { resolve } from 'node:path';
+
+const [packagePath] = process.argv.slice(2);
+const maxAttempts = Number(process.env.PUB_DEPENDENCY_ATTEMPTS ?? 90);
+const retryDelayMs = Number(process.env.PUB_DEPENDENCY_RETRY_MS ?? 10_000);
+
+if (!packagePath) {
+  throw new Error('Usage: node scripts/wait-for-pub-dependencies.mjs <package-path>');
+}
+
+const pubspec = await readFile(resolve(packagePath, 'pubspec.yaml'), 'utf8');
+const internalDependencies = new Map();
+let section = null;
+
+for (const line of pubspec.split(/\r?\n/)) {
+  const topLevelKey = line.match(/^([a-z_]+):(?:\s|$)/)?.[1];
+  if (topLevelKey) {
+    section = ['dependencies', 'dev_dependencies'].includes(topLevelKey) ? topLevelKey : null;
+    continue;
+  }
+
+  if (!section) {
+    continue;
+  }
+
+  const dependency = line.match(/^  (health_connector(?:_[a-z_]+)?):\s*\^?([0-9]+\.[0-9]+\.[0-9]+(?:-[0-9A-Za-z.-]+)?)/);
+  if (dependency) {
+    internalDependencies.set(dependency[1], dependency[2]);
+  }
+}
+
+async function isPublished(name, version) {
+  const response = await fetch(`https://pub.dev/api/packages/${name}/versions/${version}`);
+  if (response.ok) {
+    return true;
+  }
+
+  if (response.status === 404) {
+    return false;
+  }
+
+  throw new Error(`pub.dev returned ${response.status} while checking ${name} ${version}`);
+}
+
+function wait(delayMs) {
+  return new Promise((resolvePromise) => setTimeout(resolvePromise, delayMs));
+}
+
+for (let attempt = 1; attempt <= maxAttempts; attempt += 1) {
+  const pending = [];
+
+  for (const [name, version] of internalDependencies) {
+    if (!(await isPublished(name, version))) {
+      pending.push(`${name} ${version}`);
+    }
+  }
+
+  if (pending.length === 0) {
+    console.log(`All internal dependencies for ${packagePath} are available on pub.dev.`);
+    process.exit(0);
+  }
+
+  if (attempt === maxAttempts) {
+    throw new Error(`Timed out waiting for pub.dev dependencies: ${pending.join(', ')}`);
+  }
+
+  console.log(`Waiting for ${pending.join(', ')} (${attempt}/${maxAttempts})`);
+  await wait(retryDelayMs);
+}


### PR DESCRIPTION
## Summary

- create missing package-version tags when the `health_connector` facade version changes
- validate each tag against its package version and wait for internal pub.dev dependencies
- require approval through the protected `pub.dev` GitHub Environment before OIDC publishing
- add the missing `health_connector_lint` release workflow and remove two pub dry-run blockers

## Why

The existing workflows published packages independently but did not coordinate a facade release,
did not enforce manual approval, and omitted `health_connector_lint`. Concurrent package workflows
could also publish dependents before their new internal dependency versions reached pub.dev.

## Impact

Each package remains independently releasable from its own `<package>-v<version>` tag. A facade
version change now creates tags for every unpublished package version, and publish jobs wait for
their dependency versions before requesting approval.

## External configuration

- repository secret `RELEASE_TOKEN` is configured with a fine-grained, repository-only token
- token permission is limited to Contents read/write and expires on 2027-08-18
- GitHub Environment `pub.dev` requires reviewer approval and package tag policies
- all six pub.dev packages require the `pub.dev` environment and their package-specific tag
- manual CLI publishing is disabled for all six packages

## Validation

- GitHub checks: 20 passed, 0 failed
- `go run github.com/rhysd/actionlint/cmd/actionlint@v1.7.12`
- `node --check` for all three release scripts
- release tag validation for all six current package tags
- pub.dev dependency availability checks for all six packages
- `dart pub publish --dry-run` for all six packages, zero warnings
- clean merge simulation against current `origin/main`

`melos publish --dry-run --no-private` remains blocked on local Dart 3.12 by the existing
`TargetKind.directive` deprecation in `health_connector_core`; the package-level dry-runs used by
the actual publisher all pass.
