### PR TITLE
fix(release): recreate unpublished package tags

### DIFF
--- a/.github/workflows/_reusable-publish.yaml
+++ b/.github/workflows/_reusable-publish.yaml
@@ -7,11 +7,6 @@ on:
         description: 'Path to the package to publish'
         type: string
         required: true
-      release-tag:
-        description: 'Release tag to validate; defaults to the triggering tag'
-        type: string
-        required: false
-        default: ''
 
 jobs:
   validate-release-tag:
@@ -25,25 +20,13 @@ jobs:
     steps:
       - name: Check out repository
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
-        with:
-          fetch-depth: 0
 
       - name: Match tag to package version
         id: release
         env:
           PACKAGE_PATH: ${{ inputs.package-path }}
-          RELEASE_TAG: ${{ inputs.release-tag || github.ref_name }}
+          RELEASE_TAG: ${{ github.ref_name }}
         run: node scripts/validate-release-tag.mjs "$PACKAGE_PATH" "$RELEASE_TAG"
-
-      - name: Match package content to release tag
-        env:
-          PACKAGE_PATH: ${{ inputs.package-path }}
-          RELEASE_TAG: ${{ inputs.release-tag || github.ref_name }}
-        run: |
-          if ! git diff --quiet "$RELEASE_TAG" -- "$PACKAGE_PATH"; then
-            echo "::error::$PACKAGE_PATH differs from $RELEASE_TAG at the workflow ref."
-            exit 1
-          fi
 
   wait-for-pub-dependencies:
     name: Wait for pub.dev dependencies

--- a/.github/workflows/_reusable-release-validation.yaml
+++ b/.github/workflows/_reusable-release-validation.yaml
@@ -7,11 +7,6 @@ on:
         description: 'Path to the package being released'
         type: string
         required: true
-      release-tag:
-        description: 'Release tag to validate; defaults to the triggering tag'
-        type: string
-        required: false
-        default: ''
 
 permissions:
   contents: read
@@ -24,8 +19,6 @@ jobs:
     steps:
       - name: Check out repository
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
-        with:
-          fetch-depth: 0
 
       - name: Test release version convention
         run: npm run release:test
@@ -33,15 +26,5 @@ jobs:
       - name: Match tag to package version
         env:
           PACKAGE_PATH: ${{ inputs.package-path }}
-          RELEASE_TAG: ${{ inputs.release-tag || github.ref_name }}
+          RELEASE_TAG: ${{ github.ref_name }}
         run: node scripts/validate-release-tag.mjs "$PACKAGE_PATH" "$RELEASE_TAG"
-
-      - name: Match package content to release tag
-        env:
-          PACKAGE_PATH: ${{ inputs.package-path }}
-          RELEASE_TAG: ${{ inputs.release-tag || github.ref_name }}
-        run: |
-          if ! git diff --quiet "$RELEASE_TAG" -- "$PACKAGE_PATH"; then
-            echo "::error::$PACKAGE_PATH differs from $RELEASE_TAG at the workflow ref."
-            exit 1
-          fi

--- a/.github/workflows/cd-health-connector-core.yaml
+++ b/.github/workflows/cd-health-connector-core.yaml
@@ -10,12 +10,6 @@ on:
       - 'health_connector_core-v[0-9]+.[0-9]+.[0-9]+-beta.[0-9]+'
       - 'health_connector_core-v[0-9]+.[0-9]+.[0-9]+-rc'
       - 'health_connector_core-v[0-9]+.[0-9]+.[0-9]+-rc.[0-9]+'
-  workflow_dispatch:
-    inputs:
-      release_tag:
-        description: 'Existing health_connector_core release tag to recover'
-        type: string
-        required: true
 
 permissions:
   contents: read
@@ -30,7 +24,6 @@ jobs:
     uses: ./.github/workflows/_reusable-release-validation.yaml
     with:
       package-path: packages/health_connector_core
-      release-tag: ${{ inputs.release_tag || github.ref_name }}
 
   dart-quality:
     needs: release-validation
@@ -49,4 +42,3 @@ jobs:
     uses: ./.github/workflows/_reusable-publish.yaml
     with:
       package-path: packages/health_connector_core
-      release-tag: ${{ inputs.release_tag || github.ref_name }}

--- a/.github/workflows/cd-health-connector-hc-android.yaml
+++ b/.github/workflows/cd-health-connector-hc-android.yaml
@@ -10,12 +10,6 @@ on:
       - 'health_connector_hc_android-v[0-9]+.[0-9]+.[0-9]+-beta.[0-9]+'
       - 'health_connector_hc_android-v[0-9]+.[0-9]+.[0-9]+-rc'
       - 'health_connector_hc_android-v[0-9]+.[0-9]+.[0-9]+-rc.[0-9]+'
-  workflow_dispatch:
-    inputs:
-      release_tag:
-        description: 'Existing health_connector_hc_android release tag to recover'
-        type: string
-        required: true
 
 permissions:
   contents: read
@@ -31,7 +25,6 @@ jobs:
     uses: ./.github/workflows/_reusable-release-validation.yaml
     with:
       package-path: packages/health_connector_hc_android
-      release-tag: ${{ inputs.release_tag || github.ref_name }}
 
   dart-quality:
     needs: release-validation
@@ -70,4 +63,3 @@ jobs:
     uses: ./.github/workflows/_reusable-publish.yaml
     with:
       package-path: packages/health_connector_hc_android
-      release-tag: ${{ inputs.release_tag || github.ref_name }}

--- a/.github/workflows/cd-health-connector-hk-ios.yaml
+++ b/.github/workflows/cd-health-connector-hk-ios.yaml
@@ -10,12 +10,6 @@ on:
       - 'health_connector_hk_ios-v[0-9]+.[0-9]+.[0-9]+-beta.[0-9]+'
       - 'health_connector_hk_ios-v[0-9]+.[0-9]+.[0-9]+-rc'
       - 'health_connector_hk_ios-v[0-9]+.[0-9]+.[0-9]+-rc.[0-9]+'
-  workflow_dispatch:
-    inputs:
-      release_tag:
-        description: 'Existing health_connector_hk_ios release tag to recover'
-        type: string
-        required: true
 
 permissions:
   contents: read
@@ -30,7 +24,6 @@ jobs:
     uses: ./.github/workflows/_reusable-release-validation.yaml
     with:
       package-path: packages/health_connector_hk_ios
-      release-tag: ${{ inputs.release_tag || github.ref_name }}
 
   dart-quality:
     needs: release-validation
@@ -61,4 +54,3 @@ jobs:
     uses: ./.github/workflows/_reusable-publish.yaml
     with:
       package-path: packages/health_connector_hk_ios
-      release-tag: ${{ inputs.release_tag || github.ref_name }}

--- a/.github/workflows/cd-health-connector-lint.yaml
+++ b/.github/workflows/cd-health-connector-lint.yaml
@@ -10,12 +10,6 @@ on:
       - 'health_connector_lint-v[0-9]+.[0-9]+.[0-9]+-beta.[0-9]+'
       - 'health_connector_lint-v[0-9]+.[0-9]+.[0-9]+-rc'
       - 'health_connector_lint-v[0-9]+.[0-9]+.[0-9]+-rc.[0-9]+'
-  workflow_dispatch:
-    inputs:
-      release_tag:
-        description: 'Existing health_connector_lint release tag to recover'
-        type: string
-        required: true
 
 permissions:
   contents: read
@@ -30,7 +24,6 @@ jobs:
     uses: ./.github/workflows/_reusable-release-validation.yaml
     with:
       package-path: packages/health_connector_lint
-      release-tag: ${{ inputs.release_tag || github.ref_name }}
 
   dart-quality:
     needs: release-validation
@@ -43,4 +36,3 @@ jobs:
     uses: ./.github/workflows/_reusable-publish.yaml
     with:
       package-path: packages/health_connector_lint
-      release-tag: ${{ inputs.release_tag || github.ref_name }}

--- a/.github/workflows/cd-health-connector-logger.yaml
+++ b/.github/workflows/cd-health-connector-logger.yaml
@@ -10,12 +10,6 @@ on:
       - 'health_connector_logger-v[0-9]+.[0-9]+.[0-9]+-beta.[0-9]+'
       - 'health_connector_logger-v[0-9]+.[0-9]+.[0-9]+-rc'
       - 'health_connector_logger-v[0-9]+.[0-9]+.[0-9]+-rc.[0-9]+'
-  workflow_dispatch:
-    inputs:
-      release_tag:
-        description: 'Existing health_connector_logger release tag to recover'
-        type: string
-        required: true
 
 permissions:
   contents: read
@@ -30,7 +24,6 @@ jobs:
     uses: ./.github/workflows/_reusable-release-validation.yaml
     with:
       package-path: packages/health_connector_logger
-      release-tag: ${{ inputs.release_tag || github.ref_name }}
 
   dart-quality:
     needs: release-validation
@@ -49,4 +42,3 @@ jobs:
     uses: ./.github/workflows/_reusable-publish.yaml
     with:
       package-path: packages/health_connector_logger
-      release-tag: ${{ inputs.release_tag || github.ref_name }}

--- a/.github/workflows/cd-health-connector.yaml
+++ b/.github/workflows/cd-health-connector.yaml
@@ -10,12 +10,6 @@ on:
       - 'health_connector-v[0-9]+.[0-9]+.[0-9]+-beta.[0-9]+'
       - 'health_connector-v[0-9]+.[0-9]+.[0-9]+-rc'
       - 'health_connector-v[0-9]+.[0-9]+.[0-9]+-rc.[0-9]+'
-  workflow_dispatch:
-    inputs:
-      release_tag:
-        description: 'Existing health_connector release tag to recover'
-        type: string
-        required: true
 
 permissions:
   contents: read
@@ -30,7 +24,6 @@ jobs:
     uses: ./.github/workflows/_reusable-release-validation.yaml
     with:
       package-path: packages/health_connector
-      release-tag: ${{ inputs.release_tag || github.ref_name }}
 
   dart-quality:
     needs: release-validation
@@ -61,4 +54,3 @@ jobs:
     uses: ./.github/workflows/_reusable-publish.yaml
     with:
       package-path: packages/health_connector
-      release-tag: ${{ inputs.release_tag || github.ref_name }}

--- a/docs/workflows/RELEASE.md
+++ b/docs/workflows/RELEASE.md
@@ -186,8 +186,8 @@ verification is required.
   already exist and creates the missing tags.
 - If a package CD workflow fails because of a temporary error, rerun that workflow.
 - If a package CD workflow cannot start because its workflow configuration is invalid, fix the configuration through a
-  pull request. Then run that package workflow manually from `main` with its existing release tag. The workflow rejects
-  recovery when the package directory on `main` differs from the tag, so prepare a new version instead of moving the tag.
+  pull request. If the package was not published, delete its failed tag and rerun `CD - release packages`; the workflow
+  recreates the missing tag from the fixed `main`. Never delete or recreate a tag after its package was published.
 - If code or package metadata is wrong after a tag exists, prepare a new version in a new pull request. Do not move or
   reuse the existing tag.
 - If a published package is wrong, prepare corrected versions for that package and affected dependents in a new pull
@@ -224,6 +224,7 @@ record completed releases and do not replace that gate.
 
 - Never publish a package locally.
 - Never run release validation locally.
-- Never create, move, or verify release tags manually.
+- Never create, move, or verify release tags manually. Delete an unpublished failed tag only for the configuration
+  recovery described above; `CD - release packages` recreates it.
 - Never verify pub.dev manually as part of the release flow.
 - Fix release failures through a pull request or rerun the failed workflow when the error is temporary.


### PR DESCRIPTION
## Summary

- keep the existing six package versions and changelogs unchanged
- retain the reachable `dart-lang/setup-dart` `v1.8.0` workflow pin
- remove manual package publishing because pub.dev accepts only matching tag-push workflows
- document deletion and automated recreation of unpublished failed tags

## Recovery

After this PR merges, delete only these unpublished failed tags and rerun `CD - release packages` so CI recreates them from fixed `main`:

- `health_connector_lint-v1.2.1`
- `health_connector_logger-v4.0.1`
- `health_connector_core-v3.9.3`
- `health_connector_hc_android-v3.6.3`
- `health_connector_hk_ios-v3.9.3`
- `health_connector-v3.9.5`

No version or changelog replacement is introduced.

## Verification

- `go run github.com/rhysd/actionlint/cmd/actionlint@latest .github/workflows/*.yaml`
- `git diff --check origin/main`
- full release validation intentionally left to CI per `docs/workflows/RELEASE.md`