### PR TITLE
chore(release): prepare health_connector 3.10.1

### DIFF
--- a/examples/health_connector_toolbox/pubspec.yaml
+++ b/examples/health_connector_toolbox/pubspec.yaml
@@ -10,7 +10,7 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  health_connector: ^3.10.0
+  health_connector: ^3.10.1
   intl: ^0.19.0
   provider: ^6.1.5+1
   shared_preferences: ^2.5.4

--- a/packages/health_connector/CHANGELOG.md
+++ b/packages/health_connector/CHANGELOG.md
@@ -1,9 +1,10 @@
-## Unreleased
+## 3.10.1
 
 - **FIX**: Define `ExerciseType.cycling` as outdoor cycling and
   `ExerciseType.cyclingStationary` as indoor cycling across HealthKit and
   Health Connect
-  ([#218](https://github.com/fam-tung-lam/health_connector/issues/218)).
+  ([#218](https://github.com/fam-tung-lam/health_connector/issues/218),
+  [e5e0796d](https://github.com/fam-tung-lam/health_connector/commit/e5e0796d4de3c4850785d7e7ec29d9748414fdd7)).
 
 ## 3.10.0
 

--- a/packages/health_connector/pubspec.yaml
+++ b/packages/health_connector/pubspec.yaml
@@ -1,7 +1,7 @@
 name: health_connector
 resolution: workspace
 description: The most comprehensive Flutter health SDK for seamless iOS HealthKit and Android Health Connect integration.
-version: 3.10.0
+version: 3.10.1
 homepage: https://github.com/fam-tung-lam/health_connector
 repository: https://github.com/fam-tung-lam/health_connector/tree/main/packages/health_connector
 issue_tracker: https://github.com/fam-tung-lam/health_connector/issues?q=is%3Aissue%20is%3Aopen
@@ -13,9 +13,9 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  health_connector_core: ^3.9.3
-  health_connector_hc_android: ^3.7.0
-  health_connector_hk_ios: ^3.9.4
+  health_connector_core: ^3.9.4
+  health_connector_hc_android: ^3.7.1
+  health_connector_hk_ios: ^3.9.5
   health_connector_logger: ^4.0.1
   meta: ^1.16.0
 

--- a/packages/health_connector_core/CHANGELOG.md
+++ b/packages/health_connector_core/CHANGELOG.md
@@ -1,9 +1,10 @@
-## Unreleased
+## 3.9.4
 
 - **FIX**: Define `ExerciseType.cycling` as outdoor cycling and
   `ExerciseType.cyclingStationary` as indoor cycling, with both types supported
   on HealthKit and Health Connect
-  ([#218](https://github.com/fam-tung-lam/health_connector/issues/218)).
+  ([#218](https://github.com/fam-tung-lam/health_connector/issues/218),
+  [e5e0796d](https://github.com/fam-tung-lam/health_connector/commit/e5e0796d4de3c4850785d7e7ec29d9748414fdd7)).
 
 ## 3.9.3
 

--- a/packages/health_connector_core/pubspec.yaml
+++ b/packages/health_connector_core/pubspec.yaml
@@ -1,7 +1,7 @@
 name: health_connector_core
 resolution: workspace
 description: Core models, utilities, and platform interface for Health Connector
-version: 3.9.3
+version: 3.9.4
 repository: https://github.com/fam-tung-lam/health_connector/tree/main/packages/health_connector_core
 issue_tracker: https://github.com/fam-tung-lam/health_connector/issues?q=is%3Aissue%20is%3Aopen
 

--- a/packages/health_connector_hc_android/CHANGELOG.md
+++ b/packages/health_connector_hc_android/CHANGELOG.md
@@ -1,9 +1,10 @@
-## Unreleased
+## 3.7.1
 
 - **FIX**: Clarify that Health Connect biking maps to `ExerciseType.cycling`
   (outdoor) and stationary biking maps to `ExerciseType.cyclingStationary`
   (indoor)
-  ([#218](https://github.com/fam-tung-lam/health_connector/issues/218)).
+  ([#218](https://github.com/fam-tung-lam/health_connector/issues/218),
+  [e5e0796d](https://github.com/fam-tung-lam/health_connector/commit/e5e0796d4de3c4850785d7e7ec29d9748414fdd7)).
 
 ## 3.7.0
 

--- a/packages/health_connector_hc_android/example/pubspec.yaml
+++ b/packages/health_connector_hc_android/example/pubspec.yaml
@@ -9,7 +9,7 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  health_connector_core: ^3.9.3
+  health_connector_core: ^3.9.4
   health_connector_hc_android:
     path: ../
 

--- a/packages/health_connector_hc_android/pubspec.yaml
+++ b/packages/health_connector_hc_android/pubspec.yaml
@@ -1,7 +1,7 @@
 name: health_connector_hc_android
 resolution: workspace
 description: Android implementation of health_connector using Health Connect
-version: 3.7.0
+version: 3.7.1
 repository: https://github.com/fam-tung-lam/health_connector/tree/main/packages/health_connector_hc_android
 issue_tracker: https://github.com/fam-tung-lam/health_connector/issues?q=is%3Aissue%20is%3Aopen
 
@@ -12,7 +12,7 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  health_connector_core: ^3.9.3
+  health_connector_core: ^3.9.4
   health_connector_logger: ^4.0.1
   meta: ^1.16.0
 

--- a/packages/health_connector_hk_ios/CHANGELOG.md
+++ b/packages/health_connector_hk_ios/CHANGELOG.md
@@ -1,9 +1,10 @@
-## Unreleased
+## 3.9.5
 
 - **FIX**: Distinguish indoor and outdoor cycling workouts using
   `HKMetadataKeyIndoorWorkout`. Missing, invalid, or `false` metadata maps to
   `ExerciseType.cycling`; `true` maps to `ExerciseType.cyclingStationary`
-  ([#218](https://github.com/fam-tung-lam/health_connector/issues/218)).
+  ([#218](https://github.com/fam-tung-lam/health_connector/issues/218),
+  [e5e0796d](https://github.com/fam-tung-lam/health_connector/commit/e5e0796d4de3c4850785d7e7ec29d9748414fdd7)).
 
 ## 3.9.4
 

--- a/packages/health_connector_hk_ios/example/pubspec.yaml
+++ b/packages/health_connector_hk_ios/example/pubspec.yaml
@@ -9,7 +9,7 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  health_connector_core: ^3.9.3
+  health_connector_core: ^3.9.4
   health_connector_hk_ios:
     path: ../
 

--- a/packages/health_connector_hk_ios/pubspec.yaml
+++ b/packages/health_connector_hk_ios/pubspec.yaml
@@ -1,7 +1,7 @@
 name: health_connector_hk_ios
 resolution: workspace
 description: iOS implementation of health_connector using HealthKit
-version: 3.9.4
+version: 3.9.5
 repository: https://github.com/fam-tung-lam/health_connector/tree/main/packages/health_connector_hk_ios
 issue_tracker: https://github.com/fam-tung-lam/health_connector/issues?q=is%3Aissue%20is%3Aopen
 
@@ -12,7 +12,7 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  health_connector_core: ^3.9.3
+  health_connector_core: ^3.9.4
   health_connector_logger: ^4.0.1
   meta: ^1.16.0
 


### PR DESCRIPTION
## Packages

- health_connector_core: 3.9.4
- health_connector_hc_android: 3.7.1
- health_connector_hk_ios: 3.9.5
- health_connector: 3.10.1

## Changes

- **FIX**: Define `ExerciseType.cycling` as outdoor cycling and `ExerciseType.cyclingStationary` as indoor cycling across HealthKit and Health Connect.

## Breaking changes

None.

## Migration guides

None.