### PR TITLE
fix(release): recover package publishing

### DIFF
--- a/.github/workflows/_reusable-publish.yaml
+++ b/.github/workflows/_reusable-publish.yaml
@@ -7,6 +7,11 @@ on:
         description: 'Path to the package to publish'
         type: string
         required: true
+      release-tag:
+        description: 'Release tag to validate; defaults to the triggering tag'
+        type: string
+        required: false
+        default: ''
 
 jobs:
   validate-release-tag:
@@ -20,13 +25,25 @@ jobs:
     steps:
       - name: Check out repository
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        with:
+          fetch-depth: 0
 
       - name: Match tag to package version
         id: release
         env:
           PACKAGE_PATH: ${{ inputs.package-path }}
-          RELEASE_TAG: ${{ github.ref_name }}
+          RELEASE_TAG: ${{ inputs.release-tag || github.ref_name }}
         run: node scripts/validate-release-tag.mjs "$PACKAGE_PATH" "$RELEASE_TAG"
+
+      - name: Match package content to release tag
+        env:
+          PACKAGE_PATH: ${{ inputs.package-path }}
+          RELEASE_TAG: ${{ inputs.release-tag || github.ref_name }}
+        run: |
+          if ! git diff --quiet "$RELEASE_TAG" -- "$PACKAGE_PATH"; then
+            echo "::error::$PACKAGE_PATH differs from $RELEASE_TAG at the workflow ref."
+            exit 1
+          fi
 
   wait-for-pub-dependencies:
     name: Wait for pub.dev dependencies
@@ -49,7 +66,7 @@ jobs:
     needs: wait-for-pub-dependencies
     permissions:
       id-token: write
-    uses: dart-lang/setup-dart/.github/workflows/publish.yml@631075bc7d06a1ef11a42118142ba9148e41727c
+    uses: dart-lang/setup-dart/.github/workflows/publish.yml@7654d458321ee25acccccfdb86cd48bd95768ff1 # v1.8.0
     with:
       environment: pub.dev
       working-directory: ${{ inputs.package-path }}

--- a/.github/workflows/_reusable-release-validation.yaml
+++ b/.github/workflows/_reusable-release-validation.yaml
@@ -7,6 +7,11 @@ on:
         description: 'Path to the package being released'
         type: string
         required: true
+      release-tag:
+        description: 'Release tag to validate; defaults to the triggering tag'
+        type: string
+        required: false
+        default: ''
 
 permissions:
   contents: read
@@ -19,6 +24,8 @@ jobs:
     steps:
       - name: Check out repository
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        with:
+          fetch-depth: 0
 
       - name: Test release version convention
         run: npm run release:test
@@ -26,5 +33,15 @@ jobs:
       - name: Match tag to package version
         env:
           PACKAGE_PATH: ${{ inputs.package-path }}
-          RELEASE_TAG: ${{ github.ref_name }}
+          RELEASE_TAG: ${{ inputs.release-tag || github.ref_name }}
         run: node scripts/validate-release-tag.mjs "$PACKAGE_PATH" "$RELEASE_TAG"
+
+      - name: Match package content to release tag
+        env:
+          PACKAGE_PATH: ${{ inputs.package-path }}
+          RELEASE_TAG: ${{ inputs.release-tag || github.ref_name }}
+        run: |
+          if ! git diff --quiet "$RELEASE_TAG" -- "$PACKAGE_PATH"; then
+            echo "::error::$PACKAGE_PATH differs from $RELEASE_TAG at the workflow ref."
+            exit 1
+          fi

--- a/.github/workflows/cd-health-connector-core.yaml
+++ b/.github/workflows/cd-health-connector-core.yaml
@@ -10,6 +10,12 @@ on:
       - 'health_connector_core-v[0-9]+.[0-9]+.[0-9]+-beta.[0-9]+'
       - 'health_connector_core-v[0-9]+.[0-9]+.[0-9]+-rc'
       - 'health_connector_core-v[0-9]+.[0-9]+.[0-9]+-rc.[0-9]+'
+  workflow_dispatch:
+    inputs:
+      release_tag:
+        description: 'Existing health_connector_core release tag to recover'
+        type: string
+        required: true
 
 permissions:
   contents: read
@@ -24,6 +30,7 @@ jobs:
     uses: ./.github/workflows/_reusable-release-validation.yaml
     with:
       package-path: packages/health_connector_core
+      release-tag: ${{ inputs.release_tag || github.ref_name }}
 
   dart-quality:
     needs: release-validation
@@ -42,3 +49,4 @@ jobs:
     uses: ./.github/workflows/_reusable-publish.yaml
     with:
       package-path: packages/health_connector_core
+      release-tag: ${{ inputs.release_tag || github.ref_name }}

--- a/.github/workflows/cd-health-connector-hc-android.yaml
+++ b/.github/workflows/cd-health-connector-hc-android.yaml
@@ -10,6 +10,12 @@ on:
       - 'health_connector_hc_android-v[0-9]+.[0-9]+.[0-9]+-beta.[0-9]+'
       - 'health_connector_hc_android-v[0-9]+.[0-9]+.[0-9]+-rc'
       - 'health_connector_hc_android-v[0-9]+.[0-9]+.[0-9]+-rc.[0-9]+'
+  workflow_dispatch:
+    inputs:
+      release_tag:
+        description: 'Existing health_connector_hc_android release tag to recover'
+        type: string
+        required: true
 
 permissions:
   contents: read
@@ -25,6 +31,7 @@ jobs:
     uses: ./.github/workflows/_reusable-release-validation.yaml
     with:
       package-path: packages/health_connector_hc_android
+      release-tag: ${{ inputs.release_tag || github.ref_name }}
 
   dart-quality:
     needs: release-validation
@@ -63,3 +70,4 @@ jobs:
     uses: ./.github/workflows/_reusable-publish.yaml
     with:
       package-path: packages/health_connector_hc_android
+      release-tag: ${{ inputs.release_tag || github.ref_name }}

--- a/.github/workflows/cd-health-connector-hk-ios.yaml
+++ b/.github/workflows/cd-health-connector-hk-ios.yaml
@@ -10,6 +10,12 @@ on:
       - 'health_connector_hk_ios-v[0-9]+.[0-9]+.[0-9]+-beta.[0-9]+'
       - 'health_connector_hk_ios-v[0-9]+.[0-9]+.[0-9]+-rc'
       - 'health_connector_hk_ios-v[0-9]+.[0-9]+.[0-9]+-rc.[0-9]+'
+  workflow_dispatch:
+    inputs:
+      release_tag:
+        description: 'Existing health_connector_hk_ios release tag to recover'
+        type: string
+        required: true
 
 permissions:
   contents: read
@@ -24,6 +30,7 @@ jobs:
     uses: ./.github/workflows/_reusable-release-validation.yaml
     with:
       package-path: packages/health_connector_hk_ios
+      release-tag: ${{ inputs.release_tag || github.ref_name }}
 
   dart-quality:
     needs: release-validation
@@ -54,3 +61,4 @@ jobs:
     uses: ./.github/workflows/_reusable-publish.yaml
     with:
       package-path: packages/health_connector_hk_ios
+      release-tag: ${{ inputs.release_tag || github.ref_name }}

--- a/.github/workflows/cd-health-connector-lint.yaml
+++ b/.github/workflows/cd-health-connector-lint.yaml
@@ -10,6 +10,12 @@ on:
       - 'health_connector_lint-v[0-9]+.[0-9]+.[0-9]+-beta.[0-9]+'
       - 'health_connector_lint-v[0-9]+.[0-9]+.[0-9]+-rc'
       - 'health_connector_lint-v[0-9]+.[0-9]+.[0-9]+-rc.[0-9]+'
+  workflow_dispatch:
+    inputs:
+      release_tag:
+        description: 'Existing health_connector_lint release tag to recover'
+        type: string
+        required: true
 
 permissions:
   contents: read
@@ -24,6 +30,7 @@ jobs:
     uses: ./.github/workflows/_reusable-release-validation.yaml
     with:
       package-path: packages/health_connector_lint
+      release-tag: ${{ inputs.release_tag || github.ref_name }}
 
   dart-quality:
     needs: release-validation
@@ -36,3 +43,4 @@ jobs:
     uses: ./.github/workflows/_reusable-publish.yaml
     with:
       package-path: packages/health_connector_lint
+      release-tag: ${{ inputs.release_tag || github.ref_name }}

--- a/.github/workflows/cd-health-connector-logger.yaml
+++ b/.github/workflows/cd-health-connector-logger.yaml
@@ -10,6 +10,12 @@ on:
       - 'health_connector_logger-v[0-9]+.[0-9]+.[0-9]+-beta.[0-9]+'
       - 'health_connector_logger-v[0-9]+.[0-9]+.[0-9]+-rc'
       - 'health_connector_logger-v[0-9]+.[0-9]+.[0-9]+-rc.[0-9]+'
+  workflow_dispatch:
+    inputs:
+      release_tag:
+        description: 'Existing health_connector_logger release tag to recover'
+        type: string
+        required: true
 
 permissions:
   contents: read
@@ -24,6 +30,7 @@ jobs:
     uses: ./.github/workflows/_reusable-release-validation.yaml
     with:
       package-path: packages/health_connector_logger
+      release-tag: ${{ inputs.release_tag || github.ref_name }}
 
   dart-quality:
     needs: release-validation
@@ -42,3 +49,4 @@ jobs:
     uses: ./.github/workflows/_reusable-publish.yaml
     with:
       package-path: packages/health_connector_logger
+      release-tag: ${{ inputs.release_tag || github.ref_name }}

--- a/.github/workflows/cd-health-connector.yaml
+++ b/.github/workflows/cd-health-connector.yaml
@@ -10,6 +10,12 @@ on:
       - 'health_connector-v[0-9]+.[0-9]+.[0-9]+-beta.[0-9]+'
       - 'health_connector-v[0-9]+.[0-9]+.[0-9]+-rc'
       - 'health_connector-v[0-9]+.[0-9]+.[0-9]+-rc.[0-9]+'
+  workflow_dispatch:
+    inputs:
+      release_tag:
+        description: 'Existing health_connector release tag to recover'
+        type: string
+        required: true
 
 permissions:
   contents: read
@@ -24,6 +30,7 @@ jobs:
     uses: ./.github/workflows/_reusable-release-validation.yaml
     with:
       package-path: packages/health_connector
+      release-tag: ${{ inputs.release_tag || github.ref_name }}
 
   dart-quality:
     needs: release-validation
@@ -54,3 +61,4 @@ jobs:
     uses: ./.github/workflows/_reusable-publish.yaml
     with:
       package-path: packages/health_connector
+      release-tag: ${{ inputs.release_tag || github.ref_name }}

--- a/docs/workflows/RELEASE.md
+++ b/docs/workflows/RELEASE.md
@@ -185,6 +185,9 @@ verification is required.
 - If `CD - release packages` fails because of a temporary error, rerun the entire workflow. It skips package tags that
   already exist and creates the missing tags.
 - If a package CD workflow fails because of a temporary error, rerun that workflow.
+- If a package CD workflow cannot start because its workflow configuration is invalid, fix the configuration through a
+  pull request. Then run that package workflow manually from `main` with its existing release tag. The workflow rejects
+  recovery when the package directory on `main` differs from the tag, so prepare a new version instead of moving the tag.
 - If code or package metadata is wrong after a tag exists, prepare a new version in a new pull request. Do not move or
   reuse the existing tag.
 - If a published package is wrong, prepare corrected versions for that package and affected dependents in a new pull


### PR DESCRIPTION
## Summary

- replace the unreachable `dart-lang/setup-dart` workflow commit with the reachable `v1.8.0` commit
- add manual package-workflow recovery for release tags that already exist
- reject recovery when the package directory on `main` differs from the supplied tag
- document the recovery path without moving or recreating tags

## Failure addressed

All six package CD workflows were rejected before job creation because GitHub could not resolve the pinned reusable publish workflow.

## Verification

- `go run github.com/rhysd/actionlint/cmd/actionlint@latest .github/workflows/*.yaml`
- `git diff --check`
- confirmed all six package workflows pass the release tag to validation and publication