### PR TITLE
docs(health_connector): fix demo asset paths

### DIFF
--- a/packages/health_connector/README.md
+++ b/packages/health_connector/README.md
@@ -78,18 +78,18 @@ and Android.
     </thead>
     <tbody>
       <tr>
-        <td><img alt="Permission Request" src="../../doc/assets/videos/ios_request_permissions_demo.gif" width="160"/></td>
-        <td><img alt="Read Data" src="../../doc/assets/videos/ios_read_health_records_demo.gif" width="160"/></td>
-        <td><img alt="Write Data" src="../../doc/assets/videos/ios_write_health_record_demo.gif" width="160"/></td>
-        <td><img alt="Delete Data" src="../../doc/assets/videos/ios_delete_health_records_demo.gif" width="160"/></td>
-        <td><img alt="Aggregate Data" src="../../doc/assets/videos/ios_aggregate_health_data_demo.gif" width="160"/></td>
+        <td><img alt="Permission Request" src="../../docs/assets/videos/ios_request_permissions_demo.gif" width="160"/></td>
+        <td><img alt="Read Data" src="../../docs/assets/videos/ios_read_health_records_demo.gif" width="160"/></td>
+        <td><img alt="Write Data" src="../../docs/assets/videos/ios_write_health_record_demo.gif" width="160"/></td>
+        <td><img alt="Delete Data" src="../../docs/assets/videos/ios_delete_health_records_demo.gif" width="160"/></td>
+        <td><img alt="Aggregate Data" src="../../docs/assets/videos/ios_aggregate_health_data_demo.gif" width="160"/></td>
       </tr>
       <tr>
-        <td><img alt="Permission Request" src="../../doc/assets/videos/android_request_permissions_demo.gif" width="160"/></td>
-        <td><img alt="Read Data" src="../../doc/assets/videos/android_read_health_records_demo.gif" width="160"/></td>
-        <td><img alt="Write Data" src="../../doc/assets/videos/android_write_health_record_demo.gif" width="160"/></td>
-        <td><img alt="Delete Data" src="../../doc/assets/videos/android_delete_health_records_demo.gif" width="160"/></td>
-        <td><img alt="Aggregate Data" src="../../doc/assets/videos/android_aggregate_health_data_demo.gif" width="160"/></td>
+        <td><img alt="Permission Request" src="../../docs/assets/videos/android_request_permissions_demo.gif" width="160"/></td>
+        <td><img alt="Read Data" src="../../docs/assets/videos/android_read_health_records_demo.gif" width="160"/></td>
+        <td><img alt="Write Data" src="../../docs/assets/videos/android_write_health_record_demo.gif" width="160"/></td>
+        <td><img alt="Delete Data" src="../../docs/assets/videos/android_delete_health_records_demo.gif" width="160"/></td>
+        <td><img alt="Aggregate Data" src="../../docs/assets/videos/android_aggregate_health_data_demo.gif" width="160"/></td>
       </tr>
     </tbody>
   </table>


### PR DESCRIPTION
## Summary

- fix all 10 health_connector README demo paths from `doc/assets/videos` to `docs/assets/videos`
- keep the existing iOS and Android demo asset names unchanged

## Verification

- confirmed all 10 referenced GIF files exist
- confirmed no tracked `/doc/assets/videos/` reference remains
- `git diff --check`