### PR TITLE
fix(release): push tags after creation

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "version": "0.0.0",
   "type": "module",
   "scripts": {
-    "release:test": "node --test scripts/release-version.test.mjs",
+    "release:test": "node --test scripts/*.test.mjs",
     "site:build": "vitepress build webapp",
     "site:dev": "vitepress dev webapp",
     "site:preview": "vitepress preview webapp"

--- a/scripts/release-package-tags.mjs
+++ b/scripts/release-package-tags.mjs
@@ -18,12 +18,19 @@ if (publish && process.env.GITHUB_ACTIONS === 'true' && process.env.GITHUB_REF !
   throw new Error(`Package releases must run from refs/heads/main, not ${process.env.GITHUB_REF}`);
 }
 
-function git(args, options = {}) {
+function readGit(args) {
   return execFileSync('git', args, {
     cwd: resolve('.'),
     encoding: 'utf8',
-    stdio: options.stdio ?? ['ignore', 'pipe', 'pipe'],
+    stdio: ['ignore', 'pipe', 'pipe'],
   }).trim();
+}
+
+function runGit(args) {
+  execFileSync('git', args, {
+    cwd: resolve('.'),
+    stdio: 'inherit',
+  });
 }
 
 function tagExists(tag) {
@@ -52,7 +59,7 @@ async function packageRelease(packagePath) {
   return { name, packagePath, tag: `${name}-v${version}`, version };
 }
 
-git(['rev-parse', '--show-toplevel']);
+readGit(['rev-parse', '--show-toplevel']);
 const releases = await Promise.all(packages.map(packageRelease));
 const facadeRelease = releases.find(({ name }) => name === 'health_connector');
 
@@ -73,6 +80,6 @@ if (!publish) {
 }
 
 for (const { name, version, tag } of pending) {
-  git(['tag', '--annotate', tag, '--message', `${name} ${version}`], { stdio: 'inherit' });
-  git(['push', 'origin', `refs/tags/${tag}`], { stdio: 'inherit' });
+  runGit(['tag', '--annotate', tag, '--message', `${name} ${version}`]);
+  runGit(['push', 'origin', `refs/tags/${tag}`]);
 }

--- a/scripts/release-package-tags.test.mjs
+++ b/scripts/release-package-tags.test.mjs
@@ -1,0 +1,49 @@
+import assert from 'node:assert/strict';
+import { execFileSync } from 'node:child_process';
+import { mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { delimiter, join, resolve } from 'node:path';
+import test from 'node:test';
+
+test('package tag creation reaches the matching push command', async () => {
+  const temporaryDirectory = await mkdtemp(join(tmpdir(), 'release-package-tags-test-'));
+  const gitLogPath = join(temporaryDirectory, 'git.log');
+  const gitPath = join(temporaryDirectory, 'git');
+
+  await writeFile(
+    gitPath,
+    `#!/bin/sh
+printf '%s\n' "$*" >> "$GIT_LOG"
+if [ "$1" = "show-ref" ]; then
+  exit 1
+fi
+`,
+    { mode: 0o755 },
+  );
+
+  try {
+    execFileSync(process.execPath, ['scripts/release-package-tags.mjs', '--push'], {
+      cwd: resolve('.'),
+      env: {
+        ...process.env,
+        GITHUB_ACTIONS: 'false',
+        GIT_LOG: gitLogPath,
+        PATH: `${temporaryDirectory}${delimiter}${process.env.PATH}`,
+      },
+    });
+
+    const commands = (await readFile(gitLogPath, 'utf8')).trim().split('\n');
+    const tagCommands = commands.filter((command) => command.startsWith('tag --annotate '));
+    const pushCommands = commands.filter((command) => command.startsWith('push origin refs/tags/'));
+
+    assert.equal(tagCommands.length, 6);
+    assert.equal(pushCommands.length, 6);
+
+    for (const [index, tagCommand] of tagCommands.entries()) {
+      const tag = tagCommand.split(' ')[2];
+      assert.equal(pushCommands[index], `push origin refs/tags/${tag}`);
+    }
+  } finally {
+    await rm(temporaryDirectory, { force: true, recursive: true });
+  }
+});


### PR DESCRIPTION
## Summary

- Separate Git commands from Git queries in the package-tag release script.
- Prevent inherited command output from returning `null` and aborting before tag push.
- Add a regression test that proves every created package tag reaches its matching push command without touching real tags or remotes.

## Root cause

`execFileSync` returns `null` when `stdio` is inherited. The shared Git helper called `.trim()` on that value after successfully creating the first runner-local tag, so the workflow failed before running the corresponding push command.

## Impact

Rerunning `CD - release packages` after this fix can create and push all missing package tags. The workflow remains idempotent and skips tags that already exist remotely.

## Validation

- `node --check scripts/release-package-tags.mjs`
- `node --check scripts/release-package-tags.test.mjs`
- `node --test scripts/release-package-tags.test.mjs`
- `git diff --check`

The full release validation remains delegated to CI as required by `docs/workflows/RELEASE.md`.
