### PR TITLE
chore(release): publish MIT and webapp patch updates

### DIFF
--- a/examples/health_connector_toolbox/pubspec.yaml
+++ b/examples/health_connector_toolbox/pubspec.yaml
@@ -10,7 +10,7 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  health_connector: ^3.9.4
+  health_connector: ^3.9.5
   intl: ^0.19.0
   provider: ^6.1.5+1
   shared_preferences: ^2.5.4
@@ -18,7 +18,7 @@ dependencies:
 dev_dependencies:
   flutter_test:
     sdk: flutter
-  health_connector_lint: ^1.2.0
+  health_connector_lint: ^1.2.1
 
 flutter:
   uses-material-design: true

--- a/packages/health_connector/CHANGELOG.md
+++ b/packages/health_connector/CHANGELOG.md
@@ -1,3 +1,15 @@
+## 3.9.5
+
+- **CHORE**: Migrate the Health Connector SDK packages from the Apache 2.0 License to the MIT License.
+- **DOCS**(health_connector): Reorganize the package README for faster API
+  discovery ([#192](https://github.com/fam-tung-lam/health_connector/issues/192)).
+  ([be2deac1](https://github.com/fam-tung-lam/health_connector/commit/be2deac1d6ebe053c70cab689da6cb15a30fe21f))
+- **DOCS**(webapp): Source SDK reference tables from YAML data. ([62ec1b45](https://github.com/fam-tung-lam/health_connector/commit/62ec1b45ac367239ee18b60e44401b56095f1465))
+- **DOCS**: Remove dartdoc tooling and directives. ([d2ca7bd5](https://github.com/fam-tung-lam/health_connector/commit/d2ca7bd5d86d4aaefd731be13fb4be8ed790b251))
+- **DOCS**(webapp): Launch the Health Connector SDK website
+  ([#164](https://github.com/fam-tung-lam/health_connector/issues/164)).
+  ([d0c99c61](https://github.com/fam-tung-lam/health_connector/commit/d0c99c61a54a34d268fd5c0875c3aa0edef869dc))
+
 ## 3.9.4
 
 - **REFACTOR**: Remove unused native Android and iOS modules from the Dart facade. Native platform registration remains owned by `health_connector_hc_android` and `health_connector_hk_ios`. ([c4eb3848](https://github.com/fam-tung-lam/health_connector/commit/c4eb3848d64ea9a6e62111179e6811cd27050dfe))

--- a/packages/health_connector/CHANGELOG.md
+++ b/packages/health_connector/CHANGELOG.md
@@ -5,7 +5,8 @@
   discovery ([#192](https://github.com/fam-tung-lam/health_connector/issues/192)).
   ([be2deac1](https://github.com/fam-tung-lam/health_connector/commit/be2deac1d6ebe053c70cab689da6cb15a30fe21f))
 - **DOCS**(webapp): Source SDK reference tables from YAML data. ([62ec1b45](https://github.com/fam-tung-lam/health_connector/commit/62ec1b45ac367239ee18b60e44401b56095f1465))
-- **DOCS**: Remove dartdoc tooling and directives. ([d2ca7bd5](https://github.com/fam-tung-lam/health_connector/commit/d2ca7bd5d86d4aaefd731be13fb4be8ed790b251))
+- **DOCS**: Retire package-level dartdoc tooling and directives because Health Connector SDK documentation now lives
+  in the webapp. ([d2ca7bd5](https://github.com/fam-tung-lam/health_connector/commit/d2ca7bd5d86d4aaefd731be13fb4be8ed790b251))
 - **DOCS**(webapp): Launch the Health Connector SDK website
   ([#164](https://github.com/fam-tung-lam/health_connector/issues/164)).
   ([d0c99c61](https://github.com/fam-tung-lam/health_connector/commit/d0c99c61a54a34d268fd5c0875c3aa0edef869dc))

--- a/packages/health_connector/example/pubspec.yaml
+++ b/packages/health_connector/example/pubspec.yaml
@@ -16,7 +16,7 @@ dependencies:
 dev_dependencies:
   flutter_test:
     sdk: flutter
-  health_connector_lint: ^1.2.0
+  health_connector_lint: ^1.2.1
   integration_test:
     sdk: flutter
 

--- a/packages/health_connector/pubspec.yaml
+++ b/packages/health_connector/pubspec.yaml
@@ -1,7 +1,7 @@
 name: health_connector
 resolution: workspace
 description: The most comprehensive Flutter health SDK for seamless iOS HealthKit and Android Health Connect integration.
-version: 3.9.4
+version: 3.9.5
 homepage: https://github.com/fam-tung-lam/health_connector
 repository: https://github.com/fam-tung-lam/health_connector/tree/main/packages/health_connector
 issue_tracker: https://github.com/fam-tung-lam/health_connector/issues?q=is%3Aissue%20is%3Aopen
@@ -13,14 +13,14 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  health_connector_core: ^3.9.2
-  health_connector_hc_android: ^3.6.2
-  health_connector_hk_ios: ^3.9.2
-  health_connector_logger: ^4.0.0
+  health_connector_core: ^3.9.3
+  health_connector_hc_android: ^3.6.3
+  health_connector_hk_ios: ^3.9.3
+  health_connector_logger: ^4.0.1
   meta: ^1.16.0
 
 dev_dependencies:
-  health_connector_lint: ^1.2.0
+  health_connector_lint: ^1.2.1
   mocktail: ^1.0.4
   parameterized_test: ^2.0.2
   test: ^1.24.0

--- a/packages/health_connector_core/CHANGELOG.md
+++ b/packages/health_connector_core/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 3.9.3
+
+- **CHORE**: Migrate the package from the Apache 2.0 License to the MIT License.
+- **DOCS**: Remove dartdoc tooling and directives. ([d2ca7bd5](https://github.com/fam-tung-lam/health_connector/commit/d2ca7bd5d86d4aaefd731be13fb4be8ed790b251))
+
 ## 3.9.2
 
 - **FIX**: Expose `deleteByIds` and `deleteInTimeRange` APIs for `NutritionDataType`. ([54afe082](https://github.com/fam-tung-lam/health_connector/commit/54afe08239f6c100bc1c833a2e00cc8ee3d2e76a))

--- a/packages/health_connector_core/CHANGELOG.md
+++ b/packages/health_connector_core/CHANGELOG.md
@@ -1,7 +1,8 @@
 ## 3.9.3
 
 - **CHORE**: Migrate the package from the Apache 2.0 License to the MIT License.
-- **DOCS**: Remove dartdoc tooling and directives. ([d2ca7bd5](https://github.com/fam-tung-lam/health_connector/commit/d2ca7bd5d86d4aaefd731be13fb4be8ed790b251))
+- **DOCS**: Retire package-level dartdoc tooling and directives because Health Connector SDK documentation now lives
+  in the webapp. ([d2ca7bd5](https://github.com/fam-tung-lam/health_connector/commit/d2ca7bd5d86d4aaefd731be13fb4be8ed790b251))
 
 ## 3.9.2
 

--- a/packages/health_connector_core/pubspec.yaml
+++ b/packages/health_connector_core/pubspec.yaml
@@ -1,7 +1,7 @@
 name: health_connector_core
 resolution: workspace
 description: Core models, utilities, and platform interface for Health Connector
-version: 3.9.2
+version: 3.9.3
 repository: https://github.com/fam-tung-lam/health_connector/tree/main/packages/health_connector_core
 issue_tracker: https://github.com/fam-tung-lam/health_connector/issues?q=is%3Aissue%20is%3Aopen
 
@@ -10,11 +10,11 @@ environment:
 
 dependencies:
   collection: ^1.19.1
-  health_connector_logger: ^4.0.0
+  health_connector_logger: ^4.0.1
   meta: ^1.16.0
 
 dev_dependencies:
-  health_connector_lint: ^1.2.0
+  health_connector_lint: ^1.2.1
   mocktail: ^1.0.4
   parameterized_test: ^2.0.2
   test: ^1.24.0

--- a/packages/health_connector_hc_android/CHANGELOG.md
+++ b/packages/health_connector_hc_android/CHANGELOG.md
@@ -1,7 +1,8 @@
 ## 3.6.3
 
 - **CHORE**: Migrate the package from the Apache 2.0 License to the MIT License.
-- **DOCS**: Remove dartdoc tooling and directives. ([d2ca7bd5](https://github.com/fam-tung-lam/health_connector/commit/d2ca7bd5d86d4aaefd731be13fb4be8ed790b251))
+- **DOCS**: Retire package-level dartdoc tooling and directives because Health Connector SDK documentation now lives
+  in the webapp. ([d2ca7bd5](https://github.com/fam-tung-lam/health_connector/commit/d2ca7bd5d86d4aaefd731be13fb4be8ed790b251))
 
 ## 3.6.2
 

--- a/packages/health_connector_hc_android/CHANGELOG.md
+++ b/packages/health_connector_hc_android/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 3.6.3
+
+- **CHORE**: Migrate the package from the Apache 2.0 License to the MIT License.
+- **DOCS**: Remove dartdoc tooling and directives. ([d2ca7bd5](https://github.com/fam-tung-lam/health_connector/commit/d2ca7bd5d86d4aaefd731be13fb4be8ed790b251))
+
 ## 3.6.2
 
 - Update a `health_connector_core` to the latest release.

--- a/packages/health_connector_hc_android/example/pubspec.yaml
+++ b/packages/health_connector_hc_android/example/pubspec.yaml
@@ -9,14 +9,14 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  health_connector_core: ^3.9.2
+  health_connector_core: ^3.9.3
   health_connector_hc_android:
     path: ../
 
 dev_dependencies:
   flutter_test:
     sdk: flutter
-  health_connector_lint: ^1.2.0
+  health_connector_lint: ^1.2.1
   integration_test:
     sdk: flutter
 

--- a/packages/health_connector_hc_android/pubspec.yaml
+++ b/packages/health_connector_hc_android/pubspec.yaml
@@ -1,7 +1,7 @@
 name: health_connector_hc_android
 resolution: workspace
 description: Android implementation of health_connector using Health Connect
-version: 3.6.2
+version: 3.6.3
 repository: https://github.com/fam-tung-lam/health_connector/tree/main/packages/health_connector_hc_android
 issue_tracker: https://github.com/fam-tung-lam/health_connector/issues?q=is%3Aissue%20is%3Aopen
 
@@ -12,14 +12,14 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  health_connector_core: ^3.9.2
-  health_connector_logger: ^4.0.0
+  health_connector_core: ^3.9.3
+  health_connector_logger: ^4.0.1
   meta: ^1.16.0
 
 dev_dependencies:
   flutter_test:
     sdk: flutter
-  health_connector_lint: ^1.2.0
+  health_connector_lint: ^1.2.1
   mocktail: ^1.0.4
   parameterized_test: ^2.0.2
   pigeon: ^26.1.0

--- a/packages/health_connector_hk_ios/CHANGELOG.md
+++ b/packages/health_connector_hk_ios/CHANGELOG.md
@@ -1,7 +1,8 @@
 ## 3.9.3
 
 - **CHORE**: Migrate the package from the Apache 2.0 License to the MIT License.
-- **DOCS**: Remove dartdoc tooling and directives. ([d2ca7bd5](https://github.com/fam-tung-lam/health_connector/commit/d2ca7bd5d86d4aaefd731be13fb4be8ed790b251))
+- **DOCS**: Retire package-level dartdoc tooling and directives because Health Connector SDK documentation now lives
+  in the webapp. ([d2ca7bd5](https://github.com/fam-tung-lam/health_connector/commit/d2ca7bd5d86d4aaefd731be13fb4be8ed790b251))
 
 ## 3.9.2
 

--- a/packages/health_connector_hk_ios/CHANGELOG.md
+++ b/packages/health_connector_hk_ios/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 3.9.3
+
+- **CHORE**: Migrate the package from the Apache 2.0 License to the MIT License.
+- **DOCS**: Remove dartdoc tooling and directives. ([d2ca7bd5](https://github.com/fam-tung-lam/health_connector/commit/d2ca7bd5d86d4aaefd731be13fb4be8ed790b251))
+
 ## 3.9.2
 
 - Update a `health_connector_core` to the latest release.

--- a/packages/health_connector_hk_ios/example/pubspec.yaml
+++ b/packages/health_connector_hk_ios/example/pubspec.yaml
@@ -9,14 +9,14 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  health_connector_core: ^3.9.2
+  health_connector_core: ^3.9.3
   health_connector_hk_ios:
     path: ../
 
 dev_dependencies:
   flutter_test:
     sdk: flutter
-  health_connector_lint: ^1.2.0
+  health_connector_lint: ^1.2.1
   integration_test:
     sdk: flutter
 

--- a/packages/health_connector_hk_ios/pubspec.yaml
+++ b/packages/health_connector_hk_ios/pubspec.yaml
@@ -1,7 +1,7 @@
 name: health_connector_hk_ios
 resolution: workspace
 description: iOS implementation of health_connector using HealthKit
-version: 3.9.2
+version: 3.9.3
 repository: https://github.com/fam-tung-lam/health_connector/tree/main/packages/health_connector_hk_ios
 issue_tracker: https://github.com/fam-tung-lam/health_connector/issues?q=is%3Aissue%20is%3Aopen
 
@@ -12,14 +12,14 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  health_connector_core: ^3.9.2
-  health_connector_logger: ^4.0.0
+  health_connector_core: ^3.9.3
+  health_connector_logger: ^4.0.1
   meta: ^1.16.0
 
 dev_dependencies:
   flutter_test:
     sdk: flutter
-  health_connector_lint: ^1.2.0
+  health_connector_lint: ^1.2.1
   mocktail: ^1.0.4
   parameterized_test: ^2.0.2
   pigeon: ^26.1.0

--- a/packages/health_connector_lint/CHANGELOG.md
+++ b/packages/health_connector_lint/CHANGELOG.md
@@ -1,6 +1,9 @@
-## Unreleased
+## 1.2.1
 
+- **CHORE**: Migrate the package from the Apache 2.0 License to the MIT License.
 - **CHORE**: Remove API documentation lint rules from the shared configuration.
+- **DOCS**(lint): Preserve the `1.2.0` changelog history. ([bc95173b](https://github.com/fam-tung-lam/health_connector/commit/bc95173b531b4d0620ffbbc0242c9ff80fe2e858))
+- **DOCS**: Remove dartdoc tooling and directives. ([d2ca7bd5](https://github.com/fam-tung-lam/health_connector/commit/d2ca7bd5d86d4aaefd731be13fb4be8ed790b251))
 
 ## 1.2.0
 

--- a/packages/health_connector_lint/CHANGELOG.md
+++ b/packages/health_connector_lint/CHANGELOG.md
@@ -3,7 +3,8 @@
 - **CHORE**: Migrate the package from the Apache 2.0 License to the MIT License.
 - **CHORE**: Remove API documentation lint rules from the shared configuration.
 - **DOCS**(lint): Preserve the `1.2.0` changelog history. ([bc95173b](https://github.com/fam-tung-lam/health_connector/commit/bc95173b531b4d0620ffbbc0242c9ff80fe2e858))
-- **DOCS**: Remove dartdoc tooling and directives. ([d2ca7bd5](https://github.com/fam-tung-lam/health_connector/commit/d2ca7bd5d86d4aaefd731be13fb4be8ed790b251))
+- **DOCS**: Retire package-level dartdoc tooling and directives because Health Connector SDK documentation now lives
+  in the webapp. ([d2ca7bd5](https://github.com/fam-tung-lam/health_connector/commit/d2ca7bd5d86d4aaefd731be13fb4be8ed790b251))
 
 ## 1.2.0
 

--- a/packages/health_connector_lint/pubspec.yaml
+++ b/packages/health_connector_lint/pubspec.yaml
@@ -1,7 +1,7 @@
 name: health_connector_lint
 resolution: workspace
 description: Lint rules for health_connector packages
-version: 1.2.0
+version: 1.2.1
 repository: https://github.com/fam-tung-lam/health_connector/tree/main/packages/health_connector_lint
 issue_tracker: https://github.com/fam-tung-lam/health_connector/issues?q=is%3Aissue%20is%3Aopen
 

--- a/packages/health_connector_logger/CHANGELOG.md
+++ b/packages/health_connector_logger/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 4.0.1
+
+- **CHORE**: Migrate the package from the Apache 2.0 License to the MIT License.
+- **DOCS**: Remove dartdoc tooling and directives. ([d2ca7bd5](https://github.com/fam-tung-lam/health_connector/commit/d2ca7bd5d86d4aaefd731be13fb4be8ed790b251))
+
 ## 4.0.0
 
 > Note: This release has breaking changes.

--- a/packages/health_connector_logger/CHANGELOG.md
+++ b/packages/health_connector_logger/CHANGELOG.md
@@ -1,7 +1,8 @@
 ## 4.0.1
 
 - **CHORE**: Migrate the package from the Apache 2.0 License to the MIT License.
-- **DOCS**: Remove dartdoc tooling and directives. ([d2ca7bd5](https://github.com/fam-tung-lam/health_connector/commit/d2ca7bd5d86d4aaefd731be13fb4be8ed790b251))
+- **DOCS**: Retire package-level dartdoc tooling and directives because Health Connector SDK documentation now lives
+  in the webapp. ([d2ca7bd5](https://github.com/fam-tung-lam/health_connector/commit/d2ca7bd5d86d4aaefd731be13fb4be8ed790b251))
 
 ## 4.0.0
 

--- a/packages/health_connector_logger/pubspec.yaml
+++ b/packages/health_connector_logger/pubspec.yaml
@@ -1,7 +1,7 @@
 name: health_connector_logger
 resolution: workspace
 description: Structured logging utility for Health Connector packages
-version: 4.0.0
+version: 4.0.1
 repository: https://github.com/fam-tung-lam/health_connector/tree/main/packages/health_connector_logger
 issue_tracker: https://github.com/fam-tung-lam/health_connector/issues?q=is%3Aissue%20is%3Aopen
 
@@ -14,7 +14,7 @@ dependencies:
 
 dev_dependencies:
   async: ^2.13.0
-  health_connector_lint: ^1.2.0
+  health_connector_lint: ^1.2.1
   test: ^1.24.0
 
 platforms:


### PR DESCRIPTION
## Summary

- Prepare coordinated patch releases for all six publishable packages.
- Publish the completed migration from Apache 2.0 to the MIT License in each package changelog.
- Include the Health Connector SDK website, YAML-backed reference data, and reorganized facade README in the consumer-facing changelog.
- Update internal package and example dependency constraints to the new versions.

## Package versions

| Package | Version |
| --- | --- |
| `health_connector_lint` | `1.2.1` |
| `health_connector_logger` | `4.0.1` |
| `health_connector_core` | `3.9.3` |
| `health_connector_hc_android` | `3.6.3` |
| `health_connector_hk_ios` | `3.9.3` |
| `health_connector` | `3.9.5` |

## Breaking changes

None.

## Migration guides

None. The license and documentation changes do not alter the SDK API.

## Validation

- `npm run site:build` passed.
- `git diff --check` passed before commit.
- Markdown lint reports 48 existing errors in historical changelog entries outside the added release sections.
- Release validation was not run locally, as required by `docs/workflows/RELEASE.md`.
