### PR TITLE
chore(release): prepare package releases

### DIFF
--- a/examples/health_connector_toolbox/pubspec.yaml
+++ b/examples/health_connector_toolbox/pubspec.yaml
@@ -10,7 +10,7 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  health_connector: ^3.9.5
+  health_connector: ^3.10.0
   intl: ^0.19.0
   provider: ^6.1.5+1
   shared_preferences: ^2.5.4

--- a/packages/health_connector/CHANGELOG.md
+++ b/packages/health_connector/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 3.10.0
+
+- **FEAT**(hc_android): Support built-in Kotlin for Flutter versions earlier than 3.44. ([32949a7a](https://github.com/fam-tung-lam/health_connector/commit/32949a7a652e9de99056d04f11ff26951e00ea54))
+- **FIX**(hk_ios): Declare that the iOS plugin does not collect HealthKit data in its privacy manifest. ([b47453f1](https://github.com/fam-tung-lam/health_connector/commit/b47453f1f88577ef76b061156abcb14597a6f18a))
+
 ## 3.9.5
 
 - **CHORE**: Migrate the Health Connector SDK packages from the Apache 2.0 License to the MIT License.

--- a/packages/health_connector/pubspec.yaml
+++ b/packages/health_connector/pubspec.yaml
@@ -1,7 +1,7 @@
 name: health_connector
 resolution: workspace
 description: The most comprehensive Flutter health SDK for seamless iOS HealthKit and Android Health Connect integration.
-version: 3.9.5
+version: 3.10.0
 homepage: https://github.com/fam-tung-lam/health_connector
 repository: https://github.com/fam-tung-lam/health_connector/tree/main/packages/health_connector
 issue_tracker: https://github.com/fam-tung-lam/health_connector/issues?q=is%3Aissue%20is%3Aopen
@@ -14,8 +14,8 @@ dependencies:
   flutter:
     sdk: flutter
   health_connector_core: ^3.9.3
-  health_connector_hc_android: ^3.6.3
-  health_connector_hk_ios: ^3.9.3
+  health_connector_hc_android: ^3.7.0
+  health_connector_hk_ios: ^3.9.4
   health_connector_logger: ^4.0.1
   meta: ^1.16.0
 

--- a/packages/health_connector_hc_android/CHANGELOG.md
+++ b/packages/health_connector_hc_android/CHANGELOG.md
@@ -1,6 +1,6 @@
-## Unreleased
+## 3.7.0
 
-- **FEAT**: Support built-in Kotlin for Flutter versions earlier than 3.44.
+- **FEAT**: Support built-in Kotlin for Flutter versions earlier than 3.44. ([32949a7a](https://github.com/fam-tung-lam/health_connector/commit/32949a7a652e9de99056d04f11ff26951e00ea54))
 
 ## 3.6.3
 

--- a/packages/health_connector_hc_android/pubspec.yaml
+++ b/packages/health_connector_hc_android/pubspec.yaml
@@ -1,7 +1,7 @@
 name: health_connector_hc_android
 resolution: workspace
 description: Android implementation of health_connector using Health Connect
-version: 3.6.3
+version: 3.7.0
 repository: https://github.com/fam-tung-lam/health_connector/tree/main/packages/health_connector_hc_android
 issue_tracker: https://github.com/fam-tung-lam/health_connector/issues?q=is%3Aissue%20is%3Aopen
 

--- a/packages/health_connector_hk_ios/CHANGELOG.md
+++ b/packages/health_connector_hk_ios/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 3.9.4
+
+- **FIX**: Declare that the iOS plugin does not collect HealthKit data in its privacy manifest. ([b47453f1](https://github.com/fam-tung-lam/health_connector/commit/b47453f1f88577ef76b061156abcb14597a6f18a))
+
 ## 3.9.3
 
 - **CHORE**: Migrate the package from the Apache 2.0 License to the MIT License.

--- a/packages/health_connector_hk_ios/pubspec.yaml
+++ b/packages/health_connector_hk_ios/pubspec.yaml
@@ -1,7 +1,7 @@
 name: health_connector_hk_ios
 resolution: workspace
 description: iOS implementation of health_connector using HealthKit
-version: 3.9.3
+version: 3.9.4
 repository: https://github.com/fam-tung-lam/health_connector/tree/main/packages/health_connector_hk_ios
 issue_tracker: https://github.com/fam-tung-lam/health_connector/issues?q=is%3Aissue%20is%3Aopen
 


### PR DESCRIPTION
## Packages

- health_connector_hc_android 3.7.0
- health_connector_hk_ios 3.9.4
- health_connector 3.10.0

## Changes

- Release built-in Kotlin compatibility for Flutter versions earlier than 3.44.
- Release the corrected iOS privacy manifest declaration.
- Update the facade and toolbox dependency constraints.
- Add package-specific and consumer-facing changelog entries.

## Breaking changes

None.

## Migration guides

None.

## Verification

- git diff --check
- Release validation intentionally deferred to CI per docs/workflows/RELEASE.md.