### PR TITLE
feat(hc_android): support built-in Kotlin before Flutter 3.44

### DIFF
--- a/packages/health_connector_hc_android/CHANGELOG.md
+++ b/packages/health_connector_hc_android/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Unreleased
+
+- **FEAT**: Support built-in Kotlin for Flutter versions earlier than 3.44.
+
 ## 3.6.3
 
 - **CHORE**: Migrate the package from the Apache 2.0 License to the MIT License.

--- a/packages/health_connector_hc_android/android/build.gradle
+++ b/packages/health_connector_hc_android/android/build.gradle
@@ -1,5 +1,7 @@
 import io.gitlab.arturbosch.detekt.Detekt
 import io.gitlab.arturbosch.detekt.DetektCreateBaselineTask
+import org.jetbrains.kotlin.gradle.dsl.JvmTarget
+import org.jetbrains.kotlin.gradle.dsl.KotlinAndroidProjectExtension
 
 group = "com.phamtunglam.health_connector_hc_android"
 version = "1.0-SNAPSHOT"
@@ -47,7 +49,15 @@ allprojects {
 }
 
 apply plugin: "com.android.library"
-apply plugin: "kotlin-android"
+
+def agpMajor = com.android.Version.ANDROID_GRADLE_PLUGIN_VERSION.tokenize(".")[0] as int
+
+if (agpMajor < 9) {
+    // Flutter 3.44.9 scans literal `apply plugin:` calls without evaluating this AGP guard.
+    // Keep this form until the scanner recognizes guarded KGP application.
+    project.pluginManager.apply("org.jetbrains.kotlin.android")
+}
+
 apply plugin: "org.jlleitschuh.gradle.ktlint"
 apply plugin: "io.gitlab.arturbosch.detekt"
 
@@ -130,10 +140,6 @@ android {
         targetCompatibility = JavaVersion.VERSION_11
     }
 
-    kotlinOptions {
-        jvmTarget = JavaVersion.VERSION_11
-    }
-
     sourceSets {
         main.java.srcDirs += "src/main/kotlin"
         test.java.srcDirs += "src/test/kotlin"
@@ -211,4 +217,8 @@ android {
             includeAndroidResources = true
         }
     }
+}
+
+project.extensions.configure(KotlinAndroidProjectExtension) { kotlinExtension ->
+    kotlinExtension.compilerOptions.jvmTarget.set(JvmTarget.JVM_11)
 }


### PR DESCRIPTION
## Summary

- Follow Flutter's transitional plugin-author path for supporting Flutter versions earlier than 3.44.
- Detect the host Android Gradle Plugin version and apply KGP from `health_connector_hc_android` only when AGP is earlier than 9.
- Configure Kotlin through `KotlinAndroidProjectExtension.compilerOptions`, preserve JVM 11 alignment, and leave all SDK constraints unchanged.

## Test plan

- Built debug APKs for all three Flutter 3.35.7 Android hosts.
- Compiled and built with Flutter 3.44.9, AGP 9.3.1, Gradle 9.7, and `android.builtInKotlin=false`; the plugin's AGP 9 branch applied neither KGP nor built-in Kotlin and emitted no incompatible-plugin warning.
- Ran `fvm dart run melos run format:check`.
- Ran `fvm dart run melos run analyze:strict`.
- Ran `fvm dart run melos run test:dart`.
- Ran `fvm dart run melos run test:kotlin`.

Fixes #203
