### PR TITLE
fix(exercise): distinguish indoor and outdoor cycling

### DIFF
--- a/examples/health_connector_toolbox/lib/src/common/constants/app_texts.dart
+++ b/examples/health_connector_toolbox/lib/src/common/constants/app_texts.dart
@@ -1231,7 +1231,8 @@ abstract final class AppTexts {
   // Exercise Types - Common (Android + iOS)
   static const String exerciseRunning = 'Running';
   static const String exerciseWalking = 'Walking';
-  static const String exerciseCycling = 'Cycling';
+  static const String exerciseCycling = 'Outdoor Cycling';
+  static const String exerciseBikingStationary = 'Indoor Cycling';
   static const String exerciseHiking = 'Hiking';
   static const String exerciseSwimming = 'Swimming';
   static const String exerciseSurfing = 'Surfing';
@@ -1316,7 +1317,6 @@ abstract final class AppTexts {
 
   // Health Connect specific or new cross-platform types
   static const String exerciseOtherWorkout = 'Other Workout';
-  static const String exerciseBikingStationary = 'Stationary Biking';
   static const String exerciseBootCamp = 'Boot Camp';
   static const String exerciseExerciseClass = 'Exercise Class';
   static const String exerciseFrisbeeDisc = 'Frisbee Disc';

--- a/examples/health_connector_toolbox/test/src/common/utils/extensions/exercise_type_extension_test.dart
+++ b/examples/health_connector_toolbox/test/src/common/utils/extensions/exercise_type_extension_test.dart
@@ -1,0 +1,12 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:health_connector/health_connector_internal.dart';
+import 'package:health_connector_toolbox/src/common/utils/extensions/exercise_type_extension.dart';
+
+void main() {
+  group('ExerciseTypeDisplayName', () {
+    test('uses explicit cycling environment names', () {
+      expect(ExerciseType.cycling.displayName, 'Outdoor Cycling');
+      expect(ExerciseType.cyclingStationary.displayName, 'Indoor Cycling');
+    });
+  });
+}

--- a/packages/health_connector/CHANGELOG.md
+++ b/packages/health_connector/CHANGELOG.md
@@ -1,3 +1,10 @@
+## Unreleased
+
+- **FIX**: Define `ExerciseType.cycling` as outdoor cycling and
+  `ExerciseType.cyclingStationary` as indoor cycling across HealthKit and
+  Health Connect
+  ([#218](https://github.com/fam-tung-lam/health_connector/issues/218)).
+
 ## 3.10.0
 
 - **FEAT**(hc_android): Support built-in Kotlin for Flutter versions earlier than 3.44. ([32949a7a](https://github.com/fam-tung-lam/health_connector/commit/32949a7a652e9de99056d04f11ff26951e00ea54))

--- a/packages/health_connector_core/CHANGELOG.md
+++ b/packages/health_connector_core/CHANGELOG.md
@@ -1,3 +1,10 @@
+## Unreleased
+
+- **FIX**: Define `ExerciseType.cycling` as outdoor cycling and
+  `ExerciseType.cyclingStationary` as indoor cycling, with both types supported
+  on HealthKit and Health Connect
+  ([#218](https://github.com/fam-tung-lam/health_connector/issues/218)).
+
 ## 3.9.3
 
 - **CHORE**: Migrate the package from the Apache 2.0 License to the MIT License.

--- a/packages/health_connector_core/lib/src/models/health_records/exercise/exercise_type.dart
+++ b/packages/health_connector_core/lib/src/models/health_records/exercise/exercise_type.dart
@@ -70,21 +70,20 @@ enum ExerciseType {
   /// - **Android Health Connect**: `EXERCISE_TYPE_WALKING`
   walking,
 
-  /// Cycling or biking activity.
+  /// Outdoor cycling or biking activity.
   ///
   /// **Platform Mappings:**
-  /// - **iOS HealthKit**: `HKWorkoutActivityType.cycling`
+  /// - **iOS HealthKit**: `HKWorkoutActivityType.cycling` when
+  ///   `HKMetadataKeyIndoorWorkout` is `false`, missing, or invalid
   /// - **Android Health Connect**: `EXERCISE_TYPE_BIKING`
   cycling,
 
-  /// Stationary cycling or biking.
+  /// Stationary cycling or biking, normalized as indoor cycling.
   ///
   /// **Platform Mappings:**
-  /// - **iOS HealthKit**: Not supported
+  /// - **iOS HealthKit**: `HKWorkoutActivityType.cycling` with
+  ///   `HKMetadataKeyIndoorWorkout == true`
   /// - **Android Health Connect**: `EXERCISE_TYPE_BIKING_STATIONARY`
-  ///
-  /// Throws [UnsupportedOperationException] on iOS HealthKit.
-  @supportedOnHealthConnect
   cyclingStationary,
 
   /// Hiking activity.
@@ -1015,7 +1014,7 @@ extension ExerciseTypeExtension on ExerciseType {
   /// final androidOnlyTypes = ExerciseType.other.getExerciseTypesForPlatform(
   ///   HealthPlatform.healthConnect,
   /// );
-  /// // Returns: [runningTreadmill, cyclingStationary, weightlifting, ...]
+  /// // Returns: [runningTreadmill, weightlifting, ...]
   /// ```
   List<ExerciseType> getExerciseTypesForPlatform(HealthPlatform platform) {
     switch (platform) {
@@ -1031,7 +1030,6 @@ extension ExerciseTypeExtension on ExerciseType {
   /// on the enum values.
   static const Set<ExerciseType> _healthConnectOnlyTypes = {
     ExerciseType.runningTreadmill,
-    ExerciseType.cyclingStationary,
     ExerciseType.swimmingOpenWater,
     ExerciseType.swimmingPool,
     ExerciseType.weightlifting,

--- a/packages/health_connector_core/test/src/models/health_records/exercise/exercise_type_test.dart
+++ b/packages/health_connector_core/test/src/models/health_records/exercise/exercise_type_test.dart
@@ -65,6 +65,24 @@ void main() {
         expect(intersection, isEmpty);
       });
 
+      parameterizedTest(
+        'cycling environment types are supported on both platforms',
+        [
+          [ExerciseType.cycling],
+          [ExerciseType.cyclingStationary],
+        ],
+        (ExerciseType type) {
+          expect(
+            type.isSupportedOnPlatform(HealthPlatform.appleHealth),
+            isTrue,
+          );
+          expect(
+            type.isSupportedOnPlatform(HealthPlatform.healthConnect),
+            isTrue,
+          );
+        },
+      );
+
       test('every ExerciseType is in at most one platform-only list', () {
         final appleOnly = ExerciseType.other.getExerciseTypesForPlatform(
           HealthPlatform.appleHealth,

--- a/packages/health_connector_hc_android/CHANGELOG.md
+++ b/packages/health_connector_hc_android/CHANGELOG.md
@@ -1,3 +1,10 @@
+## Unreleased
+
+- **FIX**: Clarify that Health Connect biking maps to `ExerciseType.cycling`
+  (outdoor) and stationary biking maps to `ExerciseType.cyclingStationary`
+  (indoor)
+  ([#218](https://github.com/fam-tung-lam/health_connector/issues/218)).
+
 ## 3.7.0
 
 - **FEAT**: Support built-in Kotlin for Flutter versions earlier than 3.44. ([32949a7a](https://github.com/fam-tung-lam/health_connector/commit/32949a7a652e9de99056d04f11ff26951e00ea54))

--- a/packages/health_connector_hc_android/android/src/test/kotlin/com/phamtunglam/health_connector_hc_android/unit_tests/mappers/health_record_mappers/ExerciseTypeMapperTest.kt
+++ b/packages/health_connector_hc_android/android/src/test/kotlin/com/phamtunglam/health_connector_hc_android/unit_tests/mappers/health_record_mappers/ExerciseTypeMapperTest.kt
@@ -1,0 +1,50 @@
+package com.phamtunglam.health_connector_hc_android.unit_tests.mappers.health_record_mappers
+
+import androidx.health.connect.client.records.ExerciseSessionRecord
+import com.phamtunglam.health_connector_hc_android.mappers.health_record_mappers.toExerciseTypeDto
+import com.phamtunglam.health_connector_hc_android.mappers.health_record_mappers.toHealthConnectExerciseType
+import com.phamtunglam.health_connector_hc_android.pigeon.ExerciseTypeDto
+import io.kotest.matchers.shouldBe
+import java.util.stream.Stream
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.Arguments
+import org.junit.jupiter.params.provider.MethodSource
+
+@DisplayName("ExerciseTypeMapper")
+class ExerciseTypeMapperTest {
+
+    @ParameterizedTest
+    @MethodSource("provideCyclingMappings")
+    @DisplayName("GIVEN cycling DTO → WHEN mapped → THEN returns Health Connect type")
+    fun whenCyclingDtoToHealthConnect_thenMapsCorrectly(
+        dto: ExerciseTypeDto,
+        expectedHealthConnectType: Int,
+    ) {
+        dto.toHealthConnectExerciseType() shouldBe expectedHealthConnectType
+    }
+
+    @ParameterizedTest
+    @MethodSource("provideCyclingMappings")
+    @DisplayName("GIVEN Health Connect cycling type → WHEN mapped → THEN returns DTO")
+    fun whenHealthConnectCyclingToDto_thenMapsCorrectly(
+        expectedDto: ExerciseTypeDto,
+        healthConnectType: Int,
+    ) {
+        healthConnectType.toExerciseTypeDto() shouldBe expectedDto
+    }
+
+    companion object {
+        @JvmStatic
+        fun provideCyclingMappings(): Stream<Arguments> = Stream.of(
+            Arguments.of(
+                ExerciseTypeDto.CYCLING,
+                ExerciseSessionRecord.EXERCISE_TYPE_BIKING,
+            ),
+            Arguments.of(
+                ExerciseTypeDto.CYCLING_STATIONARY,
+                ExerciseSessionRecord.EXERCISE_TYPE_BIKING_STATIONARY,
+            ),
+        )
+    }
+}

--- a/packages/health_connector_hk_ios/CHANGELOG.md
+++ b/packages/health_connector_hk_ios/CHANGELOG.md
@@ -1,3 +1,10 @@
+## Unreleased
+
+- **FIX**: Distinguish indoor and outdoor cycling workouts using
+  `HKMetadataKeyIndoorWorkout`. Missing, invalid, or `false` metadata maps to
+  `ExerciseType.cycling`; `true` maps to `ExerciseType.cyclingStationary`
+  ([#218](https://github.com/fam-tung-lam/health_connector/issues/218)).
+
 ## 3.9.4
 
 - **FIX**: Declare that the iOS plugin does not collect HealthKit data in its privacy manifest. ([b47453f1](https://github.com/fam-tung-lam/health_connector/commit/b47453f1f88577ef76b061156abcb14597a6f18a))

--- a/packages/health_connector_hk_ios/ios/health_connector_hk_ios/Sources/health_connector_hk_ios/mappers/health_record_mappers/ExerciseSessionRecordMapper.swift
+++ b/packages/health_connector_hk_ios/ios/health_connector_hk_ios/Sources/health_connector_hk_ios/mappers/health_record_mappers/ExerciseSessionRecordMapper.swift
@@ -5,7 +5,13 @@ import HealthKit
 extension HKWorkout {
     /// Converts `HKWorkout` to `ExerciseSessionRecordDto`.
     func toHKWorkoutDto() throws -> ExerciseSessionRecordDto {
-        let exerciseType = workoutActivityType.toDto()
+        let exerciseType =
+            if workoutActivityType == .cycling,
+            metadata?[HKMetadataKeyIndoorWorkout] as? Bool == true {
+                ExerciseTypeDto.cyclingStationary
+            } else {
+                workoutActivityType.toDto()
+            }
 
         // Create builder from HK metadata with source and device
         var builder = MetadataBuilder(
@@ -62,6 +68,15 @@ extension ExerciseSessionRecordDto {
         }
         if let notes {
             builder.set(ExerciseSessionNotesKey.self, value: notes)
+        }
+
+        switch exerciseType {
+        case .cyclingStationary:
+            builder.set(standardKey: HKMetadataKeyIndoorWorkout, value: NSNumber(value: true))
+        case .cycling:
+            builder.set(standardKey: HKMetadataKeyIndoorWorkout, value: NSNumber(value: false))
+        default:
+            break
         }
 
         // Add timezone information for start time

--- a/packages/health_connector_hk_ios/ios/health_connector_hk_ios/Sources/health_connector_hk_ios/mappers/health_record_mappers/ExerciseTypeMapper.swift
+++ b/packages/health_connector_hk_ios/ios/health_connector_hk_ios/Sources/health_connector_hk_ios/mappers/health_record_mappers/ExerciseTypeMapper.swift
@@ -233,7 +233,7 @@ extension HKWorkoutActivityType {
             .running
         case .walking:
             .walking
-        case .cycling:
+        case .cycling, .cyclingStationary:
             .cycling
         case .hiking:
             .hiking

--- a/packages/health_connector_hk_ios/ios/health_connector_hk_ios/Sources/health_connector_hk_ios/pigeon/HealthConnectorHKIOSApi.g.swift
+++ b/packages/health_connector_hk_ios/ios/health_connector_hk_ios/Sources/health_connector_hk_ios/pigeon/HealthConnectorHKIOSApi.g.swift
@@ -641,6 +641,8 @@ public enum ExerciseTypeDto: Int {
   /// Multisport
   case transition = 78
   case swimBikeRun = 79
+  /// Stationary cycling, appended to preserve existing Pigeon enum indices.
+  case cyclingStationary = 80
 }
 
 /// Mindfulness session type classification.

--- a/packages/health_connector_hk_ios/lib/src/mappers/health_record_mappers/exercise/exercise_type_mapper.dart
+++ b/packages/health_connector_hk_ios/lib/src/mappers/health_record_mappers/exercise/exercise_type_mapper.dart
@@ -14,6 +14,7 @@ extension ExerciseTypeToDto on ExerciseType {
       ExerciseType.running => ExerciseTypeDto.running,
       ExerciseType.walking => ExerciseTypeDto.walking,
       ExerciseType.cycling => ExerciseTypeDto.cycling,
+      ExerciseType.cyclingStationary => ExerciseTypeDto.cyclingStationary,
       ExerciseType.hiking => ExerciseTypeDto.hiking,
 
       // Water Sports
@@ -116,7 +117,6 @@ extension ExerciseTypeToDto on ExerciseType {
 
       // Android Health Connect only types
       ExerciseType.runningTreadmill ||
-      ExerciseType.cyclingStationary ||
       ExerciseType.swimmingOpenWater ||
       ExerciseType.swimmingPool ||
       ExerciseType.weightlifting ||
@@ -147,6 +147,7 @@ extension ExerciseTypeDtoToDomain on ExerciseTypeDto {
       ExerciseTypeDto.running => ExerciseType.running,
       ExerciseTypeDto.walking => ExerciseType.walking,
       ExerciseTypeDto.cycling => ExerciseType.cycling,
+      ExerciseTypeDto.cyclingStationary => ExerciseType.cyclingStationary,
       ExerciseTypeDto.hiking => ExerciseType.hiking,
       // Water Sports
       ExerciseTypeDto.swimming => ExerciseType.swimming,

--- a/packages/health_connector_hk_ios/lib/src/pigeon/health_connector_hk_ios_api.g.dart
+++ b/packages/health_connector_hk_ios/lib/src/pigeon/health_connector_hk_ios_api.g.dart
@@ -665,6 +665,9 @@ enum ExerciseTypeDto {
   /// Multisport
   transition,
   swimBikeRun,
+
+  /// Stationary cycling, appended to preserve existing Pigeon enum indices.
+  cyclingStationary,
 }
 
 /// Mindfulness session type classification.

--- a/packages/health_connector_hk_ios/pigeon/health_connector_hk_ios_api.dart
+++ b/packages/health_connector_hk_ios/pigeon/health_connector_hk_ios_api.dart
@@ -694,6 +694,9 @@ enum ExerciseTypeDto {
   /// Multisport
   transition,
   swimBikeRun,
+
+  /// Stationary cycling, appended to preserve existing Pigeon enum indices.
+  cyclingStationary,
 }
 
 /// Mindfulness session type classification.

--- a/packages/health_connector_hk_ios/test/unit_tests/src/mappers/health_record_mappers/exercise/exercise_type_mapper_test.dart
+++ b/packages/health_connector_hk_ios/test/unit_tests/src/mappers/health_record_mappers/exercise/exercise_type_mapper_test.dart
@@ -18,6 +18,10 @@ void main() {
               [ExerciseType.running, ExerciseTypeDto.running],
               [ExerciseType.walking, ExerciseTypeDto.walking],
               [ExerciseType.cycling, ExerciseTypeDto.cycling],
+              [
+                ExerciseType.cyclingStationary,
+                ExerciseTypeDto.cyclingStationary,
+              ],
               [ExerciseType.hiking, ExerciseTypeDto.hiking],
               // Water Sports
               [ExerciseType.swimming, ExerciseTypeDto.swimming],
@@ -136,10 +140,6 @@ void main() {
                 throwsA(isA<ArgumentError>()),
               );
               expect(
-                () => ExerciseType.cyclingStationary.toDto(),
-                throwsA(isA<ArgumentError>()),
-              );
-              expect(
                 () => ExerciseType.swimmingOpenWater.toDto(),
                 throwsA(isA<ArgumentError>()),
               );
@@ -210,6 +210,10 @@ void main() {
               [ExerciseTypeDto.running, ExerciseType.running],
               [ExerciseTypeDto.walking, ExerciseType.walking],
               [ExerciseTypeDto.cycling, ExerciseType.cycling],
+              [
+                ExerciseTypeDto.cyclingStationary,
+                ExerciseType.cyclingStationary,
+              ],
               [ExerciseTypeDto.hiking, ExerciseType.hiking],
               // Water Sports
               [ExerciseTypeDto.swimming, ExerciseType.swimming],


### PR DESCRIPTION
## Summary

- define the existing `ExerciseType.cycling` as outdoor cycling
- define the existing `ExerciseType.cyclingStationary` as indoor cycling and support it on iOS
- read HealthKit cycling metadata strictly: `true` maps to `cyclingStationary`; `false`, missing, or invalid values map to `cycling`
- write `HKMetadataKeyIndoorWorkout` explicitly for both cycling types
- retain the existing Android mappings to `EXERCISE_TYPE_BIKING` and `EXERCISE_TYPE_BIKING_STATIONARY`
- label the two existing cycling types as Outdoor Cycling and Indoor Cycling in Health Connector Toolbox
- update every affected unreleased changelog section

## Compatibility

- no new public `ExerciseType` cases
- no deprecations
- no downstream exhaustive-switch break
- existing Android behavior is unchanged

## Testing

- core cycling platform-support tests
- Android Dart exercise-type mapper tests: 120 passed
- iOS Dart exercise-type mapper tests: 159 passed
- Android native cycling mapper tests: 4 passed
- Health Connector Toolbox cycling-label test
- iOS simulator build
- Dart analysis for core, Android, iOS, and Toolbox
- SwiftFormat and SwiftLint
- ktlint and detekt

Native Swift unit tests were intentionally not added in this PR.

Closes #218