### PR TITLE
ci: configure Dependabot updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,54 @@
+version: 2
+
+updates:
+  - package-ecosystem: "pub"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    groups:
+      pub-minor-and-patch:
+        patterns:
+          - "*"
+        update-types:
+          - "minor"
+          - "patch"
+
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    groups:
+      npm-minor-and-patch:
+        patterns:
+          - "*"
+        update-types:
+          - "minor"
+          - "patch"
+
+  - package-ecosystem: "gradle"
+    directories:
+      - "/examples/health_connector_toolbox/android"
+      - "/packages/health_connector/example/android"
+      - "/packages/health_connector_hc_android/android"
+      - "/packages/health_connector_hc_android/example/android"
+    schedule:
+      interval: "weekly"
+    groups:
+      gradle-minor-and-patch:
+        patterns:
+          - "*"
+        update-types:
+          - "minor"
+          - "patch"
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    groups:
+      actions-minor-and-patch:
+        patterns:
+          - "*"
+        update-types:
+          - "minor"
+          - "patch"


### PR DESCRIPTION
## Summary

- Enable weekly Dependabot version updates for the Dart workspace, npm documentation tooling, four Gradle projects, and GitHub Actions.
- Group minor and patch updates within each ecosystem while keeping major upgrades separate.

## Why

The repository currently has no Dependabot configuration, so dependency version updates require manual discovery and maintenance.

## Impact

After this lands on `main`, Dependabot will check all configured ecosystems weekly and open focused update pull requests.

## Validation

- Parsed `.github/dependabot.yml` as YAML and verified all four expected ecosystems.
- Ran `git diff --cached --check` with no errors.
