### PR TITLE
feat(health-data): add Apple Stand Hour support

### DIFF
--- a/examples/health_connector_toolbox/lib/src/common/constants/app_texts.dart
+++ b/examples/health_connector_toolbox/lib/src/common/constants/app_texts.dart
@@ -208,6 +208,7 @@ abstract final class AppTexts {
       ExerciseTimeDataType() => exerciseTime,
       MoveTimeDataType() => moveTime,
       StandTimeDataType() => standTime,
+      AppleStandHourDataType() => appleStandHour,
       WalkingSteadinessDataType() => walkingSteadiness,
       WalkingAsymmetryPercentageDataType() => walkingAsymmetryPercentage,
       WalkingDoubleSupportPercentageDataType() =>
@@ -381,6 +382,9 @@ abstract final class AppTexts {
       'Amount of time spent moving actively';
   static const String standTime = 'Apple Stand Time';
   static const String standTimeDescription = 'Amount of time spent standing';
+  static const String appleStandHour = 'Apple Stand Hour';
+  static const String standGoalAchieved = 'Stand goal achieved';
+  static const String standGoalNotAchieved = 'Stand goal not achieved';
   static const String walkingAsymmetryPercentage = 'Walking Asymmetry';
   static const String walkingAsymmetryPercentageDescription =
       'Percentage of time the weight alternates between left and right feet '

--- a/examples/health_connector_toolbox/lib/src/common/utils/extensions/health_data_type_ui_extension.dart
+++ b/examples/health_connector_toolbox/lib/src/common/utils/extensions/health_data_type_ui_extension.dart
@@ -131,6 +131,7 @@ extension HealthDataTypeUI on HealthDataType {
       ExerciseTimeDataType _ => AppTexts.exerciseTime,
       MoveTimeDataType _ => AppTexts.moveTime,
       StandTimeDataType _ => AppTexts.standTime,
+      AppleStandHourDataType _ => AppTexts.appleStandHour,
       WalkingSteadinessDataType _ => 'Walking Steadiness',
       WalkingAsymmetryPercentageDataType _ =>
         AppTexts.walkingAsymmetryPercentage,
@@ -312,6 +313,8 @@ extension HealthDataTypeUI on HealthDataType {
       ExerciseTimeDataType _ => AppTexts.exerciseTimeDescription,
       MoveTimeDataType _ => AppTexts.moveTimeDescription,
       StandTimeDataType _ => AppTexts.standTimeDescription,
+      AppleStandHourDataType _ =>
+        'Whether the Stand or Roll goal was achieved during an hour (iOS only)',
       WalkingSteadinessDataType _ =>
         'Measure of walking stability and gait regularity (iOS only)',
       WalkingAsymmetryPercentageDataType _ =>
@@ -482,6 +485,7 @@ extension HealthDataTypeUI on HealthDataType {
       ExerciseTimeDataType _ => AppIcons.time,
       MoveTimeDataType _ => AppIcons.time,
       StandTimeDataType _ => AppIcons.time,
+      AppleStandHourDataType _ => AppIcons.directionsWalk,
       WalkingSteadinessDataType _ => AppIcons.directionsWalk,
       WalkingAsymmetryPercentageDataType _ => AppIcons.directionsWalk,
       WalkingDoubleSupportPercentageDataType _ => AppIcons.directionsWalk,

--- a/examples/health_connector_toolbox/lib/src/common/utils/measurement_unit_value_parser.dart
+++ b/examples/health_connector_toolbox/lib/src/common/utils/measurement_unit_value_parser.dart
@@ -21,6 +21,7 @@ abstract class MeasurementUnitValueParser {
       FloorsClimbedDataType() ||
       WheelchairPushesDataType() ||
       NumberOfTimesFallenDataType() ||
+      AppleStandHourDataType() ||
       HeartRateRecoveryOneMinuteDataType() ||
       SwimmingStrokesDataType() => _parseIntegerCount(value),
 

--- a/examples/health_connector_toolbox/lib/src/features/aggregate_health_data/aggregate_health_data_change_notifier.dart
+++ b/examples/health_connector_toolbox/lib/src/features/aggregate_health_data/aggregate_health_data_change_notifier.dart
@@ -114,6 +114,13 @@ final class AggregateDataChangeNotifier extends ChangeNotifier {
         ),
         metric,
       ),
+      AppleStandHourDataType() => _buildSum(
+        () => HealthDataType.appleStandHour.aggregateSum(
+          startTime: startTime,
+          endTime: endTime,
+        ),
+        metric,
+      ),
       ElectrodermalActivityDataType() => _buildAvgMinMax(
         () => HealthDataType.electrodermalActivity.aggregateAvg(
           startTime: startTime,

--- a/examples/health_connector_toolbox/lib/src/features/read_health_records/widgets/health_record_list_tiles/health_record_list_tile.dart
+++ b/examples/health_connector_toolbox/lib/src/features/read_health_records/widgets/health_record_list_tiles/health_record_list_tile.dart
@@ -26,6 +26,7 @@ import 'package:health_connector_toolbox/src/features/read_health_records/widget
 import 'package:health_connector_toolbox/src/features/read_health_records/widgets/health_record_list_tiles/instant_health_record_list_tiles/simple_instant_measurement_list_tile.dart';
 import 'package:health_connector_toolbox/src/features/read_health_records/widgets/health_record_list_tiles/instant_health_record_list_tiles/systolic_blood_pressure_list_tile.dart';
 import 'package:health_connector_toolbox/src/features/read_health_records/widgets/health_record_list_tiles/interval_health_record_list_tiles/alcoholic_beverages_list_tile.dart';
+import 'package:health_connector_toolbox/src/features/read_health_records/widgets/health_record_list_tiles/interval_health_record_list_tiles/apple_stand_hour_record_list_tile.dart';
 import 'package:health_connector_toolbox/src/features/read_health_records/widgets/health_record_list_tiles/interval_health_record_list_tiles/contraceptive_record_list_tile.dart';
 import 'package:health_connector_toolbox/src/features/read_health_records/widgets/health_record_list_tiles/interval_health_record_list_tiles/distance_activity_list_tile.dart';
 import 'package:health_connector_toolbox/src/features/read_health_records/widgets/health_record_list_tiles/interval_health_record_list_tiles/electrodermal_activity_list_tile.dart';
@@ -140,6 +141,7 @@ final class HealthRecordListTile extends StatelessWidget {
         WalkingSteadinessEventRecordListTile(
           record: r,
         ),
+      final AppleStandHourRecord r => AppleStandHourRecordListTile(record: r),
       final EnvironmentalAudioExposureEventRecord r =>
         SimpleIntervalMeasurementListTile<
           EnvironmentalAudioExposureEventRecord

--- a/examples/health_connector_toolbox/lib/src/features/read_health_records/widgets/health_record_list_tiles/interval_health_record_list_tiles/apple_stand_hour_record_list_tile.dart
+++ b/examples/health_connector_toolbox/lib/src/features/read_health_records/widgets/health_record_list_tiles/interval_health_record_list_tiles/apple_stand_hour_record_list_tile.dart
@@ -1,0 +1,34 @@
+import 'package:flutter/material.dart';
+import 'package:health_connector/health_connector_internal.dart';
+import 'package:health_connector_toolbox/src/common/constants/app_icons.dart';
+import 'package:health_connector_toolbox/src/common/constants/app_texts.dart';
+import 'package:health_connector_toolbox/src/features/read_health_records/widgets/health_record_list_tiles/health_record_list_tile_subtitle.dart';
+import 'package:health_connector_toolbox/src/features/read_health_records/widgets/health_record_list_tiles/interval_health_record_list_tiles/interval_health_record_list_tile.dart';
+
+/// Widget for displaying an Apple Stand Hour record.
+class AppleStandHourRecordListTile extends StatelessWidget {
+  const AppleStandHourRecordListTile({
+    required this.record,
+    super.key,
+  });
+
+  final AppleStandHourRecord record;
+
+  @override
+  Widget build(BuildContext context) {
+    return IntervalHealthRecordTile<AppleStandHourRecord>(
+      record: record,
+      icon: AppIcons.directionsWalk,
+      title: switch (record.status) {
+        AppleStandHourStatus.stood => AppTexts.standGoalAchieved,
+        AppleStandHourStatus.idle => AppTexts.standGoalNotAchieved,
+      },
+      subtitleBuilder: (r, ctx) => HealthRecordListTileSubtitle.interval(
+        startTime: r.startTime,
+        endTime: r.endTime,
+        recordingMethod: r.metadata.recordingMethod.name,
+      ),
+      detailRowsBuilder: (r, ctx) => [],
+    );
+  }
+}

--- a/examples/health_connector_toolbox/lib/src/features/write_health_record/pages/health_record_write_page.dart
+++ b/examples/health_connector_toolbox/lib/src/features/write_health_record/pages/health_record_write_page.dart
@@ -659,6 +659,9 @@ class _HealthRecordWritePageState extends State<HealthRecordWritePage>
       StandTimeDataType _ => throw UnsupportedError(
         'Apple Stand Time is read-only',
       ),
+      AppleStandHourDataType _ => throw UnsupportedError(
+        'Apple Stand Hour is read-only',
+      ),
       WalkingSteadinessDataType _ => throw UnsupportedError(
         'Apple Walking Steadiness is read-only',
       ),

--- a/packages/health_connector/CHANGELOG.md
+++ b/packages/health_connector/CHANGELOG.md
@@ -1,7 +1,10 @@
-## 3.10.1
+## Unreleased
 
 - **FEAT**: Add read and sum-aggregation support for Apple Stand Hour records
   on HealthKit ([#217](https://github.com/fam-tung-lam/health_connector/issues/217)).
+
+## 3.10.1
+
 - **FEAT**: Add runtime platform and OS requirement checks through
   `HealthConnector.getSupportStatusFor`, backed by an immutable
   `operatingSystemInfo` snapshot

--- a/packages/health_connector/CHANGELOG.md
+++ b/packages/health_connector/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## 3.10.1
 
+- **FEAT**: Add read and sum-aggregation support for Apple Stand Hour records
+  on HealthKit ([#217](https://github.com/fam-tung-lam/health_connector/issues/217)).
 - **FEAT**: Add runtime platform and OS requirement checks through
   `HealthConnector.getSupportStatusFor`, backed by an immutable
   `operatingSystemInfo` snapshot

--- a/packages/health_connector_core/CHANGELOG.md
+++ b/packages/health_connector_core/CHANGELOG.md
@@ -1,7 +1,10 @@
-## 3.9.4
+## Unreleased
 
 - **FEAT**: Add read and sum-aggregation support for Apple Stand Hour records
   on HealthKit ([#217](https://github.com/fam-tung-lam/health_connector/issues/217)).
+
+## 3.9.4
+
 - **FEAT**: Add runtime platform requirement, support status, and immutable
   operating-system information models
   ([#223](https://github.com/fam-tung-lam/health_connector/pull/223)).

--- a/packages/health_connector_core/CHANGELOG.md
+++ b/packages/health_connector_core/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## 3.9.4
 
+- **FEAT**: Add read and sum-aggregation support for Apple Stand Hour records
+  on HealthKit ([#217](https://github.com/fam-tung-lam/health_connector/issues/217)).
 - **FEAT**: Add runtime platform requirement, support status, and immutable
   operating-system information models
   ([#223](https://github.com/fam-tung-lam/health_connector/pull/223)).

--- a/packages/health_connector_core/lib/src/models/health_data_types/activity/apple_stand_hour_data_type.dart
+++ b/packages/health_connector_core/lib/src/models/health_data_types/activity/apple_stand_hour_data_type.dart
@@ -1,0 +1,110 @@
+part of '../health_data_type.dart';
+
+/// Apple Stand Hour data type.
+///
+/// Each record indicates whether the user stood and moved for at least one
+/// continuous minute during an hour. For wheelchair users, Apple Watch tracks
+/// Roll hours using the same HealthKit type.
+///
+/// > [!NOTE]
+/// > This data type is **read-only**. Apple Watch generates these records, and
+/// > third-party apps cannot write or delete them.
+///
+/// ## Platform Mapping
+///
+/// - **Android Health Connect**: Not supported
+/// - **iOS HealthKit**:
+///   [`HKCategoryTypeIdentifier.appleStandHour`](https://developer.apple.com/documentation/healthkit/hkcategorytypeidentifier/applestandhour)
+///
+/// ## Capabilities
+///
+/// - Readable by ID and time range
+/// - Aggregatable by sum, returning the number of stood or rolled hours
+///
+/// ## See also
+///
+/// - [AppleStandHourRecord]
+/// - [AppleStandHourStatus]
+///
+@sinceV3_11_0
+@readOnly
+@immutable
+final class AppleStandHourDataType
+    extends HealthDataType<AppleStandHourRecord, Number>
+    implements
+        ReadableByIdHealthDataType<AppleStandHourRecord>,
+        ReadableInTimeRangeHealthDataType<AppleStandHourRecord>,
+        SumAggregatableHealthDataType<Number> {
+  /// Creates an Apple Stand Hour data type.
+  ///
+  /// This is a constant constructor used internally. Use
+  /// [HealthDataType.appleStandHour] to reference this data type.
+  @internal
+  const AppleStandHourDataType();
+
+  @override
+  List<HealthPlatformRequirement> get healthPlatformRequirements => const [
+    AppleHealthRequirement.none,
+  ];
+
+  @override
+  String get id => 'apple_stand_hour';
+
+  @override
+  List<AggregationMetric> get supportedAggregationMetrics => const [
+    AggregationMetric.sum,
+  ];
+
+  @override
+  HealthDataPermission get readPermission => HealthDataPermission.read(this);
+
+  @override
+  ReadRecordByIdRequest<AppleStandHourRecord> readById(HealthRecordId id) {
+    return ReadRecordByIdRequest(dataType: this, id: id);
+  }
+
+  @override
+  ReadRecordsInTimeRangeRequest<AppleStandHourRecord> readInTimeRange({
+    required DateTime startTime,
+    required DateTime endTime,
+    List<DataOrigin> dataOrigins = const [],
+    int pageSize = HealthConnectorConfigConstants.defaultPageSize,
+    String? pageToken,
+  }) {
+    return ReadRecordsInTimeRangeRequest(
+      dataType: this,
+      dataOrigins: dataOrigins,
+      startTime: startTime,
+      endTime: endTime,
+      pageSize: pageSize,
+      pageToken: pageToken,
+    );
+  }
+
+  @override
+  AggregateRequest<Number> aggregateSum({
+    required DateTime startTime,
+    required DateTime endTime,
+  }) {
+    return StandardAggregateRequest(
+      dataType: this,
+      aggregationMetric: AggregationMetric.sum,
+      startTime: startTime,
+      endTime: endTime,
+    );
+  }
+
+  @override
+  List<Permission> get permissions => [readPermission];
+
+  @override
+  HealthDataTypeCategory get category => HealthDataTypeCategory.activity;
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is AppleStandHourDataType && runtimeType == other.runtimeType;
+
+  @override
+  int get hashCode => runtimeType.hashCode;
+}

--- a/packages/health_connector_core/lib/src/models/health_data_types/health_data_type.dart
+++ b/packages/health_connector_core/lib/src/models/health_data_types/health_data_type.dart
@@ -21,6 +21,7 @@ import 'package:health_connector_core/src/models/requests/read_requests/read_rec
 import 'package:meta/meta.dart' show immutable, internal;
 
 part 'activity_intensity_data_type.dart';
+part 'activity/apple_stand_hour_data_type.dart';
 part 'alcoholic_beverages_data_type.dart';
 part 'blood_alcohol_content_data_type.dart';
 part 'blood_glucose_data_type.dart';
@@ -526,6 +527,16 @@ sealed class HealthDataType<R extends HealthRecord, U extends MeasurementUnit> {
   /// time interval. Active energy are those burned through exercise
   /// and movement, excluding basal metabolic rate.
   static const activeEnergyBurned = ActiveEnergyBurnedDataType();
+
+  /// Apple Stand Hour data type.
+  ///
+  /// Records whether the user stood and moved for at least one minute during
+  /// each hour. For wheelchair users, HealthKit reports Roll hours instead.
+  ///
+  /// **Note**: This is a read-only data type.
+  @sinceV3_11_0
+  @readOnly
+  static const appleStandHour = AppleStandHourDataType();
 
   /// Activity intensity data type.
   ///
@@ -1252,6 +1263,7 @@ sealed class HealthDataType<R extends HealthRecord, U extends MeasurementUnit> {
     activeEnergyBurned,
     activityIntensity,
     alcoholicBeverages,
+    appleStandHour,
     atrialFibrillationBurden,
     electrodermalActivity,
     exerciseTime,

--- a/packages/health_connector_core/lib/src/models/health_records/activity/apple_stand_hour_record.dart
+++ b/packages/health_connector_core/lib/src/models/health_records/activity/apple_stand_hour_record.dart
@@ -1,0 +1,81 @@
+part of '../health_record.dart';
+
+/// An hourly Apple Stand or Roll status recorded by Apple Watch.
+///
+/// ## Platform Mapping
+///
+/// - **Android Health Connect**: Not supported
+/// - **iOS HealthKit**:
+///   [`HKCategoryTypeIdentifier.appleStandHour`](https://developer.apple.com/documentation/healthkit/hkcategorytypeidentifier/applestandhour)
+///
+/// ## See also
+///
+/// - [AppleStandHourDataType]
+/// - [AppleStandHourStatus]
+///
+@sinceV3_11_0
+@readOnly
+@immutable
+final class AppleStandHourRecord extends IntervalHealthRecord {
+  /// Internal factory for creating [AppleStandHourRecord] instances without
+  /// validation.
+  ///
+  /// **Warning**: Not for public use.
+  @internalUse
+  factory AppleStandHourRecord.internal({
+    required HealthRecordId id,
+    required DateTime startTime,
+    required DateTime endTime,
+    required Metadata metadata,
+    required AppleStandHourStatus status,
+    int? startZoneOffsetSeconds,
+    int? endZoneOffsetSeconds,
+  }) {
+    return AppleStandHourRecord._(
+      id: id,
+      startTime: startTime,
+      endTime: endTime,
+      metadata: metadata,
+      status: status,
+      startZoneOffsetSeconds: startZoneOffsetSeconds,
+      endZoneOffsetSeconds: endZoneOffsetSeconds,
+    );
+  }
+
+  AppleStandHourRecord._({
+    required super.id,
+    required super.startTime,
+    required super.endTime,
+    required super.metadata,
+    required this.status,
+    super.startZoneOffsetSeconds,
+    super.endZoneOffsetSeconds,
+  });
+
+  /// Whether the user completed the Stand or Roll goal during this hour.
+  final AppleStandHourStatus status;
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is AppleStandHourRecord &&
+          runtimeType == other.runtimeType &&
+          id == other.id &&
+          startTime == other.startTime &&
+          endTime == other.endTime &&
+          startZoneOffsetSeconds == other.startZoneOffsetSeconds &&
+          endZoneOffsetSeconds == other.endZoneOffsetSeconds &&
+          metadata == other.metadata &&
+          status == other.status;
+
+  @override
+  int get hashCode => Object.hash(
+    id,
+    startTime,
+    endTime,
+    startZoneOffsetSeconds,
+    endZoneOffsetSeconds,
+    metadata,
+    status,
+  );
+}

--- a/packages/health_connector_core/lib/src/models/health_records/activity/apple_stand_hour_status.dart
+++ b/packages/health_connector_core/lib/src/models/health_records/activity/apple_stand_hour_status.dart
@@ -1,0 +1,12 @@
+part of '../health_record.dart';
+
+/// Whether the user completed the Stand or Roll goal during an hour.
+@sinceV3_11_0
+enum AppleStandHourStatus {
+  /// The user stood or rolled and moved for at least one continuous minute.
+  stood,
+
+  /// The user did not stand or roll and move for at least one continuous
+  /// minute.
+  idle,
+}

--- a/packages/health_connector_core/lib/src/models/health_records/health_record.dart
+++ b/packages/health_connector_core/lib/src/models/health_records/health_record.dart
@@ -12,6 +12,8 @@ import 'package:meta/meta.dart' show immutable, internal;
 
 part 'activity_intensity/activity_intensity_record.dart';
 part 'activity_intensity/activity_intensity_type.dart';
+part 'activity/apple_stand_hour_record.dart';
+part 'activity/apple_stand_hour_status.dart';
 part 'alcoholic_beverages_record.dart';
 part 'time/exercise_time_record.dart';
 part 'time/move_time_record.dart';

--- a/packages/health_connector_core/lib/src/utils/double_to_measurement_unit_extension.dart
+++ b/packages/health_connector_core/lib/src/utils/double_to_measurement_unit_extension.dart
@@ -100,6 +100,7 @@ extension DoubleToMeasurementUnit on double {
 
       // Number
       case AlcoholicBeveragesDataType _:
+      case AppleStandHourDataType _:
       case BodyMassIndexDataType _:
       case ElectrodermalActivityDataType _:
       case FloorsClimbedDataType _:

--- a/packages/health_connector_core/lib/src/utils/health_record_data_type_extension.dart
+++ b/packages/health_connector_core/lib/src/utils/health_record_data_type_extension.dart
@@ -69,6 +69,7 @@ extension HealthRecordDataTypeExtension on HealthRecord {
         HealthDataType.skinTemperatureDeltaSeries,
       CervicalMucusRecord _ => HealthDataType.cervicalMucus,
       ActiveEnergyBurnedRecord _ => HealthDataType.activeEnergyBurned,
+      AppleStandHourRecord _ => HealthDataType.appleStandHour,
       ActivityIntensityRecord _ => HealthDataType.activityIntensity,
       AlcoholicBeveragesRecord _ => HealthDataType.alcoholicBeverages,
       ExerciseTimeRecord _ => HealthDataType.exerciseTime,

--- a/packages/health_connector_core/test/src/models/health_data_types/activity/apple_stand_hour_data_type_test.dart
+++ b/packages/health_connector_core/test/src/models/health_data_types/activity/apple_stand_hour_data_type_test.dart
@@ -1,0 +1,57 @@
+import 'package:health_connector_core/health_connector_core.dart';
+import 'package:health_connector_core/src/models/health_data_types/health_data_type_capabilities/health_data_type_capabilities.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('AppleStandHourDataType', () {
+    const dataType = HealthDataType.appleStandHour;
+
+    test('exposes its stable identity and platform support', () {
+      // Given / When
+      final supportedPlatforms =
+          dataType.healthPlatformRequirements.supportedHealthPlatforms;
+
+      // Then
+      expect(dataType.id, equals('apple_stand_hour'));
+      expect(dataType.category, equals(HealthDataTypeCategory.activity));
+      expect(supportedPlatforms, contains(HealthPlatform.appleHealth));
+      expect(supportedPlatforms, isNot(contains(HealthPlatform.healthConnect)));
+    });
+
+    test('supports reading and sum aggregation only', () {
+      // Given / When / Then
+      expect(dataType, isA<ReadableByIdHealthDataType>());
+      expect(dataType, isA<ReadableInTimeRangeHealthDataType>());
+      expect(dataType, isA<SumAggregatableHealthDataType<Number>>());
+      expect(dataType, isNot(isA<WriteableHealthDataType>()));
+      expect(dataType, isNot(isA<DeletableHealthDataType>()));
+      expect(dataType.supportedAggregationMetrics, [AggregationMetric.sum]);
+    });
+
+    test('requests read permission only', () {
+      // Given / When
+      final permissions = dataType.permissions;
+
+      // Then
+      expect(permissions, [dataType.readPermission]);
+    });
+
+    test('creates a sum request for the requested time range', () {
+      // Given
+      final startTime = DateTime.utc(2026, 9, 10);
+      final endTime = DateTime.utc(2026, 9, 11);
+
+      // When
+      final request = dataType.aggregateSum(
+        startTime: startTime,
+        endTime: endTime,
+      );
+
+      // Then
+      expect(request.dataType, same(dataType));
+      expect(request.aggregationMetric, AggregationMetric.sum);
+      expect(request.startTime, startTime);
+      expect(request.endTime, endTime);
+    });
+  });
+}

--- a/packages/health_connector_core/test/src/models/health_data_types/health_data_type_test.dart
+++ b/packages/health_connector_core/test/src/models/health_data_types/health_data_type_test.dart
@@ -15,6 +15,7 @@ void main() {
             <HealthDataType>[
               HealthDataType.activeEnergyBurned,
               HealthDataType.activityIntensity,
+              HealthDataType.appleStandHour,
               HealthDataType.exerciseTime,
               HealthDataType.moveTime,
               HealthDataType.standTime,

--- a/packages/health_connector_core/test/src/models/health_records/activity/apple_stand_hour_record_test.dart
+++ b/packages/health_connector_core/test/src/models/health_records/activity/apple_stand_hour_record_test.dart
@@ -1,0 +1,60 @@
+import 'package:health_connector_core/health_connector_core.dart';
+import 'package:health_connector_core/src/utils/health_record_data_type_extension.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('AppleStandHourRecord', () {
+    test('preserves the hourly status and maps to its data type', () {
+      // Given
+      final startTime = DateTime.utc(2026, 9, 11, 8);
+      final endTime = DateTime.utc(2026, 9, 11, 9);
+      final metadata = Metadata.manualEntry();
+
+      // When
+      final record = AppleStandHourRecord.internal(
+        id: HealthRecordId('stand-hour-id'),
+        startTime: startTime,
+        endTime: endTime,
+        metadata: metadata,
+        status: AppleStandHourStatus.stood,
+      );
+
+      // Then
+      expect(record.status, AppleStandHourStatus.stood);
+      expect(record.startTime, startTime);
+      expect(record.endTime, endTime);
+      expect(record.dataType, HealthDataType.appleStandHour);
+    });
+
+    test('uses all record fields for value equality', () {
+      // Given
+      final startTime = DateTime.utc(2026, 9, 11, 8);
+      final endTime = DateTime.utc(2026, 9, 11, 9);
+      final metadata = Metadata.manualEntry();
+
+      // When
+      final first = AppleStandHourRecord.internal(
+        id: HealthRecordId('stand-hour-id'),
+        startTime: startTime,
+        endTime: endTime,
+        metadata: metadata,
+        status: AppleStandHourStatus.idle,
+        startZoneOffsetSeconds: 7200,
+        endZoneOffsetSeconds: 7200,
+      );
+      final second = AppleStandHourRecord.internal(
+        id: HealthRecordId('stand-hour-id'),
+        startTime: startTime,
+        endTime: endTime,
+        metadata: metadata,
+        status: AppleStandHourStatus.idle,
+        startZoneOffsetSeconds: 7200,
+        endZoneOffsetSeconds: 7200,
+      );
+
+      // Then
+      expect(first, equals(second));
+      expect(first.hashCode, equals(second.hashCode));
+    });
+  });
+}

--- a/packages/health_connector_core/test/utils/double_to_measurement_unit_extension_test.dart
+++ b/packages/health_connector_core/test/utils/double_to_measurement_unit_extension_test.dart
@@ -289,6 +289,7 @@ void main() {
         'converts number data types to Number',
         [
           [2.0, HealthDataType.alcoholicBeverages],
+          [12.0, HealthDataType.appleStandHour],
           [22.5, HealthDataType.bodyMassIndex],
           [0.5, HealthDataType.electrodermalActivity],
           [10000.0, HealthDataType.steps],

--- a/packages/health_connector_hc_android/lib/src/mappers/health_data_type_mapper.dart
+++ b/packages/health_connector_hc_android/lib/src/mappers/health_data_type_mapper.dart
@@ -338,6 +338,7 @@ extension HealthDataTypeToDto on HealthDataType {
       case InfrequentMenstrualCycleEventDataType():
       case HighHeartRateEventDataType():
       case WalkingSteadinessEventDataType():
+      case AppleStandHourDataType():
       case PersistentIntermenstrualBleedingEventDataType():
       case ProlongedMenstrualPeriodEventDataType():
       case AtrialFibrillationBurdenDataType():

--- a/packages/health_connector_hc_android/lib/src/mappers/health_record_mappers/health_record_mapper.dart
+++ b/packages/health_connector_hc_android/lib/src/mappers/health_record_mappers/health_record_mapper.dart
@@ -580,6 +580,10 @@ extension HealthRecordToDto on HealthRecord {
           '$WalkingSteadinessEventRecord is not supported on Android '
           'Health Connect.',
         );
+      case AppleStandHourRecord():
+        throw UnsupportedError(
+          '$AppleStandHourRecord is not supported on Android Health Connect.',
+        );
       case PersistentIntermenstrualBleedingEventRecord():
         throw UnsupportedError(
           '$PersistentIntermenstrualBleedingEventRecord is not supported on '

--- a/packages/health_connector_hc_android/lib/src/mappers/request_and_response_mappers/aggregate_request_mapper.dart
+++ b/packages/health_connector_hc_android/lib/src/mappers/request_and_response_mappers/aggregate_request_mapper.dart
@@ -166,6 +166,7 @@ extension AggregateRequestDtoMapper<U extends MeasurementUnit>
           case IrregularMenstrualCycleEventDataType _:
           case HighHeartRateEventDataType _:
           case WalkingSteadinessEventDataType _:
+          case AppleStandHourDataType _:
           case PersistentIntermenstrualBleedingEventDataType _:
           case ProlongedMenstrualPeriodEventDataType _:
           case AtrialFibrillationBurdenDataType _:

--- a/packages/health_connector_hk_ios/CHANGELOG.md
+++ b/packages/health_connector_hk_ios/CHANGELOG.md
@@ -1,7 +1,10 @@
-## 3.9.5
+## Unreleased
 
 - **FEAT**: Add read and sum-aggregation support for Apple Stand Hour records
   ([#217](https://github.com/fam-tung-lam/health_connector/issues/217)).
+
+## 3.9.5
+
 - **FEAT**: Return the current iOS version snapshot during connector
   initialization
   ([#223](https://github.com/fam-tung-lam/health_connector/pull/223)).

--- a/packages/health_connector_hk_ios/CHANGELOG.md
+++ b/packages/health_connector_hk_ios/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## 3.9.5
 
+- **FEAT**: Add read and sum-aggregation support for Apple Stand Hour records
+  ([#217](https://github.com/fam-tung-lam/health_connector/issues/217)).
 - **FEAT**: Return the current iOS version snapshot during connector
   initialization
   ([#223](https://github.com/fam-tung-lam/health_connector/pull/223)).

--- a/packages/health_connector_hk_ios/example/ios/RunnerTests/RunnerTests.swift
+++ b/packages/health_connector_hk_ios/example/ios/RunnerTests/RunnerTests.swift
@@ -1,4 +1,5 @@
 import Foundation
+import HealthKit
 @testable import health_connector_hk_ios
 import XCTest
 
@@ -18,5 +19,74 @@ final class RunnerTests: XCTestCase {
         XCTAssertEqual(dto.majorVersion, 17)
         XCTAssertEqual(dto.minorVersion, 4)
         XCTAssertEqual(dto.patchVersion, 1)
+    }
+
+    func testAppleStandHourStatusMapperMapsStoodStatus() throws {
+        let status = try AppleStandHourStatusDto(
+            standHourValue: HKCategoryValueAppleStandHour.stood.rawValue
+        )
+
+        XCTAssertEqual(status, .stood)
+    }
+
+    func testAppleStandHourStatusMapperMapsIdleStatus() throws {
+        let status = try AppleStandHourStatusDto(
+            standHourValue: HKCategoryValueAppleStandHour.idle.rawValue
+        )
+
+        XCTAssertEqual(status, .idle)
+    }
+
+    func testAppleStandHourStatusMapperRejectsUnknownStatusWithoutExposingValue() {
+        XCTAssertThrowsError(try AppleStandHourStatusDto(standHourValue: Int.max)) { error in
+            guard case let HealthConnectorError.invalidArgument(message, _, context) = error else {
+                return XCTFail("Expected invalidArgument, got \(error)")
+            }
+
+            XCTAssertEqual(message, "Invalid Apple Stand Hour category value")
+            XCTAssertEqual(context?["data_type"] as? String, "appleStandHour")
+            XCTAssertNil(context?["value"])
+        }
+    }
+
+    func testAppleStandHourMapperRejectsWrongCategoryWithoutExposingIdentifier() throws {
+        let sleepType = try XCTUnwrap(HKObjectType.categoryType(forIdentifier: .sleepAnalysis))
+        let sample = HKCategorySample(
+            type: sleepType,
+            value: HKCategoryValueSleepAnalysis.inBed.rawValue,
+            start: Date(timeIntervalSince1970: 0),
+            end: Date(timeIntervalSince1970: 3600)
+        )
+
+        XCTAssertThrowsError(try sample.toAppleStandHourRecordDto()) { error in
+            guard case let HealthConnectorError.invalidArgument(message, _, context) = error else {
+                return XCTFail("Expected invalidArgument, got \(error)")
+            }
+
+            XCTAssertEqual(message, "Expected Apple Stand Hour category type")
+            XCTAssertEqual(context?["data_type"] as? String, "appleStandHour")
+            XCTAssertNil(context?["actual"])
+        }
+    }
+
+    func testAppleStandHourAggregationCountsOnlyStoodSamples() throws {
+        let samples = try [
+            makeAppleStandHourSample(value: HKCategoryValueAppleStandHour.stood.rawValue),
+            makeAppleStandHourSample(value: HKCategoryValueAppleStandHour.idle.rawValue),
+            makeAppleStandHourSample(value: HKCategoryValueAppleStandHour.stood.rawValue),
+        ]
+
+        XCTAssertEqual(AppleStandHourHandler.countStoodHours(in: samples), 2.0)
+    }
+
+    private func makeAppleStandHourSample(value: Int) throws -> HKCategorySample {
+        let type = try XCTUnwrap(HKObjectType.categoryType(forIdentifier: .appleStandHour))
+
+        return HKCategorySample(
+            type: type,
+            value: value,
+            start: Date(timeIntervalSince1970: 0),
+            end: Date(timeIntervalSince1970: 3600)
+        )
     }
 }

--- a/packages/health_connector_hk_ios/ios/health_connector_hk_ios/Sources/health_connector_hk_ios/handlers/HealthRecordHandlerRegistry.swift
+++ b/packages/health_connector_hk_ios/ios/health_connector_hk_ios/Sources/health_connector_hk_ios/handlers/HealthRecordHandlerRegistry.swift
@@ -190,6 +190,7 @@ final class HealthRecordHandlerRegistry: @unchecked Sendable {
         register(IrregularHeartRhythmEventRecordHandler(healthStore: healthStore))
         register(LowHeartRateEventRecordHandler(healthStore: healthStore))
         register(WalkingSteadinessEventRecordHandler(healthStore: healthStore))
+        register(AppleStandHourHandler(healthStore: healthStore))
         register(InfrequentMenstrualCycleEventRecordHandler(healthStore: healthStore))
         register(IrregularMenstrualCycleEventRecordHandler(healthStore: healthStore))
         register(PersistentIntermenstrualBleedingEventRecordHandler(healthStore: healthStore))

--- a/packages/health_connector_hk_ios/ios/health_connector_hk_ios/Sources/health_connector_hk_ios/handlers/HealthRecordHandlerRegistry.swift
+++ b/packages/health_connector_hk_ios/ios/health_connector_hk_ios/Sources/health_connector_hk_ios/handlers/HealthRecordHandlerRegistry.swift
@@ -189,8 +189,7 @@ final class HealthRecordHandlerRegistry: @unchecked Sendable {
         register(HighHeartRateEventRecordHandler(healthStore: healthStore))
         register(IrregularHeartRhythmEventRecordHandler(healthStore: healthStore))
         register(LowHeartRateEventRecordHandler(healthStore: healthStore))
-        register(WalkingSteadinessEventRecordHandler(healthStore: healthStore))
-        register(AppleStandHourHandler(healthStore: healthStore))
+        registerAppleActivityCategoryHandlers()
         register(InfrequentMenstrualCycleEventRecordHandler(healthStore: healthStore))
         register(IrregularMenstrualCycleEventRecordHandler(healthStore: healthStore))
         register(PersistentIntermenstrualBleedingEventRecordHandler(healthStore: healthStore))
@@ -204,6 +203,11 @@ final class HealthRecordHandlerRegistry: @unchecked Sendable {
         register(HeadphoneAudioExposureEventRecordHandler(healthStore: healthStore))
         register(EnvironmentalAudioExposureHandler(healthStore: healthStore))
         register(HeadphoneAudioExposureHandler(healthStore: healthStore))
+    }
+
+    private func registerAppleActivityCategoryHandlers() {
+        register(WalkingSteadinessEventRecordHandler(healthStore: healthStore))
+        register(AppleStandHourHandler(healthStore: healthStore))
     }
 
     /// Register a handler instance (called during init only)

--- a/packages/health_connector_hk_ios/ios/health_connector_hk_ios/Sources/health_connector_hk_ios/handlers/health_record_handlers/AppleStandHourHandler.swift
+++ b/packages/health_connector_hk_ios/ios/health_connector_hk_ios/Sources/health_connector_hk_ios/handlers/health_record_handlers/AppleStandHourHandler.swift
@@ -35,8 +35,7 @@ extension AppleStandHourHandler {
             operation: "aggregate",
             context: [
                 "metric": metric.rawValue,
-                "start_time": startTime,
-                "end_time": endTime,
+                "query_span_seconds": endTime.timeIntervalSince(startTime),
             ]
         ) {
             try validateAggregationMetric(metric)
@@ -46,9 +45,13 @@ extension AppleStandHourHandler {
                 endTime: endTime
             )
 
-            return samples.reduce(0.0) { total, sample in
-                total + (sample.value == HKCategoryValueAppleStandHour.stood.rawValue ? 1.0 : 0.0)
-            }
+            return Self.countStoodHours(in: samples)
+        }
+    }
+
+    static func countStoodHours(in samples: [HKCategorySample]) -> Double {
+        samples.reduce(0.0) { total, sample in
+            total + (sample.value == HKCategoryValueAppleStandHour.stood.rawValue ? 1.0 : 0.0)
         }
     }
 }

--- a/packages/health_connector_hk_ios/ios/health_connector_hk_ios/Sources/health_connector_hk_ios/handlers/health_record_handlers/AppleStandHourHandler.swift
+++ b/packages/health_connector_hk_ios/ios/health_connector_hk_ios/Sources/health_connector_hk_ios/handlers/health_record_handlers/AppleStandHourHandler.swift
@@ -1,0 +1,54 @@
+import Foundation
+import HealthKit
+
+/// Handles read and sum aggregation operations for Apple Stand Hour records.
+final class AppleStandHourHandler: @unchecked Sendable {
+    typealias RecordDto = AppleStandHourRecordDto
+    typealias SampleType = HKCategorySample
+
+    let healthStore: HKHealthStore
+
+    init(healthStore: HKHealthStore) {
+        self.healthStore = healthStore
+    }
+
+    static let dataType: HealthDataTypeDto = .appleStandHour
+    static let supportedAggregationMetrics: Set<AggregationMetricDto> = [.sum]
+}
+
+extension AppleStandHourHandler: ReadableHealthRecordHandler {
+}
+
+extension AppleStandHourHandler: AggregatableHealthRecordHandler {
+}
+
+// MARK: - Aggregation
+
+extension AppleStandHourHandler {
+    /// Counts hours in which the user completed the Stand or Roll goal.
+    func aggregate(
+        metric: AggregationMetricDto,
+        startTime: Date,
+        endTime: Date
+    ) async throws -> Double {
+        try await process(
+            operation: "aggregate",
+            context: [
+                "metric": metric.rawValue,
+                "start_time": startTime,
+                "end_time": endTime,
+            ]
+        ) {
+            try validateAggregationMetric(metric)
+
+            let samples = try await readAllRecords(
+                startTime: startTime,
+                endTime: endTime
+            )
+
+            return samples.reduce(0.0) { total, sample in
+                total + (sample.value == HKCategoryValueAppleStandHour.stood.rawValue ? 1.0 : 0.0)
+            }
+        }
+    }
+}

--- a/packages/health_connector_hk_ios/ios/health_connector_hk_ios/Sources/health_connector_hk_ios/mappers/HealthDataTypeMapper.swift
+++ b/packages/health_connector_hk_ios/ios/health_connector_hk_ios/Sources/health_connector_hk_ios/mappers/HealthDataTypeMapper.swift
@@ -360,6 +360,8 @@ extension HealthDataTypeDto {
             try HKCategoryType.make(from: .highHeartRateEvent)
         case .walkingSteadinessEvent:
             try HKCategoryType.make(from: .appleWalkingSteadinessEvent)
+        case .appleStandHour:
+            try HKCategoryType.make(from: .appleStandHour)
         case .persistentIntermenstrualBleedingEvent:
             if #available(iOS 16.0, *) {
                 try HKCategoryType.make(from: .persistentIntermenstrualBleeding)

--- a/packages/health_connector_hk_ios/ios/health_connector_hk_ios/Sources/health_connector_hk_ios/mappers/HealthDataTypeMapper.swift
+++ b/packages/health_connector_hk_ios/ios/health_connector_hk_ios/Sources/health_connector_hk_ios/mappers/HealthDataTypeMapper.swift
@@ -358,10 +358,8 @@ extension HealthDataTypeDto {
             }
         case .highHeartRateEvent:
             try HKCategoryType.make(from: .highHeartRateEvent)
-        case .walkingSteadinessEvent:
-            try HKCategoryType.make(from: .appleWalkingSteadinessEvent)
-        case .appleStandHour:
-            try HKCategoryType.make(from: .appleStandHour)
+        case .walkingSteadinessEvent, .appleStandHour:
+            try HKCategoryType.make(from: appleActivityCategoryTypeIdentifier)
         case .persistentIntermenstrualBleedingEvent:
             if #available(iOS 16.0, *) {
                 try HKCategoryType.make(from: .persistentIntermenstrualBleeding)
@@ -432,5 +430,11 @@ extension HealthDataTypeDto {
         case .headphoneAudioExposure:
             try HKQuantityType.make(from: .headphoneAudioExposure)
         }
+    }
+}
+
+private extension HealthDataTypeDto {
+    var appleActivityCategoryTypeIdentifier: HKCategoryTypeIdentifier {
+        self == .appleStandHour ? .appleStandHour : .appleWalkingSteadinessEvent
     }
 }

--- a/packages/health_connector_hk_ios/ios/health_connector_hk_ios/Sources/health_connector_hk_ios/mappers/PermissionMapper.swift
+++ b/packages/health_connector_hk_ios/ios/health_connector_hk_ios/Sources/health_connector_hk_ios/mappers/PermissionMapper.swift
@@ -128,7 +128,6 @@ extension HealthDataPermissionRequestDto {
              .appleStandHour,
              .persistentIntermenstrualBleedingEvent,
              .prolongedMenstrualPeriodEvent,
-             .prolongedMenstrualPeriodEvent,
              .atrialFibrillationBurden,
              .walkingHeartRateAverage,
              .numberOfTimesFallen,

--- a/packages/health_connector_hk_ios/ios/health_connector_hk_ios/Sources/health_connector_hk_ios/mappers/PermissionMapper.swift
+++ b/packages/health_connector_hk_ios/ios/health_connector_hk_ios/Sources/health_connector_hk_ios/mappers/PermissionMapper.swift
@@ -125,6 +125,7 @@ extension HealthDataPermissionRequestDto {
              .infrequentMenstrualCycleEvent,
              .highHeartRateEvent,
              .walkingSteadinessEvent,
+             .appleStandHour,
              .persistentIntermenstrualBleedingEvent,
              .prolongedMenstrualPeriodEvent,
              .prolongedMenstrualPeriodEvent,

--- a/packages/health_connector_hk_ios/ios/health_connector_hk_ios/Sources/health_connector_hk_ios/mappers/health_record_mappers/HealthRecordMapper.swift
+++ b/packages/health_connector_hk_ios/ios/health_connector_hk_ios/Sources/health_connector_hk_ios/mappers/health_record_mappers/HealthRecordMapper.swift
@@ -354,6 +354,8 @@ extension HKCategorySample {
             try toHeadphoneAudioExposureEventRecordDto()
         case .walkingSteadinessEvent:
             try toWalkingSteadinessEventRecordDto()
+        case .appleStandHour:
+            try toAppleStandHourRecordDto()
         default:
             throw HealthConnectorError.invalidArgument(
                 message:

--- a/packages/health_connector_hk_ios/ios/health_connector_hk_ios/Sources/health_connector_hk_ios/mappers/health_record_mappers/HealthRecordMapper.swift
+++ b/packages/health_connector_hk_ios/ios/health_connector_hk_ios/Sources/health_connector_hk_ios/mappers/health_record_mappers/HealthRecordMapper.swift
@@ -352,10 +352,8 @@ extension HKCategorySample {
             try toEnvironmentalAudioExposureEventRecordDto()
         case .headphoneAudioExposureEvent:
             try toHeadphoneAudioExposureEventRecordDto()
-        case .walkingSteadinessEvent:
-            try toWalkingSteadinessEventRecordDto()
-        case .appleStandHour:
-            try toAppleStandHourRecordDto()
+        case .walkingSteadinessEvent, .appleStandHour:
+            try toAppleActivityCategoryRecordDto(for: type)
         default:
             throw HealthConnectorError.invalidArgument(
                 message:

--- a/packages/health_connector_hk_ios/ios/health_connector_hk_ios/Sources/health_connector_hk_ios/mappers/health_record_mappers/activity/AppleStandHourRecordMapper.swift
+++ b/packages/health_connector_hk_ios/ios/health_connector_hk_ios/Sources/health_connector_hk_ios/mappers/health_record_mappers/activity/AppleStandHourRecordMapper.swift
@@ -3,23 +3,29 @@ import HealthKit
 
 /// Maps an Apple Stand Hour category sample to its platform DTO.
 extension HKCategorySample {
+    func toAppleActivityCategoryRecordDto(for type: HealthDataTypeDto) throws -> HealthRecordDto {
+        switch type {
+        case .walkingSteadinessEvent:
+            try toWalkingSteadinessEventRecordDto()
+        case .appleStandHour:
+            try toAppleStandHourRecordDto()
+        default:
+            throw HealthConnectorError.invalidArgument(
+                message: "Expected an Apple activity event data type",
+                context: ["data_type": type.rawValue]
+            )
+        }
+    }
+
     func toAppleStandHourRecordDto() throws -> AppleStandHourRecordDto {
         guard categoryType.identifier == HKCategoryTypeIdentifier.appleStandHour.rawValue else {
             throw HealthConnectorError.invalidArgument(
-                message: "Expected Apple Stand Hour category type, got \(categoryType.identifier)",
-                context: [
-                    "expected": HKCategoryTypeIdentifier.appleStandHour.rawValue,
-                    "actual": categoryType.identifier,
-                ]
+                message: "Expected Apple Stand Hour category type",
+                context: ["data_type": "appleStandHour"]
             )
         }
 
-        guard let standHourValue = HKCategoryValueAppleStandHour(rawValue: value) else {
-            throw HealthConnectorError.invalidArgument(
-                message: "Invalid Apple Stand Hour value: \(value)",
-                context: ["value": value]
-            )
-        }
+        let status = try AppleStandHourStatusDto(standHourValue: value)
 
         var builder = MetadataBuilder(
             fromHKMetadata: metadata ?? [:],
@@ -34,24 +40,24 @@ extension HKCategorySample {
             startTime: startDate.millisecondsSince1970,
             endTime: endDate.millisecondsSince1970,
             metadata: builder.toMetadataDto(),
-            status: AppleStandHourStatusDto(from: standHourValue),
+            status: status,
             startZoneOffsetSeconds: startZoneOffset,
             endZoneOffsetSeconds: endZoneOffset
         )
     }
 }
 
-private extension AppleStandHourStatusDto {
-    init(from standHourValue: HKCategoryValueAppleStandHour) throws {
+extension AppleStandHourStatusDto {
+    init(standHourValue: Int) throws {
         switch standHourValue {
-        case .stood:
+        case HKCategoryValueAppleStandHour.stood.rawValue:
             self = .stood
-        case .idle:
+        case HKCategoryValueAppleStandHour.idle.rawValue:
             self = .idle
-        @unknown default:
+        default:
             throw HealthConnectorError.invalidArgument(
-                message: "Unknown Apple Stand Hour value: \(standHourValue.rawValue)",
-                context: ["value": standHourValue.rawValue]
+                message: "Invalid Apple Stand Hour category value",
+                context: ["data_type": "appleStandHour"]
             )
         }
     }

--- a/packages/health_connector_hk_ios/ios/health_connector_hk_ios/Sources/health_connector_hk_ios/mappers/health_record_mappers/activity/AppleStandHourRecordMapper.swift
+++ b/packages/health_connector_hk_ios/ios/health_connector_hk_ios/Sources/health_connector_hk_ios/mappers/health_record_mappers/activity/AppleStandHourRecordMapper.swift
@@ -1,0 +1,58 @@
+import Foundation
+import HealthKit
+
+/// Maps an Apple Stand Hour category sample to its platform DTO.
+extension HKCategorySample {
+    func toAppleStandHourRecordDto() throws -> AppleStandHourRecordDto {
+        guard categoryType.identifier == HKCategoryTypeIdentifier.appleStandHour.rawValue else {
+            throw HealthConnectorError.invalidArgument(
+                message: "Expected Apple Stand Hour category type, got \(categoryType.identifier)",
+                context: [
+                    "expected": HKCategoryTypeIdentifier.appleStandHour.rawValue,
+                    "actual": categoryType.identifier,
+                ]
+            )
+        }
+
+        guard let standHourValue = HKCategoryValueAppleStandHour(rawValue: value) else {
+            throw HealthConnectorError.invalidArgument(
+                message: "Invalid Apple Stand Hour value: \(value)",
+                context: ["value": value]
+            )
+        }
+
+        var builder = MetadataBuilder(
+            fromHKMetadata: metadata ?? [:],
+            source: sourceRevision.source,
+            device: device
+        )
+        let startZoneOffset = StartTimeZoneOffsetKey.read(from: builder.metadataDict)
+        let endZoneOffset = EndTimeZoneOffsetKey.read(from: builder.metadataDict)
+
+        return try AppleStandHourRecordDto(
+            id: uuid.uuidString,
+            startTime: startDate.millisecondsSince1970,
+            endTime: endDate.millisecondsSince1970,
+            metadata: builder.toMetadataDto(),
+            status: AppleStandHourStatusDto(from: standHourValue),
+            startZoneOffsetSeconds: startZoneOffset,
+            endZoneOffsetSeconds: endZoneOffset
+        )
+    }
+}
+
+private extension AppleStandHourStatusDto {
+    init(from standHourValue: HKCategoryValueAppleStandHour) throws {
+        switch standHourValue {
+        case .stood:
+            self = .stood
+        case .idle:
+            self = .idle
+        @unknown default:
+            throw HealthConnectorError.invalidArgument(
+                message: "Unknown Apple Stand Hour value: \(standHourValue.rawValue)",
+                context: ["value": standHourValue.rawValue]
+            )
+        }
+    }
+}

--- a/packages/health_connector_hk_ios/ios/health_connector_hk_ios/Sources/health_connector_hk_ios/pigeon/HealthConnectorHKIOSApi.g.swift
+++ b/packages/health_connector_hk_ios/ios/health_connector_hk_ios/Sources/health_connector_hk_ios/pigeon/HealthConnectorHKIOSApi.g.swift
@@ -936,6 +936,8 @@ public enum HealthDataTypeDto: Int {
   case headphoneAudioExposure = 126
   /// Headphone audio exposure event data.
   case headphoneAudioExposureEvent = 127
+  /// Apple Stand Hour data.
+  case appleStandHour = 128
 }
 
 /// Types of exercise state transitions.
@@ -1103,6 +1105,15 @@ public enum HealthConnectorLogLevelDto: Int {
   case warning = 2
   /// Error level for serious problems.
   case error = 3
+}
+
+/// Whether the user completed the Stand or Roll goal during an hour.
+public enum AppleStandHourStatusDto: Int {
+  /// The user stood or rolled and moved for at least one continuous minute.
+  case stood = 0
+  /// The user did not stand or roll and move for at least one continuous
+  /// minute.
+  case idle = 1
 }
 
 /// Configuration data transfer object for Health Connector.
@@ -8445,6 +8456,64 @@ public struct NumberOfTimesFallenRecordDto: HealthRecordDto {
   }
 }
 
+/// Represents an Apple Stand Hour record for platform transfer.
+///
+/// Generated class from Pigeon that represents data sent in messages.
+public struct AppleStandHourRecordDto: HealthRecordDto {
+  /// Platform-assigned unique identifier.
+  var id: String? = nil
+  /// Start time in milliseconds since epoch (UTC).
+  var startTime: Int64
+  /// End time in milliseconds since epoch (UTC).
+  var endTime: Int64
+  /// Metadata about this record.
+  var metadata: MetadataDto
+  /// Whether the Stand or Roll goal was completed during this hour.
+  var status: AppleStandHourStatusDto
+  /// Timezone offset in seconds for start time.
+  var startZoneOffsetSeconds: Int64? = nil
+  /// Timezone offset in seconds for end time.
+  var endZoneOffsetSeconds: Int64? = nil
+
+
+  // swift-format-ignore: AlwaysUseLowerCamelCase
+  static func fromList(_ pigeonVar_list: [Any?]) -> AppleStandHourRecordDto? {
+    let id: String? = nilOrValue(pigeonVar_list[0])
+    let startTime = pigeonVar_list[1] as! Int64
+    let endTime = pigeonVar_list[2] as! Int64
+    let metadata = pigeonVar_list[3] as! MetadataDto
+    let status = pigeonVar_list[4] as! AppleStandHourStatusDto
+    let startZoneOffsetSeconds: Int64? = nilOrValue(pigeonVar_list[5])
+    let endZoneOffsetSeconds: Int64? = nilOrValue(pigeonVar_list[6])
+
+    return AppleStandHourRecordDto(
+      id: id,
+      startTime: startTime,
+      endTime: endTime,
+      metadata: metadata,
+      status: status,
+      startZoneOffsetSeconds: startZoneOffsetSeconds,
+      endZoneOffsetSeconds: endZoneOffsetSeconds
+    )
+  }
+  func toList() -> [Any?] {
+    return [
+      id,
+      startTime,
+      endTime,
+      metadata,
+      status,
+      startZoneOffsetSeconds,
+      endZoneOffsetSeconds,
+    ]
+  }
+  public static func == (lhs: AppleStandHourRecordDto, rhs: AppleStandHourRecordDto) -> Bool {
+    return deepEqualsHealthConnectorHKIOSApi(lhs.toList(), rhs.toList())  }
+  public func hash(into hasher: inout Hasher) {
+    deepHashHealthConnectorHKIOSApi(value: toList(), hasher: &hasher)
+  }
+}
+
 
 private struct PigeonInternalCodecOverflow {
   var type: Int
@@ -8476,99 +8545,103 @@ private struct PigeonInternalCodecOverflow {
         
     switch type {
       case 0:
-        return DietaryFiberRecordDto.fromList(wrapped as! [Any?]);
+        return DietaryCholesterolRecordDto.fromList(wrapped as! [Any?]);
       case 1:
-        return DietarySugarRecordDto.fromList(wrapped as! [Any?]);
+        return DietaryFiberRecordDto.fromList(wrapped as! [Any?]);
       case 2:
-        return DietaryVitaminARecordDto.fromList(wrapped as! [Any?]);
+        return DietarySugarRecordDto.fromList(wrapped as! [Any?]);
       case 3:
-        return DietaryVitaminB6RecordDto.fromList(wrapped as! [Any?]);
+        return DietaryVitaminARecordDto.fromList(wrapped as! [Any?]);
       case 4:
-        return DietaryVitaminB12RecordDto.fromList(wrapped as! [Any?]);
+        return DietaryVitaminB6RecordDto.fromList(wrapped as! [Any?]);
       case 5:
-        return DietaryVitaminCRecordDto.fromList(wrapped as! [Any?]);
+        return DietaryVitaminB12RecordDto.fromList(wrapped as! [Any?]);
       case 6:
-        return DietaryVitaminDRecordDto.fromList(wrapped as! [Any?]);
+        return DietaryVitaminCRecordDto.fromList(wrapped as! [Any?]);
       case 7:
-        return DietaryVitaminERecordDto.fromList(wrapped as! [Any?]);
+        return DietaryVitaminDRecordDto.fromList(wrapped as! [Any?]);
       case 8:
-        return LactationRecordDto.fromList(wrapped as! [Any?]);
+        return DietaryVitaminERecordDto.fromList(wrapped as! [Any?]);
       case 9:
-        return DietaryVitaminKRecordDto.fromList(wrapped as! [Any?]);
+        return LactationRecordDto.fromList(wrapped as! [Any?]);
       case 10:
-        return DietaryThiaminRecordDto.fromList(wrapped as! [Any?]);
+        return DietaryVitaminKRecordDto.fromList(wrapped as! [Any?]);
       case 11:
-        return DietaryRiboflavinRecordDto.fromList(wrapped as! [Any?]);
+        return DietaryThiaminRecordDto.fromList(wrapped as! [Any?]);
       case 12:
-        return DietaryNiacinRecordDto.fromList(wrapped as! [Any?]);
+        return DietaryRiboflavinRecordDto.fromList(wrapped as! [Any?]);
       case 13:
-        return DietaryFolateRecordDto.fromList(wrapped as! [Any?]);
+        return DietaryNiacinRecordDto.fromList(wrapped as! [Any?]);
       case 14:
-        return DietaryBiotinRecordDto.fromList(wrapped as! [Any?]);
+        return DietaryFolateRecordDto.fromList(wrapped as! [Any?]);
       case 15:
-        return DietaryPantothenicAcidRecordDto.fromList(wrapped as! [Any?]);
+        return DietaryBiotinRecordDto.fromList(wrapped as! [Any?]);
       case 16:
-        return DietaryCalciumRecordDto.fromList(wrapped as! [Any?]);
+        return DietaryPantothenicAcidRecordDto.fromList(wrapped as! [Any?]);
       case 17:
-        return DietaryIronRecordDto.fromList(wrapped as! [Any?]);
+        return DietaryCalciumRecordDto.fromList(wrapped as! [Any?]);
       case 18:
-        return DietaryMagnesiumRecordDto.fromList(wrapped as! [Any?]);
+        return DietaryIronRecordDto.fromList(wrapped as! [Any?]);
       case 19:
-        return DietaryManganeseRecordDto.fromList(wrapped as! [Any?]);
+        return DietaryMagnesiumRecordDto.fromList(wrapped as! [Any?]);
       case 20:
-        return DietaryPhosphorusRecordDto.fromList(wrapped as! [Any?]);
+        return DietaryManganeseRecordDto.fromList(wrapped as! [Any?]);
       case 21:
-        return DietaryPotassiumRecordDto.fromList(wrapped as! [Any?]);
+        return DietaryPhosphorusRecordDto.fromList(wrapped as! [Any?]);
       case 22:
-        return DietarySeleniumRecordDto.fromList(wrapped as! [Any?]);
+        return DietaryPotassiumRecordDto.fromList(wrapped as! [Any?]);
       case 23:
-        return DietarySodiumRecordDto.fromList(wrapped as! [Any?]);
+        return DietarySeleniumRecordDto.fromList(wrapped as! [Any?]);
       case 24:
-        return DietaryZincRecordDto.fromList(wrapped as! [Any?]);
+        return DietarySodiumRecordDto.fromList(wrapped as! [Any?]);
       case 25:
-        return NutritionRecordDto.fromList(wrapped as! [Any?]);
+        return DietaryZincRecordDto.fromList(wrapped as! [Any?]);
       case 26:
-        return BasalEnergyBurnedRecordDto.fromList(wrapped as! [Any?]);
+        return NutritionRecordDto.fromList(wrapped as! [Any?]);
       case 27:
-        return HealthDataSyncTokenDto.fromList(wrapped as! [Any?]);
+        return BasalEnergyBurnedRecordDto.fromList(wrapped as! [Any?]);
       case 28:
-        return HealthDataSyncResultDto.fromList(wrapped as! [Any?]);
+        return HealthDataSyncTokenDto.fromList(wrapped as! [Any?]);
       case 29:
-        return HealthDataPermissionRequestDto.fromList(wrapped as! [Any?]);
+        return HealthDataSyncResultDto.fromList(wrapped as! [Any?]);
       case 30:
-        return ExerciseRoutePermissionRequestDto.fromList(wrapped as! [Any?]);
+        return HealthDataPermissionRequestDto.fromList(wrapped as! [Any?]);
       case 31:
-        return PermissionsRequestDto.fromList(wrapped as! [Any?]);
+        return ExerciseRoutePermissionRequestDto.fromList(wrapped as! [Any?]);
       case 32:
-        return HealthDataPermissionRequestResultDto.fromList(wrapped as! [Any?]);
+        return PermissionsRequestDto.fromList(wrapped as! [Any?]);
       case 33:
-        return ExerciseRoutePermissionRequestResultDto.fromList(wrapped as! [Any?]);
+        return HealthDataPermissionRequestResultDto.fromList(wrapped as! [Any?]);
       case 34:
-        return AggregateRequestDto.fromList(wrapped as! [Any?]);
+        return ExerciseRoutePermissionRequestResultDto.fromList(wrapped as! [Any?]);
       case 35:
-        return DeleteRecordsByIdsRequestDto.fromList(wrapped as! [Any?]);
+        return AggregateRequestDto.fromList(wrapped as! [Any?]);
       case 36:
-        return DeleteRecordsByTimeRangeRequestDto.fromList(wrapped as! [Any?]);
+        return DeleteRecordsByIdsRequestDto.fromList(wrapped as! [Any?]);
       case 37:
-        return ReadRecordRequestDto.fromList(wrapped as! [Any?]);
+        return DeleteRecordsByTimeRangeRequestDto.fromList(wrapped as! [Any?]);
       case 38:
-        return ReadRecordsRequestDto.fromList(wrapped as! [Any?]);
+        return ReadRecordRequestDto.fromList(wrapped as! [Any?]);
       case 39:
-        return ReadRecordsResponseDto.fromList(wrapped as! [Any?]);
+        return ReadRecordsRequestDto.fromList(wrapped as! [Any?]);
       case 40:
-        return HealthConnectorExceptionDto.fromList(wrapped as! [Any?]);
+        return ReadRecordsResponseDto.fromList(wrapped as! [Any?]);
       case 41:
-        return HealthConnectorLogDto.fromList(wrapped as! [Any?]);
+        return HealthConnectorExceptionDto.fromList(wrapped as! [Any?]);
       case 42:
-        return PeripheralPerfusionIndexRecordDto.fromList(wrapped as! [Any?]);
+        return HealthConnectorLogDto.fromList(wrapped as! [Any?]);
       case 43:
-        return PersistentIntermenstrualBleedingEventRecordDto.fromList(wrapped as! [Any?]);
+        return PeripheralPerfusionIndexRecordDto.fromList(wrapped as! [Any?]);
       case 44:
-        return ProlongedMenstrualPeriodEventRecordDto.fromList(wrapped as! [Any?]);
+        return PersistentIntermenstrualBleedingEventRecordDto.fromList(wrapped as! [Any?]);
       case 45:
-        return AtrialFibrillationBurdenRecordDto.fromList(wrapped as! [Any?]);
+        return ProlongedMenstrualPeriodEventRecordDto.fromList(wrapped as! [Any?]);
       case 46:
+        return AtrialFibrillationBurdenRecordDto.fromList(wrapped as! [Any?]);
+      case 47:
         return NumberOfTimesFallenRecordDto.fromList(wrapped as! [Any?]);
+      case 48:
+        return AppleStandHourRecordDto.fromList(wrapped as! [Any?]);
       default: 
         return nil
     }
@@ -8789,187 +8862,191 @@ private class HealthConnectorHKIOSApiPigeonCodecReader: FlutterStandardReader {
       }
       return nil
     case 164:
-      return HealthConnectorConfigDto.fromList(self.readValue() as! [Any?])
+      let enumResultAsInt: Int? = nilOrValue(self.readValue() as! Int?)
+      if let enumResultAsInt = enumResultAsInt {
+        return AppleStandHourStatusDto(rawValue: enumResultAsInt)
+      }
+      return nil
     case 165:
-      return OperatingSystemInfoDto.fromList(self.readValue() as! [Any?])
+      return HealthConnectorConfigDto.fromList(self.readValue() as! [Any?])
     case 166:
-      return MetadataDto.fromList(self.readValue() as! [Any?])
+      return OperatingSystemInfoDto.fromList(self.readValue() as! [Any?])
     case 167:
-      return RestingHeartRateRecordDto.fromList(self.readValue() as! [Any?])
+      return MetadataDto.fromList(self.readValue() as! [Any?])
     case 168:
-      return WalkingHeartRateAverageRecordDto.fromList(self.readValue() as! [Any?])
+      return RestingHeartRateRecordDto.fromList(self.readValue() as! [Any?])
     case 169:
-      return LowCardioFitnessEventRecordDto.fromList(self.readValue() as! [Any?])
+      return WalkingHeartRateAverageRecordDto.fromList(self.readValue() as! [Any?])
     case 170:
-      return EnvironmentalAudioExposureEventRecordDto.fromList(self.readValue() as! [Any?])
+      return LowCardioFitnessEventRecordDto.fromList(self.readValue() as! [Any?])
     case 171:
-      return HeadphoneAudioExposureEventRecordDto.fromList(self.readValue() as! [Any?])
+      return EnvironmentalAudioExposureEventRecordDto.fromList(self.readValue() as! [Any?])
     case 172:
-      return EnvironmentalAudioExposureRecordDto.fromList(self.readValue() as! [Any?])
+      return HeadphoneAudioExposureEventRecordDto.fromList(self.readValue() as! [Any?])
     case 173:
-      return HeadphoneAudioExposureRecordDto.fromList(self.readValue() as! [Any?])
+      return EnvironmentalAudioExposureRecordDto.fromList(self.readValue() as! [Any?])
     case 174:
-      return LowHeartRateEventRecordDto.fromList(self.readValue() as! [Any?])
+      return HeadphoneAudioExposureRecordDto.fromList(self.readValue() as! [Any?])
     case 175:
-      return HighHeartRateEventRecordDto.fromList(self.readValue() as! [Any?])
+      return LowHeartRateEventRecordDto.fromList(self.readValue() as! [Any?])
     case 176:
-      return IrregularMenstrualCycleEventRecordDto.fromList(self.readValue() as! [Any?])
+      return HighHeartRateEventRecordDto.fromList(self.readValue() as! [Any?])
     case 177:
-      return InfrequentMenstrualCycleEventRecordDto.fromList(self.readValue() as! [Any?])
+      return IrregularMenstrualCycleEventRecordDto.fromList(self.readValue() as! [Any?])
     case 178:
-      return IrregularHeartRhythmEventRecordDto.fromList(self.readValue() as! [Any?])
+      return InfrequentMenstrualCycleEventRecordDto.fromList(self.readValue() as! [Any?])
     case 179:
-      return WalkingSteadinessEventRecordDto.fromList(self.readValue() as! [Any?])
+      return IrregularHeartRhythmEventRecordDto.fromList(self.readValue() as! [Any?])
     case 180:
-      return Vo2MaxRecordDto.fromList(self.readValue() as! [Any?])
+      return WalkingSteadinessEventRecordDto.fromList(self.readValue() as! [Any?])
     case 181:
-      return ForcedVitalCapacityRecordDto.fromList(self.readValue() as! [Any?])
+      return Vo2MaxRecordDto.fromList(self.readValue() as! [Any?])
     case 182:
-      return ForcedExpiratoryVolumeRecordDto.fromList(self.readValue() as! [Any?])
+      return ForcedVitalCapacityRecordDto.fromList(self.readValue() as! [Any?])
     case 183:
-      return PeakExpiratoryFlowRateRecordDto.fromList(self.readValue() as! [Any?])
+      return ForcedExpiratoryVolumeRecordDto.fromList(self.readValue() as! [Any?])
     case 184:
-      return BodyMassIndexRecordDto.fromList(self.readValue() as! [Any?])
+      return PeakExpiratoryFlowRateRecordDto.fromList(self.readValue() as! [Any?])
     case 185:
-      return WaistCircumferenceRecordDto.fromList(self.readValue() as! [Any?])
+      return BodyMassIndexRecordDto.fromList(self.readValue() as! [Any?])
     case 186:
-      return HeartRateVariabilitySDNNRecordDto.fromList(self.readValue() as! [Any?])
+      return WaistCircumferenceRecordDto.fromList(self.readValue() as! [Any?])
     case 187:
-      return BloodGlucoseRecordDto.fromList(self.readValue() as! [Any?])
+      return HeartRateVariabilitySDNNRecordDto.fromList(self.readValue() as! [Any?])
     case 188:
-      return ExerciseSessionStateTransitionEventDto.fromList(self.readValue() as! [Any?])
+      return BloodGlucoseRecordDto.fromList(self.readValue() as! [Any?])
     case 189:
-      return ExerciseSessionMarkerEventDto.fromList(self.readValue() as! [Any?])
+      return ExerciseSessionStateTransitionEventDto.fromList(self.readValue() as! [Any?])
     case 190:
-      return ExerciseSessionLapEventDto.fromList(self.readValue() as! [Any?])
+      return ExerciseSessionMarkerEventDto.fromList(self.readValue() as! [Any?])
     case 191:
-      return ExerciseSessionSegmentEventDto.fromList(self.readValue() as! [Any?])
+      return ExerciseSessionLapEventDto.fromList(self.readValue() as! [Any?])
     case 192:
-      return ExerciseRouteLocationDto.fromList(self.readValue() as! [Any?])
+      return ExerciseSessionSegmentEventDto.fromList(self.readValue() as! [Any?])
     case 193:
-      return ExerciseRouteDto.fromList(self.readValue() as! [Any?])
+      return ExerciseRouteLocationDto.fromList(self.readValue() as! [Any?])
     case 194:
-      return ExerciseSessionRecordDto.fromList(self.readValue() as! [Any?])
+      return ExerciseRouteDto.fromList(self.readValue() as! [Any?])
     case 195:
-      return MindfulnessSessionRecordDto.fromList(self.readValue() as! [Any?])
+      return ExerciseSessionRecordDto.fromList(self.readValue() as! [Any?])
     case 196:
-      return ActiveEnergyBurnedRecordDto.fromList(self.readValue() as! [Any?])
+      return MindfulnessSessionRecordDto.fromList(self.readValue() as! [Any?])
     case 197:
-      return AlcoholicBeveragesRecordDto.fromList(self.readValue() as! [Any?])
+      return ActiveEnergyBurnedRecordDto.fromList(self.readValue() as! [Any?])
     case 198:
-      return ExerciseTimeRecordDto.fromList(self.readValue() as! [Any?])
+      return AlcoholicBeveragesRecordDto.fromList(self.readValue() as! [Any?])
     case 199:
-      return MoveTimeRecordDto.fromList(self.readValue() as! [Any?])
+      return ExerciseTimeRecordDto.fromList(self.readValue() as! [Any?])
     case 200:
-      return StandTimeRecordDto.fromList(self.readValue() as! [Any?])
+      return MoveTimeRecordDto.fromList(self.readValue() as! [Any?])
     case 201:
-      return WalkingSteadinessRecordDto.fromList(self.readValue() as! [Any?])
+      return StandTimeRecordDto.fromList(self.readValue() as! [Any?])
     case 202:
-      return WalkingAsymmetryPercentageRecordDto.fromList(self.readValue() as! [Any?])
+      return WalkingSteadinessRecordDto.fromList(self.readValue() as! [Any?])
     case 203:
-      return WalkingDoubleSupportPercentageRecordDto.fromList(self.readValue() as! [Any?])
+      return WalkingAsymmetryPercentageRecordDto.fromList(self.readValue() as! [Any?])
     case 204:
-      return WalkingStepLengthRecordDto.fromList(self.readValue() as! [Any?])
+      return WalkingDoubleSupportPercentageRecordDto.fromList(self.readValue() as! [Any?])
     case 205:
-      return RunningGroundContactTimeRecordDto.fromList(self.readValue() as! [Any?])
+      return WalkingStepLengthRecordDto.fromList(self.readValue() as! [Any?])
     case 206:
-      return RunningStrideLengthRecordDto.fromList(self.readValue() as! [Any?])
+      return RunningGroundContactTimeRecordDto.fromList(self.readValue() as! [Any?])
     case 207:
-      return DistanceActivityRecordDto.fromList(self.readValue() as! [Any?])
+      return RunningStrideLengthRecordDto.fromList(self.readValue() as! [Any?])
     case 208:
-      return SpeedActivityRecordDto.fromList(self.readValue() as! [Any?])
+      return DistanceActivityRecordDto.fromList(self.readValue() as! [Any?])
     case 209:
-      return FloorsClimbedRecordDto.fromList(self.readValue() as! [Any?])
+      return SpeedActivityRecordDto.fromList(self.readValue() as! [Any?])
     case 210:
-      return WheelchairPushesRecordDto.fromList(self.readValue() as! [Any?])
+      return FloorsClimbedRecordDto.fromList(self.readValue() as! [Any?])
     case 211:
-      return StepsRecordDto.fromList(self.readValue() as! [Any?])
+      return WheelchairPushesRecordDto.fromList(self.readValue() as! [Any?])
     case 212:
-      return SwimmingStrokesRecordDto.fromList(self.readValue() as! [Any?])
+      return StepsRecordDto.fromList(self.readValue() as! [Any?])
     case 213:
-      return WeightRecordDto.fromList(self.readValue() as! [Any?])
+      return SwimmingStrokesRecordDto.fromList(self.readValue() as! [Any?])
     case 214:
-      return BloodPressureRecordDto.fromList(self.readValue() as! [Any?])
+      return WeightRecordDto.fromList(self.readValue() as! [Any?])
     case 215:
-      return SystolicBloodPressureRecordDto.fromList(self.readValue() as! [Any?])
+      return BloodPressureRecordDto.fromList(self.readValue() as! [Any?])
     case 216:
-      return DiastolicBloodPressureRecordDto.fromList(self.readValue() as! [Any?])
+      return SystolicBloodPressureRecordDto.fromList(self.readValue() as! [Any?])
     case 217:
-      return LeanBodyMassRecordDto.fromList(self.readValue() as! [Any?])
+      return DiastolicBloodPressureRecordDto.fromList(self.readValue() as! [Any?])
     case 218:
-      return HeightRecordDto.fromList(self.readValue() as! [Any?])
+      return LeanBodyMassRecordDto.fromList(self.readValue() as! [Any?])
     case 219:
-      return BloodAlcoholContentRecordDto.fromList(self.readValue() as! [Any?])
+      return HeightRecordDto.fromList(self.readValue() as! [Any?])
     case 220:
-      return BodyFatPercentageRecordDto.fromList(self.readValue() as! [Any?])
+      return BloodAlcoholContentRecordDto.fromList(self.readValue() as! [Any?])
     case 221:
-      return BodyTemperatureRecordDto.fromList(self.readValue() as! [Any?])
+      return BodyFatPercentageRecordDto.fromList(self.readValue() as! [Any?])
     case 222:
-      return BasalBodyTemperatureRecordDto.fromList(self.readValue() as! [Any?])
+      return BodyTemperatureRecordDto.fromList(self.readValue() as! [Any?])
     case 223:
-      return SleepingWristTemperatureRecordDto.fromList(self.readValue() as! [Any?])
+      return BasalBodyTemperatureRecordDto.fromList(self.readValue() as! [Any?])
     case 224:
-      return CervicalMucusRecordDto.fromList(self.readValue() as! [Any?])
+      return SleepingWristTemperatureRecordDto.fromList(self.readValue() as! [Any?])
     case 225:
-      return CyclingPowerRecordDto.fromList(self.readValue() as! [Any?])
+      return CervicalMucusRecordDto.fromList(self.readValue() as! [Any?])
     case 226:
-      return RunningPowerRecordDto.fromList(self.readValue() as! [Any?])
+      return CyclingPowerRecordDto.fromList(self.readValue() as! [Any?])
     case 227:
-      return OxygenSaturationRecordDto.fromList(self.readValue() as! [Any?])
+      return RunningPowerRecordDto.fromList(self.readValue() as! [Any?])
     case 228:
-      return OvulationTestRecordDto.fromList(self.readValue() as! [Any?])
+      return OxygenSaturationRecordDto.fromList(self.readValue() as! [Any?])
     case 229:
-      return PregnancyTestRecordDto.fromList(self.readValue() as! [Any?])
+      return OvulationTestRecordDto.fromList(self.readValue() as! [Any?])
     case 230:
-      return PregnancyRecordDto.fromList(self.readValue() as! [Any?])
+      return PregnancyTestRecordDto.fromList(self.readValue() as! [Any?])
     case 231:
-      return ContraceptiveRecordDto.fromList(self.readValue() as! [Any?])
+      return PregnancyRecordDto.fromList(self.readValue() as! [Any?])
     case 232:
-      return ProgesteroneTestRecordDto.fromList(self.readValue() as! [Any?])
+      return ContraceptiveRecordDto.fromList(self.readValue() as! [Any?])
     case 233:
-      return IntermenstrualBleedingRecordDto.fromList(self.readValue() as! [Any?])
+      return ProgesteroneTestRecordDto.fromList(self.readValue() as! [Any?])
     case 234:
-      return MenstrualFlowRecordDto.fromList(self.readValue() as! [Any?])
+      return IntermenstrualBleedingRecordDto.fromList(self.readValue() as! [Any?])
     case 235:
-      return RespiratoryRateRecordDto.fromList(self.readValue() as! [Any?])
+      return MenstrualFlowRecordDto.fromList(self.readValue() as! [Any?])
     case 236:
-      return ElectrodermalActivityRecordDto.fromList(self.readValue() as! [Any?])
+      return RespiratoryRateRecordDto.fromList(self.readValue() as! [Any?])
     case 237:
-      return HydrationRecordDto.fromList(self.readValue() as! [Any?])
+      return ElectrodermalActivityRecordDto.fromList(self.readValue() as! [Any?])
     case 238:
-      return InsulinDeliveryRecordDto.fromList(self.readValue() as! [Any?])
+      return HydrationRecordDto.fromList(self.readValue() as! [Any?])
     case 239:
-      return InhalerUsageRecordDto.fromList(self.readValue() as! [Any?])
+      return InsulinDeliveryRecordDto.fromList(self.readValue() as! [Any?])
     case 240:
-      return HeartRateMeasurementDto.fromList(self.readValue() as! [Any?])
+      return InhalerUsageRecordDto.fromList(self.readValue() as! [Any?])
     case 241:
-      return HeartRateRecordDto.fromList(self.readValue() as! [Any?])
+      return HeartRateMeasurementDto.fromList(self.readValue() as! [Any?])
     case 242:
-      return CyclingPedalingCadenceRecordDto.fromList(self.readValue() as! [Any?])
+      return HeartRateRecordDto.fromList(self.readValue() as! [Any?])
     case 243:
-      return HeartRateRecoveryOneMinuteRecordDto.fromList(self.readValue() as! [Any?])
+      return CyclingPedalingCadenceRecordDto.fromList(self.readValue() as! [Any?])
     case 244:
-      return SleepStageRecordDto.fromList(self.readValue() as! [Any?])
+      return HeartRateRecoveryOneMinuteRecordDto.fromList(self.readValue() as! [Any?])
     case 245:
-      return SexualActivityRecordDto.fromList(self.readValue() as! [Any?])
+      return SleepStageRecordDto.fromList(self.readValue() as! [Any?])
     case 246:
-      return DietaryEnergyConsumedRecordDto.fromList(self.readValue() as! [Any?])
+      return SexualActivityRecordDto.fromList(self.readValue() as! [Any?])
     case 247:
-      return DietaryCaffeineRecordDto.fromList(self.readValue() as! [Any?])
+      return DietaryEnergyConsumedRecordDto.fromList(self.readValue() as! [Any?])
     case 248:
-      return DietaryProteinRecordDto.fromList(self.readValue() as! [Any?])
+      return DietaryCaffeineRecordDto.fromList(self.readValue() as! [Any?])
     case 249:
-      return DietaryTotalCarbohydrateRecordDto.fromList(self.readValue() as! [Any?])
+      return DietaryProteinRecordDto.fromList(self.readValue() as! [Any?])
     case 250:
-      return DietaryTotalFatRecordDto.fromList(self.readValue() as! [Any?])
+      return DietaryTotalCarbohydrateRecordDto.fromList(self.readValue() as! [Any?])
     case 251:
-      return DietarySaturatedFatRecordDto.fromList(self.readValue() as! [Any?])
+      return DietaryTotalFatRecordDto.fromList(self.readValue() as! [Any?])
     case 252:
-      return DietaryMonounsaturatedFatRecordDto.fromList(self.readValue() as! [Any?])
+      return DietarySaturatedFatRecordDto.fromList(self.readValue() as! [Any?])
     case 253:
-      return DietaryPolyunsaturatedFatRecordDto.fromList(self.readValue() as! [Any?])
+      return DietaryMonounsaturatedFatRecordDto.fromList(self.readValue() as! [Any?])
     case 254:
-      return DietaryCholesterolRecordDto.fromList(self.readValue() as! [Any?])
+      return DietaryPolyunsaturatedFatRecordDto.fromList(self.readValue() as! [Any?])
     case 255:
       return PigeonInternalCodecOverflow.fromList(self.readValue() as! [Any?])
     default:
@@ -9085,465 +9162,473 @@ private class HealthConnectorHKIOSApiPigeonCodecWriter: FlutterStandardWriter {
     } else if let value = value as? HealthConnectorLogLevelDto {
       super.writeByte(163)
       super.writeValue(value.rawValue)
-    } else if let value = value as? HealthConnectorConfigDto {
+    } else if let value = value as? AppleStandHourStatusDto {
       super.writeByte(164)
-      super.writeValue(value.toList())
-    } else if let value = value as? OperatingSystemInfoDto {
+      super.writeValue(value.rawValue)
+    } else if let value = value as? HealthConnectorConfigDto {
       super.writeByte(165)
       super.writeValue(value.toList())
-    } else if let value = value as? MetadataDto {
+    } else if let value = value as? OperatingSystemInfoDto {
       super.writeByte(166)
       super.writeValue(value.toList())
-    } else if let value = value as? RestingHeartRateRecordDto {
+    } else if let value = value as? MetadataDto {
       super.writeByte(167)
       super.writeValue(value.toList())
-    } else if let value = value as? WalkingHeartRateAverageRecordDto {
+    } else if let value = value as? RestingHeartRateRecordDto {
       super.writeByte(168)
       super.writeValue(value.toList())
-    } else if let value = value as? LowCardioFitnessEventRecordDto {
+    } else if let value = value as? WalkingHeartRateAverageRecordDto {
       super.writeByte(169)
       super.writeValue(value.toList())
-    } else if let value = value as? EnvironmentalAudioExposureEventRecordDto {
+    } else if let value = value as? LowCardioFitnessEventRecordDto {
       super.writeByte(170)
       super.writeValue(value.toList())
-    } else if let value = value as? HeadphoneAudioExposureEventRecordDto {
+    } else if let value = value as? EnvironmentalAudioExposureEventRecordDto {
       super.writeByte(171)
       super.writeValue(value.toList())
-    } else if let value = value as? EnvironmentalAudioExposureRecordDto {
+    } else if let value = value as? HeadphoneAudioExposureEventRecordDto {
       super.writeByte(172)
       super.writeValue(value.toList())
-    } else if let value = value as? HeadphoneAudioExposureRecordDto {
+    } else if let value = value as? EnvironmentalAudioExposureRecordDto {
       super.writeByte(173)
       super.writeValue(value.toList())
-    } else if let value = value as? LowHeartRateEventRecordDto {
+    } else if let value = value as? HeadphoneAudioExposureRecordDto {
       super.writeByte(174)
       super.writeValue(value.toList())
-    } else if let value = value as? HighHeartRateEventRecordDto {
+    } else if let value = value as? LowHeartRateEventRecordDto {
       super.writeByte(175)
       super.writeValue(value.toList())
-    } else if let value = value as? IrregularMenstrualCycleEventRecordDto {
+    } else if let value = value as? HighHeartRateEventRecordDto {
       super.writeByte(176)
       super.writeValue(value.toList())
-    } else if let value = value as? InfrequentMenstrualCycleEventRecordDto {
+    } else if let value = value as? IrregularMenstrualCycleEventRecordDto {
       super.writeByte(177)
       super.writeValue(value.toList())
-    } else if let value = value as? IrregularHeartRhythmEventRecordDto {
+    } else if let value = value as? InfrequentMenstrualCycleEventRecordDto {
       super.writeByte(178)
       super.writeValue(value.toList())
-    } else if let value = value as? WalkingSteadinessEventRecordDto {
+    } else if let value = value as? IrregularHeartRhythmEventRecordDto {
       super.writeByte(179)
       super.writeValue(value.toList())
-    } else if let value = value as? Vo2MaxRecordDto {
+    } else if let value = value as? WalkingSteadinessEventRecordDto {
       super.writeByte(180)
       super.writeValue(value.toList())
-    } else if let value = value as? ForcedVitalCapacityRecordDto {
+    } else if let value = value as? Vo2MaxRecordDto {
       super.writeByte(181)
       super.writeValue(value.toList())
-    } else if let value = value as? ForcedExpiratoryVolumeRecordDto {
+    } else if let value = value as? ForcedVitalCapacityRecordDto {
       super.writeByte(182)
       super.writeValue(value.toList())
-    } else if let value = value as? PeakExpiratoryFlowRateRecordDto {
+    } else if let value = value as? ForcedExpiratoryVolumeRecordDto {
       super.writeByte(183)
       super.writeValue(value.toList())
-    } else if let value = value as? BodyMassIndexRecordDto {
+    } else if let value = value as? PeakExpiratoryFlowRateRecordDto {
       super.writeByte(184)
       super.writeValue(value.toList())
-    } else if let value = value as? WaistCircumferenceRecordDto {
+    } else if let value = value as? BodyMassIndexRecordDto {
       super.writeByte(185)
       super.writeValue(value.toList())
-    } else if let value = value as? HeartRateVariabilitySDNNRecordDto {
+    } else if let value = value as? WaistCircumferenceRecordDto {
       super.writeByte(186)
       super.writeValue(value.toList())
-    } else if let value = value as? BloodGlucoseRecordDto {
+    } else if let value = value as? HeartRateVariabilitySDNNRecordDto {
       super.writeByte(187)
       super.writeValue(value.toList())
-    } else if let value = value as? ExerciseSessionStateTransitionEventDto {
+    } else if let value = value as? BloodGlucoseRecordDto {
       super.writeByte(188)
       super.writeValue(value.toList())
-    } else if let value = value as? ExerciseSessionMarkerEventDto {
+    } else if let value = value as? ExerciseSessionStateTransitionEventDto {
       super.writeByte(189)
       super.writeValue(value.toList())
-    } else if let value = value as? ExerciseSessionLapEventDto {
+    } else if let value = value as? ExerciseSessionMarkerEventDto {
       super.writeByte(190)
       super.writeValue(value.toList())
-    } else if let value = value as? ExerciseSessionSegmentEventDto {
+    } else if let value = value as? ExerciseSessionLapEventDto {
       super.writeByte(191)
       super.writeValue(value.toList())
-    } else if let value = value as? ExerciseRouteLocationDto {
+    } else if let value = value as? ExerciseSessionSegmentEventDto {
       super.writeByte(192)
       super.writeValue(value.toList())
-    } else if let value = value as? ExerciseRouteDto {
+    } else if let value = value as? ExerciseRouteLocationDto {
       super.writeByte(193)
       super.writeValue(value.toList())
-    } else if let value = value as? ExerciseSessionRecordDto {
+    } else if let value = value as? ExerciseRouteDto {
       super.writeByte(194)
       super.writeValue(value.toList())
-    } else if let value = value as? MindfulnessSessionRecordDto {
+    } else if let value = value as? ExerciseSessionRecordDto {
       super.writeByte(195)
       super.writeValue(value.toList())
-    } else if let value = value as? ActiveEnergyBurnedRecordDto {
+    } else if let value = value as? MindfulnessSessionRecordDto {
       super.writeByte(196)
       super.writeValue(value.toList())
-    } else if let value = value as? AlcoholicBeveragesRecordDto {
+    } else if let value = value as? ActiveEnergyBurnedRecordDto {
       super.writeByte(197)
       super.writeValue(value.toList())
-    } else if let value = value as? ExerciseTimeRecordDto {
+    } else if let value = value as? AlcoholicBeveragesRecordDto {
       super.writeByte(198)
       super.writeValue(value.toList())
-    } else if let value = value as? MoveTimeRecordDto {
+    } else if let value = value as? ExerciseTimeRecordDto {
       super.writeByte(199)
       super.writeValue(value.toList())
-    } else if let value = value as? StandTimeRecordDto {
+    } else if let value = value as? MoveTimeRecordDto {
       super.writeByte(200)
       super.writeValue(value.toList())
-    } else if let value = value as? WalkingSteadinessRecordDto {
+    } else if let value = value as? StandTimeRecordDto {
       super.writeByte(201)
       super.writeValue(value.toList())
-    } else if let value = value as? WalkingAsymmetryPercentageRecordDto {
+    } else if let value = value as? WalkingSteadinessRecordDto {
       super.writeByte(202)
       super.writeValue(value.toList())
-    } else if let value = value as? WalkingDoubleSupportPercentageRecordDto {
+    } else if let value = value as? WalkingAsymmetryPercentageRecordDto {
       super.writeByte(203)
       super.writeValue(value.toList())
-    } else if let value = value as? WalkingStepLengthRecordDto {
+    } else if let value = value as? WalkingDoubleSupportPercentageRecordDto {
       super.writeByte(204)
       super.writeValue(value.toList())
-    } else if let value = value as? RunningGroundContactTimeRecordDto {
+    } else if let value = value as? WalkingStepLengthRecordDto {
       super.writeByte(205)
       super.writeValue(value.toList())
-    } else if let value = value as? RunningStrideLengthRecordDto {
+    } else if let value = value as? RunningGroundContactTimeRecordDto {
       super.writeByte(206)
       super.writeValue(value.toList())
-    } else if let value = value as? DistanceActivityRecordDto {
+    } else if let value = value as? RunningStrideLengthRecordDto {
       super.writeByte(207)
       super.writeValue(value.toList())
-    } else if let value = value as? SpeedActivityRecordDto {
+    } else if let value = value as? DistanceActivityRecordDto {
       super.writeByte(208)
       super.writeValue(value.toList())
-    } else if let value = value as? FloorsClimbedRecordDto {
+    } else if let value = value as? SpeedActivityRecordDto {
       super.writeByte(209)
       super.writeValue(value.toList())
-    } else if let value = value as? WheelchairPushesRecordDto {
+    } else if let value = value as? FloorsClimbedRecordDto {
       super.writeByte(210)
       super.writeValue(value.toList())
-    } else if let value = value as? StepsRecordDto {
+    } else if let value = value as? WheelchairPushesRecordDto {
       super.writeByte(211)
       super.writeValue(value.toList())
-    } else if let value = value as? SwimmingStrokesRecordDto {
+    } else if let value = value as? StepsRecordDto {
       super.writeByte(212)
       super.writeValue(value.toList())
-    } else if let value = value as? WeightRecordDto {
+    } else if let value = value as? SwimmingStrokesRecordDto {
       super.writeByte(213)
       super.writeValue(value.toList())
-    } else if let value = value as? BloodPressureRecordDto {
+    } else if let value = value as? WeightRecordDto {
       super.writeByte(214)
       super.writeValue(value.toList())
-    } else if let value = value as? SystolicBloodPressureRecordDto {
+    } else if let value = value as? BloodPressureRecordDto {
       super.writeByte(215)
       super.writeValue(value.toList())
-    } else if let value = value as? DiastolicBloodPressureRecordDto {
+    } else if let value = value as? SystolicBloodPressureRecordDto {
       super.writeByte(216)
       super.writeValue(value.toList())
-    } else if let value = value as? LeanBodyMassRecordDto {
+    } else if let value = value as? DiastolicBloodPressureRecordDto {
       super.writeByte(217)
       super.writeValue(value.toList())
-    } else if let value = value as? HeightRecordDto {
+    } else if let value = value as? LeanBodyMassRecordDto {
       super.writeByte(218)
       super.writeValue(value.toList())
-    } else if let value = value as? BloodAlcoholContentRecordDto {
+    } else if let value = value as? HeightRecordDto {
       super.writeByte(219)
       super.writeValue(value.toList())
-    } else if let value = value as? BodyFatPercentageRecordDto {
+    } else if let value = value as? BloodAlcoholContentRecordDto {
       super.writeByte(220)
       super.writeValue(value.toList())
-    } else if let value = value as? BodyTemperatureRecordDto {
+    } else if let value = value as? BodyFatPercentageRecordDto {
       super.writeByte(221)
       super.writeValue(value.toList())
-    } else if let value = value as? BasalBodyTemperatureRecordDto {
+    } else if let value = value as? BodyTemperatureRecordDto {
       super.writeByte(222)
       super.writeValue(value.toList())
-    } else if let value = value as? SleepingWristTemperatureRecordDto {
+    } else if let value = value as? BasalBodyTemperatureRecordDto {
       super.writeByte(223)
       super.writeValue(value.toList())
-    } else if let value = value as? CervicalMucusRecordDto {
+    } else if let value = value as? SleepingWristTemperatureRecordDto {
       super.writeByte(224)
       super.writeValue(value.toList())
-    } else if let value = value as? CyclingPowerRecordDto {
+    } else if let value = value as? CervicalMucusRecordDto {
       super.writeByte(225)
       super.writeValue(value.toList())
-    } else if let value = value as? RunningPowerRecordDto {
+    } else if let value = value as? CyclingPowerRecordDto {
       super.writeByte(226)
       super.writeValue(value.toList())
-    } else if let value = value as? OxygenSaturationRecordDto {
+    } else if let value = value as? RunningPowerRecordDto {
       super.writeByte(227)
       super.writeValue(value.toList())
-    } else if let value = value as? OvulationTestRecordDto {
+    } else if let value = value as? OxygenSaturationRecordDto {
       super.writeByte(228)
       super.writeValue(value.toList())
-    } else if let value = value as? PregnancyTestRecordDto {
+    } else if let value = value as? OvulationTestRecordDto {
       super.writeByte(229)
       super.writeValue(value.toList())
-    } else if let value = value as? PregnancyRecordDto {
+    } else if let value = value as? PregnancyTestRecordDto {
       super.writeByte(230)
       super.writeValue(value.toList())
-    } else if let value = value as? ContraceptiveRecordDto {
+    } else if let value = value as? PregnancyRecordDto {
       super.writeByte(231)
       super.writeValue(value.toList())
-    } else if let value = value as? ProgesteroneTestRecordDto {
+    } else if let value = value as? ContraceptiveRecordDto {
       super.writeByte(232)
       super.writeValue(value.toList())
-    } else if let value = value as? IntermenstrualBleedingRecordDto {
+    } else if let value = value as? ProgesteroneTestRecordDto {
       super.writeByte(233)
       super.writeValue(value.toList())
-    } else if let value = value as? MenstrualFlowRecordDto {
+    } else if let value = value as? IntermenstrualBleedingRecordDto {
       super.writeByte(234)
       super.writeValue(value.toList())
-    } else if let value = value as? RespiratoryRateRecordDto {
+    } else if let value = value as? MenstrualFlowRecordDto {
       super.writeByte(235)
       super.writeValue(value.toList())
-    } else if let value = value as? ElectrodermalActivityRecordDto {
+    } else if let value = value as? RespiratoryRateRecordDto {
       super.writeByte(236)
       super.writeValue(value.toList())
-    } else if let value = value as? HydrationRecordDto {
+    } else if let value = value as? ElectrodermalActivityRecordDto {
       super.writeByte(237)
       super.writeValue(value.toList())
-    } else if let value = value as? InsulinDeliveryRecordDto {
+    } else if let value = value as? HydrationRecordDto {
       super.writeByte(238)
       super.writeValue(value.toList())
-    } else if let value = value as? InhalerUsageRecordDto {
+    } else if let value = value as? InsulinDeliveryRecordDto {
       super.writeByte(239)
       super.writeValue(value.toList())
-    } else if let value = value as? HeartRateMeasurementDto {
+    } else if let value = value as? InhalerUsageRecordDto {
       super.writeByte(240)
       super.writeValue(value.toList())
-    } else if let value = value as? HeartRateRecordDto {
+    } else if let value = value as? HeartRateMeasurementDto {
       super.writeByte(241)
       super.writeValue(value.toList())
-    } else if let value = value as? CyclingPedalingCadenceRecordDto {
+    } else if let value = value as? HeartRateRecordDto {
       super.writeByte(242)
       super.writeValue(value.toList())
-    } else if let value = value as? HeartRateRecoveryOneMinuteRecordDto {
+    } else if let value = value as? CyclingPedalingCadenceRecordDto {
       super.writeByte(243)
       super.writeValue(value.toList())
-    } else if let value = value as? SleepStageRecordDto {
+    } else if let value = value as? HeartRateRecoveryOneMinuteRecordDto {
       super.writeByte(244)
       super.writeValue(value.toList())
-    } else if let value = value as? SexualActivityRecordDto {
+    } else if let value = value as? SleepStageRecordDto {
       super.writeByte(245)
       super.writeValue(value.toList())
-    } else if let value = value as? DietaryEnergyConsumedRecordDto {
+    } else if let value = value as? SexualActivityRecordDto {
       super.writeByte(246)
       super.writeValue(value.toList())
-    } else if let value = value as? DietaryCaffeineRecordDto {
+    } else if let value = value as? DietaryEnergyConsumedRecordDto {
       super.writeByte(247)
       super.writeValue(value.toList())
-    } else if let value = value as? DietaryProteinRecordDto {
+    } else if let value = value as? DietaryCaffeineRecordDto {
       super.writeByte(248)
       super.writeValue(value.toList())
-    } else if let value = value as? DietaryTotalCarbohydrateRecordDto {
+    } else if let value = value as? DietaryProteinRecordDto {
       super.writeByte(249)
       super.writeValue(value.toList())
-    } else if let value = value as? DietaryTotalFatRecordDto {
+    } else if let value = value as? DietaryTotalCarbohydrateRecordDto {
       super.writeByte(250)
       super.writeValue(value.toList())
-    } else if let value = value as? DietarySaturatedFatRecordDto {
+    } else if let value = value as? DietaryTotalFatRecordDto {
       super.writeByte(251)
       super.writeValue(value.toList())
-    } else if let value = value as? DietaryMonounsaturatedFatRecordDto {
+    } else if let value = value as? DietarySaturatedFatRecordDto {
       super.writeByte(252)
       super.writeValue(value.toList())
-    } else if let value = value as? DietaryPolyunsaturatedFatRecordDto {
+    } else if let value = value as? DietaryMonounsaturatedFatRecordDto {
       super.writeByte(253)
       super.writeValue(value.toList())
-    } else if let value = value as? DietaryCholesterolRecordDto {
+    } else if let value = value as? DietaryPolyunsaturatedFatRecordDto {
       super.writeByte(254)
       super.writeValue(value.toList())
-    } else if let value = value as? DietaryFiberRecordDto {
+    } else if let value = value as? DietaryCholesterolRecordDto {
       let wrap = PigeonInternalCodecOverflow(type: 0, wrapped: value.toList())
       super.writeByte(255)
       super.writeValue(wrap.toList())
-    } else if let value = value as? DietarySugarRecordDto {
+    } else if let value = value as? DietaryFiberRecordDto {
       let wrap = PigeonInternalCodecOverflow(type: 1, wrapped: value.toList())
       super.writeByte(255)
       super.writeValue(wrap.toList())
-    } else if let value = value as? DietaryVitaminARecordDto {
+    } else if let value = value as? DietarySugarRecordDto {
       let wrap = PigeonInternalCodecOverflow(type: 2, wrapped: value.toList())
       super.writeByte(255)
       super.writeValue(wrap.toList())
-    } else if let value = value as? DietaryVitaminB6RecordDto {
+    } else if let value = value as? DietaryVitaminARecordDto {
       let wrap = PigeonInternalCodecOverflow(type: 3, wrapped: value.toList())
       super.writeByte(255)
       super.writeValue(wrap.toList())
-    } else if let value = value as? DietaryVitaminB12RecordDto {
+    } else if let value = value as? DietaryVitaminB6RecordDto {
       let wrap = PigeonInternalCodecOverflow(type: 4, wrapped: value.toList())
       super.writeByte(255)
       super.writeValue(wrap.toList())
-    } else if let value = value as? DietaryVitaminCRecordDto {
+    } else if let value = value as? DietaryVitaminB12RecordDto {
       let wrap = PigeonInternalCodecOverflow(type: 5, wrapped: value.toList())
       super.writeByte(255)
       super.writeValue(wrap.toList())
-    } else if let value = value as? DietaryVitaminDRecordDto {
+    } else if let value = value as? DietaryVitaminCRecordDto {
       let wrap = PigeonInternalCodecOverflow(type: 6, wrapped: value.toList())
       super.writeByte(255)
       super.writeValue(wrap.toList())
-    } else if let value = value as? DietaryVitaminERecordDto {
+    } else if let value = value as? DietaryVitaminDRecordDto {
       let wrap = PigeonInternalCodecOverflow(type: 7, wrapped: value.toList())
       super.writeByte(255)
       super.writeValue(wrap.toList())
-    } else if let value = value as? LactationRecordDto {
+    } else if let value = value as? DietaryVitaminERecordDto {
       let wrap = PigeonInternalCodecOverflow(type: 8, wrapped: value.toList())
       super.writeByte(255)
       super.writeValue(wrap.toList())
-    } else if let value = value as? DietaryVitaminKRecordDto {
+    } else if let value = value as? LactationRecordDto {
       let wrap = PigeonInternalCodecOverflow(type: 9, wrapped: value.toList())
       super.writeByte(255)
       super.writeValue(wrap.toList())
-    } else if let value = value as? DietaryThiaminRecordDto {
+    } else if let value = value as? DietaryVitaminKRecordDto {
       let wrap = PigeonInternalCodecOverflow(type: 10, wrapped: value.toList())
       super.writeByte(255)
       super.writeValue(wrap.toList())
-    } else if let value = value as? DietaryRiboflavinRecordDto {
+    } else if let value = value as? DietaryThiaminRecordDto {
       let wrap = PigeonInternalCodecOverflow(type: 11, wrapped: value.toList())
       super.writeByte(255)
       super.writeValue(wrap.toList())
-    } else if let value = value as? DietaryNiacinRecordDto {
+    } else if let value = value as? DietaryRiboflavinRecordDto {
       let wrap = PigeonInternalCodecOverflow(type: 12, wrapped: value.toList())
       super.writeByte(255)
       super.writeValue(wrap.toList())
-    } else if let value = value as? DietaryFolateRecordDto {
+    } else if let value = value as? DietaryNiacinRecordDto {
       let wrap = PigeonInternalCodecOverflow(type: 13, wrapped: value.toList())
       super.writeByte(255)
       super.writeValue(wrap.toList())
-    } else if let value = value as? DietaryBiotinRecordDto {
+    } else if let value = value as? DietaryFolateRecordDto {
       let wrap = PigeonInternalCodecOverflow(type: 14, wrapped: value.toList())
       super.writeByte(255)
       super.writeValue(wrap.toList())
-    } else if let value = value as? DietaryPantothenicAcidRecordDto {
+    } else if let value = value as? DietaryBiotinRecordDto {
       let wrap = PigeonInternalCodecOverflow(type: 15, wrapped: value.toList())
       super.writeByte(255)
       super.writeValue(wrap.toList())
-    } else if let value = value as? DietaryCalciumRecordDto {
+    } else if let value = value as? DietaryPantothenicAcidRecordDto {
       let wrap = PigeonInternalCodecOverflow(type: 16, wrapped: value.toList())
       super.writeByte(255)
       super.writeValue(wrap.toList())
-    } else if let value = value as? DietaryIronRecordDto {
+    } else if let value = value as? DietaryCalciumRecordDto {
       let wrap = PigeonInternalCodecOverflow(type: 17, wrapped: value.toList())
       super.writeByte(255)
       super.writeValue(wrap.toList())
-    } else if let value = value as? DietaryMagnesiumRecordDto {
+    } else if let value = value as? DietaryIronRecordDto {
       let wrap = PigeonInternalCodecOverflow(type: 18, wrapped: value.toList())
       super.writeByte(255)
       super.writeValue(wrap.toList())
-    } else if let value = value as? DietaryManganeseRecordDto {
+    } else if let value = value as? DietaryMagnesiumRecordDto {
       let wrap = PigeonInternalCodecOverflow(type: 19, wrapped: value.toList())
       super.writeByte(255)
       super.writeValue(wrap.toList())
-    } else if let value = value as? DietaryPhosphorusRecordDto {
+    } else if let value = value as? DietaryManganeseRecordDto {
       let wrap = PigeonInternalCodecOverflow(type: 20, wrapped: value.toList())
       super.writeByte(255)
       super.writeValue(wrap.toList())
-    } else if let value = value as? DietaryPotassiumRecordDto {
+    } else if let value = value as? DietaryPhosphorusRecordDto {
       let wrap = PigeonInternalCodecOverflow(type: 21, wrapped: value.toList())
       super.writeByte(255)
       super.writeValue(wrap.toList())
-    } else if let value = value as? DietarySeleniumRecordDto {
+    } else if let value = value as? DietaryPotassiumRecordDto {
       let wrap = PigeonInternalCodecOverflow(type: 22, wrapped: value.toList())
       super.writeByte(255)
       super.writeValue(wrap.toList())
-    } else if let value = value as? DietarySodiumRecordDto {
+    } else if let value = value as? DietarySeleniumRecordDto {
       let wrap = PigeonInternalCodecOverflow(type: 23, wrapped: value.toList())
       super.writeByte(255)
       super.writeValue(wrap.toList())
-    } else if let value = value as? DietaryZincRecordDto {
+    } else if let value = value as? DietarySodiumRecordDto {
       let wrap = PigeonInternalCodecOverflow(type: 24, wrapped: value.toList())
       super.writeByte(255)
       super.writeValue(wrap.toList())
-    } else if let value = value as? NutritionRecordDto {
+    } else if let value = value as? DietaryZincRecordDto {
       let wrap = PigeonInternalCodecOverflow(type: 25, wrapped: value.toList())
       super.writeByte(255)
       super.writeValue(wrap.toList())
-    } else if let value = value as? BasalEnergyBurnedRecordDto {
+    } else if let value = value as? NutritionRecordDto {
       let wrap = PigeonInternalCodecOverflow(type: 26, wrapped: value.toList())
       super.writeByte(255)
       super.writeValue(wrap.toList())
-    } else if let value = value as? HealthDataSyncTokenDto {
+    } else if let value = value as? BasalEnergyBurnedRecordDto {
       let wrap = PigeonInternalCodecOverflow(type: 27, wrapped: value.toList())
       super.writeByte(255)
       super.writeValue(wrap.toList())
-    } else if let value = value as? HealthDataSyncResultDto {
+    } else if let value = value as? HealthDataSyncTokenDto {
       let wrap = PigeonInternalCodecOverflow(type: 28, wrapped: value.toList())
       super.writeByte(255)
       super.writeValue(wrap.toList())
-    } else if let value = value as? HealthDataPermissionRequestDto {
+    } else if let value = value as? HealthDataSyncResultDto {
       let wrap = PigeonInternalCodecOverflow(type: 29, wrapped: value.toList())
       super.writeByte(255)
       super.writeValue(wrap.toList())
-    } else if let value = value as? ExerciseRoutePermissionRequestDto {
+    } else if let value = value as? HealthDataPermissionRequestDto {
       let wrap = PigeonInternalCodecOverflow(type: 30, wrapped: value.toList())
       super.writeByte(255)
       super.writeValue(wrap.toList())
-    } else if let value = value as? PermissionsRequestDto {
+    } else if let value = value as? ExerciseRoutePermissionRequestDto {
       let wrap = PigeonInternalCodecOverflow(type: 31, wrapped: value.toList())
       super.writeByte(255)
       super.writeValue(wrap.toList())
-    } else if let value = value as? HealthDataPermissionRequestResultDto {
+    } else if let value = value as? PermissionsRequestDto {
       let wrap = PigeonInternalCodecOverflow(type: 32, wrapped: value.toList())
       super.writeByte(255)
       super.writeValue(wrap.toList())
-    } else if let value = value as? ExerciseRoutePermissionRequestResultDto {
+    } else if let value = value as? HealthDataPermissionRequestResultDto {
       let wrap = PigeonInternalCodecOverflow(type: 33, wrapped: value.toList())
       super.writeByte(255)
       super.writeValue(wrap.toList())
-    } else if let value = value as? AggregateRequestDto {
+    } else if let value = value as? ExerciseRoutePermissionRequestResultDto {
       let wrap = PigeonInternalCodecOverflow(type: 34, wrapped: value.toList())
       super.writeByte(255)
       super.writeValue(wrap.toList())
-    } else if let value = value as? DeleteRecordsByIdsRequestDto {
+    } else if let value = value as? AggregateRequestDto {
       let wrap = PigeonInternalCodecOverflow(type: 35, wrapped: value.toList())
       super.writeByte(255)
       super.writeValue(wrap.toList())
-    } else if let value = value as? DeleteRecordsByTimeRangeRequestDto {
+    } else if let value = value as? DeleteRecordsByIdsRequestDto {
       let wrap = PigeonInternalCodecOverflow(type: 36, wrapped: value.toList())
       super.writeByte(255)
       super.writeValue(wrap.toList())
-    } else if let value = value as? ReadRecordRequestDto {
+    } else if let value = value as? DeleteRecordsByTimeRangeRequestDto {
       let wrap = PigeonInternalCodecOverflow(type: 37, wrapped: value.toList())
       super.writeByte(255)
       super.writeValue(wrap.toList())
-    } else if let value = value as? ReadRecordsRequestDto {
+    } else if let value = value as? ReadRecordRequestDto {
       let wrap = PigeonInternalCodecOverflow(type: 38, wrapped: value.toList())
       super.writeByte(255)
       super.writeValue(wrap.toList())
-    } else if let value = value as? ReadRecordsResponseDto {
+    } else if let value = value as? ReadRecordsRequestDto {
       let wrap = PigeonInternalCodecOverflow(type: 39, wrapped: value.toList())
       super.writeByte(255)
       super.writeValue(wrap.toList())
-    } else if let value = value as? HealthConnectorExceptionDto {
+    } else if let value = value as? ReadRecordsResponseDto {
       let wrap = PigeonInternalCodecOverflow(type: 40, wrapped: value.toList())
       super.writeByte(255)
       super.writeValue(wrap.toList())
-    } else if let value = value as? HealthConnectorLogDto {
+    } else if let value = value as? HealthConnectorExceptionDto {
       let wrap = PigeonInternalCodecOverflow(type: 41, wrapped: value.toList())
       super.writeByte(255)
       super.writeValue(wrap.toList())
-    } else if let value = value as? PeripheralPerfusionIndexRecordDto {
+    } else if let value = value as? HealthConnectorLogDto {
       let wrap = PigeonInternalCodecOverflow(type: 42, wrapped: value.toList())
       super.writeByte(255)
       super.writeValue(wrap.toList())
-    } else if let value = value as? PersistentIntermenstrualBleedingEventRecordDto {
+    } else if let value = value as? PeripheralPerfusionIndexRecordDto {
       let wrap = PigeonInternalCodecOverflow(type: 43, wrapped: value.toList())
       super.writeByte(255)
       super.writeValue(wrap.toList())
-    } else if let value = value as? ProlongedMenstrualPeriodEventRecordDto {
+    } else if let value = value as? PersistentIntermenstrualBleedingEventRecordDto {
       let wrap = PigeonInternalCodecOverflow(type: 44, wrapped: value.toList())
       super.writeByte(255)
       super.writeValue(wrap.toList())
-    } else if let value = value as? AtrialFibrillationBurdenRecordDto {
+    } else if let value = value as? ProlongedMenstrualPeriodEventRecordDto {
       let wrap = PigeonInternalCodecOverflow(type: 45, wrapped: value.toList())
       super.writeByte(255)
       super.writeValue(wrap.toList())
-    } else if let value = value as? NumberOfTimesFallenRecordDto {
+    } else if let value = value as? AtrialFibrillationBurdenRecordDto {
       let wrap = PigeonInternalCodecOverflow(type: 46, wrapped: value.toList())
+      super.writeByte(255)
+      super.writeValue(wrap.toList())
+    } else if let value = value as? NumberOfTimesFallenRecordDto {
+      let wrap = PigeonInternalCodecOverflow(type: 47, wrapped: value.toList())
+      super.writeByte(255)
+      super.writeValue(wrap.toList())
+    } else if let value = value as? AppleStandHourRecordDto {
+      let wrap = PigeonInternalCodecOverflow(type: 48, wrapped: value.toList())
       super.writeByte(255)
       super.writeValue(wrap.toList())
     } else {

--- a/packages/health_connector_hk_ios/ios/health_connector_hk_ios/Sources/health_connector_hk_ios/utils/HealthConnectorDtoExtensions.swift
+++ b/packages/health_connector_hk_ios/ios/health_connector_hk_ios/Sources/health_connector_hk_ios/utils/HealthConnectorDtoExtensions.swift
@@ -22,6 +22,8 @@ extension HealthRecordDto {
             record.id
         case let record as WalkingSteadinessEventRecordDto:
             record.id
+        case let record as AppleStandHourRecordDto:
+            record.id
         case let record as BloodAlcoholContentRecordDto:
             record.id
         case let record as BasalEnergyBurnedRecordDto:
@@ -255,6 +257,8 @@ extension HealthRecordDto {
                 return .walkingSteadiness
             case is WalkingSteadinessEventRecordDto:
                 return .walkingSteadinessEvent
+            case is AppleStandHourRecordDto:
+                return .appleStandHour
             case is AlcoholicBeveragesRecordDto:
                 return .alcoholicBeverages
             case is BloodAlcoholContentRecordDto:

--- a/packages/health_connector_hk_ios/ios/health_connector_hk_ios/Sources/health_connector_hk_ios/utils/HealthConnectorDtoExtensions.swift
+++ b/packages/health_connector_hk_ios/ios/health_connector_hk_ios/Sources/health_connector_hk_ios/utils/HealthConnectorDtoExtensions.swift
@@ -1,9 +1,6 @@
 import Foundation
 
-/// Extension providing common property access for `HealthRecordDto` protocol
-///
-/// Pigeon does not allow defining properties in base classes and interfaces, this extension
-/// provides a computed property to access fields that exist in all `HealthRecordDto` implementations.
+/// Provides common property access that Pigeon cannot define on `HealthRecordDto`.
 extension HealthRecordDto {
     /// Platform-assigned unique identifier for this health record
     var id: String? {
@@ -486,7 +483,6 @@ extension HealthRecordDto {
     /// - Interval records: `endTime`
     /// - Nutrients: `time`
     /// - Correlations: `endTime`
-    ///
     /// - Returns: Pagination timestamp
     /// - Throws: `HealthConnectorError.invalidArgument` for unknown DTO types
     func extractTimestamp() throws -> Int64 {

--- a/packages/health_connector_hk_ios/ios/health_connector_hk_ios/Sources/health_connector_hk_ios/utils/HealthKitExtensions.swift
+++ b/packages/health_connector_hk_ios/ios/health_connector_hk_ios/Sources/health_connector_hk_ios/utils/HealthKitExtensions.swift
@@ -224,6 +224,8 @@ extension HKSample {
                 return .highHeartRateEvent
             case HKCategoryTypeIdentifier.appleWalkingSteadinessEvent.rawValue:
                 return .walkingSteadinessEvent
+            case HKCategoryTypeIdentifier.appleStandHour.rawValue:
+                return .appleStandHour
             // Correlation types
             case HKCorrelationTypeIdentifier.bloodPressure.rawValue:
                 return .bloodPressure

--- a/packages/health_connector_hk_ios/lib/src/mappers/health_data_type_mapper.dart
+++ b/packages/health_connector_hk_ios/lib/src/mappers/health_data_type_mapper.dart
@@ -250,6 +250,8 @@ extension HealthDataTypeDtoToDomain on HealthDataTypeDto {
         return HealthDataType.highHeartRateEvent;
       case HealthDataTypeDto.walkingSteadinessEvent:
         return HealthDataType.walkingSteadinessEvent;
+      case HealthDataTypeDto.appleStandHour:
+        return HealthDataType.appleStandHour;
       case HealthDataTypeDto.persistentIntermenstrualBleedingEvent:
         return HealthDataType.persistentIntermenstrualBleedingEvent;
       case HealthDataTypeDto.prolongedMenstrualPeriodEvent:
@@ -510,6 +512,8 @@ extension HealthDataTypeToDto on HealthDataType {
         return HealthDataTypeDto.highHeartRateEvent;
       case WalkingSteadinessEventDataType _:
         return HealthDataTypeDto.walkingSteadinessEvent;
+      case AppleStandHourDataType _:
+        return HealthDataTypeDto.appleStandHour;
       case PersistentIntermenstrualBleedingEventDataType _:
         return HealthDataTypeDto.persistentIntermenstrualBleedingEvent;
       case ProlongedMenstrualPeriodEventDataType _:

--- a/packages/health_connector_hk_ios/lib/src/mappers/health_record_mappers/activity/apple_stand_hour_record_mapper.dart
+++ b/packages/health_connector_hk_ios/lib/src/mappers/health_record_mappers/activity/apple_stand_hour_record_mapper.dart
@@ -1,0 +1,32 @@
+import 'package:health_connector_core/health_connector_core_internal.dart';
+import 'package:health_connector_hk_ios/src/mappers/health_record_mappers/health_record_id_mapper.dart';
+import 'package:health_connector_hk_ios/src/mappers/metadata_mappers/metadata_mapper.dart';
+import 'package:health_connector_hk_ios/src/pigeon/health_connector_hk_ios_api.g.dart';
+import 'package:meta/meta.dart' show internal;
+
+/// Converts [AppleStandHourRecordDto] to [AppleStandHourRecord].
+@internal
+extension AppleStandHourRecordDtoToDomain on AppleStandHourRecordDto {
+  AppleStandHourRecord toDomain() {
+    return AppleStandHourRecord.internal(
+      id: id?.toDomain() ?? HealthRecordId.none,
+      startTime: DateTime.fromMillisecondsSinceEpoch(startTime, isUtc: true),
+      endTime: DateTime.fromMillisecondsSinceEpoch(endTime, isUtc: true),
+      metadata: metadata.toDomain(),
+      status: status.toDomain(),
+      startZoneOffsetSeconds: startZoneOffsetSeconds,
+      endZoneOffsetSeconds: endZoneOffsetSeconds,
+    );
+  }
+}
+
+/// Converts [AppleStandHourStatusDto] to [AppleStandHourStatus].
+@internal
+extension AppleStandHourStatusDtoToDomain on AppleStandHourStatusDto {
+  AppleStandHourStatus toDomain() {
+    return switch (this) {
+      AppleStandHourStatusDto.stood => AppleStandHourStatus.stood,
+      AppleStandHourStatusDto.idle => AppleStandHourStatus.idle,
+    };
+  }
+}

--- a/packages/health_connector_hk_ios/lib/src/mappers/health_record_mappers/health_record_mapper.dart
+++ b/packages/health_connector_hk_ios/lib/src/mappers/health_record_mappers/health_record_mapper.dart
@@ -1,4 +1,5 @@
 import 'package:health_connector_core/health_connector_core_internal.dart';
+import 'package:health_connector_hk_ios/src/mappers/health_record_mappers/activity/apple_stand_hour_record_mapper.dart';
 import 'package:health_connector_hk_ios/src/mappers/health_record_mappers/activity/low_cardio_fitness_event_record_mapper.dart';
 import 'package:health_connector_hk_ios/src/mappers/health_record_mappers/alcoholic_beverages_record_mapper.dart';
 import 'package:health_connector_hk_ios/src/mappers/health_record_mappers/blood_alcohol_content_record_mapper.dart';
@@ -496,6 +497,8 @@ extension HealthRecordToDto on HealthRecord {
         throw UnsupportedError(
           '$WalkingSteadinessEventRecord is read-only data type.',
         );
+      case final AppleStandHourRecord _:
+        throw UnsupportedError('$AppleStandHourRecord is read-only data type.');
       case final PersistentIntermenstrualBleedingEventRecord _:
         throw UnsupportedError(
           '$PersistentIntermenstrualBleedingEventRecord is '
@@ -744,6 +747,8 @@ extension HealthRecordDtoToDomain on HealthRecordDto {
         return RunningStrideLengthRecordDtoToDomain(dto).toDomain();
       case final WalkingSteadinessEventRecordDto dto:
         return WalkingSteadinessEventRecordDtoMapper(dto).toDomain();
+      case final AppleStandHourRecordDto dto:
+        return AppleStandHourRecordDtoToDomain(dto).toDomain();
       case final PersistentIntermenstrualBleedingEventRecordDto dto:
         return PersistentIntermenstrualBleedingEventRecordDtoToDomain(
           dto,

--- a/packages/health_connector_hk_ios/lib/src/pigeon/health_connector_hk_ios_api.g.dart
+++ b/packages/health_connector_hk_ios/lib/src/pigeon/health_connector_hk_ios_api.g.dart
@@ -1096,6 +1096,9 @@ enum HealthDataTypeDto {
 
   /// Headphone audio exposure event data.
   headphoneAudioExposureEvent,
+
+  /// Apple Stand Hour data.
+  appleStandHour,
 }
 
 /// Types of exercise state transitions.
@@ -1285,6 +1288,16 @@ enum HealthConnectorLogLevelDto {
 
   /// Error level for serious problems.
   error,
+}
+
+/// Whether the user completed the Stand or Roll goal during an hour.
+enum AppleStandHourStatusDto {
+  /// The user stood or rolled and moved for at least one continuous minute.
+  stood,
+
+  /// The user did not stand or roll and move for at least one continuous
+  /// minute.
+  idle,
 }
 
 /// Configuration data transfer object for Health Connector.
@@ -11496,6 +11509,85 @@ class NumberOfTimesFallenRecordDto extends HealthRecordDto {
   int get hashCode => Object.hashAll(_toList());
 }
 
+/// Represents an Apple Stand Hour record for platform transfer.
+class AppleStandHourRecordDto extends HealthRecordDto {
+  AppleStandHourRecordDto({
+    this.id,
+    required this.startTime,
+    required this.endTime,
+    required this.metadata,
+    required this.status,
+    this.startZoneOffsetSeconds,
+    this.endZoneOffsetSeconds,
+  });
+
+  /// Platform-assigned unique identifier.
+  String? id;
+
+  /// Start time in milliseconds since epoch (UTC).
+  int startTime;
+
+  /// End time in milliseconds since epoch (UTC).
+  int endTime;
+
+  /// Metadata about this record.
+  MetadataDto metadata;
+
+  /// Whether the Stand or Roll goal was completed during this hour.
+  AppleStandHourStatusDto status;
+
+  /// Timezone offset in seconds for start time.
+  int? startZoneOffsetSeconds;
+
+  /// Timezone offset in seconds for end time.
+  int? endZoneOffsetSeconds;
+
+  List<Object?> _toList() {
+    return <Object?>[
+      id,
+      startTime,
+      endTime,
+      metadata,
+      status,
+      startZoneOffsetSeconds,
+      endZoneOffsetSeconds,
+    ];
+  }
+
+  Object encode() {
+    return _toList();
+  }
+
+  static AppleStandHourRecordDto decode(Object result) {
+    result as List<Object?>;
+    return AppleStandHourRecordDto(
+      id: result[0] as String?,
+      startTime: result[1]! as int,
+      endTime: result[2]! as int,
+      metadata: result[3]! as MetadataDto,
+      status: result[4]! as AppleStandHourStatusDto,
+      startZoneOffsetSeconds: result[5] as int?,
+      endZoneOffsetSeconds: result[6] as int?,
+    );
+  }
+
+  @override
+  // ignore: avoid_equals_and_hash_code_on_mutable_classes
+  bool operator ==(Object other) {
+    if (other is! AppleStandHourRecordDto || other.runtimeType != runtimeType) {
+      return false;
+    }
+    if (identical(this, other)) {
+      return true;
+    }
+    return _deepEquals(encode(), other.encode());
+  }
+
+  @override
+  // ignore: avoid_equals_and_hash_code_on_mutable_classes
+  int get hashCode => Object.hashAll(_toList());
+}
+
 // ignore: camel_case_types
 class _PigeonCodecOverflow {
   _PigeonCodecOverflow({required this.type, required this.wrapped});
@@ -11522,99 +11614,103 @@ class _PigeonCodecOverflow {
 
     switch (type) {
       case 0:
-        return DietaryFiberRecordDto.decode(wrapped!);
+        return DietaryCholesterolRecordDto.decode(wrapped!);
       case 1:
-        return DietarySugarRecordDto.decode(wrapped!);
+        return DietaryFiberRecordDto.decode(wrapped!);
       case 2:
-        return DietaryVitaminARecordDto.decode(wrapped!);
+        return DietarySugarRecordDto.decode(wrapped!);
       case 3:
-        return DietaryVitaminB6RecordDto.decode(wrapped!);
+        return DietaryVitaminARecordDto.decode(wrapped!);
       case 4:
-        return DietaryVitaminB12RecordDto.decode(wrapped!);
+        return DietaryVitaminB6RecordDto.decode(wrapped!);
       case 5:
-        return DietaryVitaminCRecordDto.decode(wrapped!);
+        return DietaryVitaminB12RecordDto.decode(wrapped!);
       case 6:
-        return DietaryVitaminDRecordDto.decode(wrapped!);
+        return DietaryVitaminCRecordDto.decode(wrapped!);
       case 7:
-        return DietaryVitaminERecordDto.decode(wrapped!);
+        return DietaryVitaminDRecordDto.decode(wrapped!);
       case 8:
-        return LactationRecordDto.decode(wrapped!);
+        return DietaryVitaminERecordDto.decode(wrapped!);
       case 9:
-        return DietaryVitaminKRecordDto.decode(wrapped!);
+        return LactationRecordDto.decode(wrapped!);
       case 10:
-        return DietaryThiaminRecordDto.decode(wrapped!);
+        return DietaryVitaminKRecordDto.decode(wrapped!);
       case 11:
-        return DietaryRiboflavinRecordDto.decode(wrapped!);
+        return DietaryThiaminRecordDto.decode(wrapped!);
       case 12:
-        return DietaryNiacinRecordDto.decode(wrapped!);
+        return DietaryRiboflavinRecordDto.decode(wrapped!);
       case 13:
-        return DietaryFolateRecordDto.decode(wrapped!);
+        return DietaryNiacinRecordDto.decode(wrapped!);
       case 14:
-        return DietaryBiotinRecordDto.decode(wrapped!);
+        return DietaryFolateRecordDto.decode(wrapped!);
       case 15:
-        return DietaryPantothenicAcidRecordDto.decode(wrapped!);
+        return DietaryBiotinRecordDto.decode(wrapped!);
       case 16:
-        return DietaryCalciumRecordDto.decode(wrapped!);
+        return DietaryPantothenicAcidRecordDto.decode(wrapped!);
       case 17:
-        return DietaryIronRecordDto.decode(wrapped!);
+        return DietaryCalciumRecordDto.decode(wrapped!);
       case 18:
-        return DietaryMagnesiumRecordDto.decode(wrapped!);
+        return DietaryIronRecordDto.decode(wrapped!);
       case 19:
-        return DietaryManganeseRecordDto.decode(wrapped!);
+        return DietaryMagnesiumRecordDto.decode(wrapped!);
       case 20:
-        return DietaryPhosphorusRecordDto.decode(wrapped!);
+        return DietaryManganeseRecordDto.decode(wrapped!);
       case 21:
-        return DietaryPotassiumRecordDto.decode(wrapped!);
+        return DietaryPhosphorusRecordDto.decode(wrapped!);
       case 22:
-        return DietarySeleniumRecordDto.decode(wrapped!);
+        return DietaryPotassiumRecordDto.decode(wrapped!);
       case 23:
-        return DietarySodiumRecordDto.decode(wrapped!);
+        return DietarySeleniumRecordDto.decode(wrapped!);
       case 24:
-        return DietaryZincRecordDto.decode(wrapped!);
+        return DietarySodiumRecordDto.decode(wrapped!);
       case 25:
-        return NutritionRecordDto.decode(wrapped!);
+        return DietaryZincRecordDto.decode(wrapped!);
       case 26:
-        return BasalEnergyBurnedRecordDto.decode(wrapped!);
+        return NutritionRecordDto.decode(wrapped!);
       case 27:
-        return HealthDataSyncTokenDto.decode(wrapped!);
+        return BasalEnergyBurnedRecordDto.decode(wrapped!);
       case 28:
-        return HealthDataSyncResultDto.decode(wrapped!);
+        return HealthDataSyncTokenDto.decode(wrapped!);
       case 29:
-        return HealthDataPermissionRequestDto.decode(wrapped!);
+        return HealthDataSyncResultDto.decode(wrapped!);
       case 30:
-        return ExerciseRoutePermissionRequestDto.decode(wrapped!);
+        return HealthDataPermissionRequestDto.decode(wrapped!);
       case 31:
-        return PermissionsRequestDto.decode(wrapped!);
+        return ExerciseRoutePermissionRequestDto.decode(wrapped!);
       case 32:
-        return HealthDataPermissionRequestResultDto.decode(wrapped!);
+        return PermissionsRequestDto.decode(wrapped!);
       case 33:
-        return ExerciseRoutePermissionRequestResultDto.decode(wrapped!);
+        return HealthDataPermissionRequestResultDto.decode(wrapped!);
       case 34:
-        return AggregateRequestDto.decode(wrapped!);
+        return ExerciseRoutePermissionRequestResultDto.decode(wrapped!);
       case 35:
-        return DeleteRecordsByIdsRequestDto.decode(wrapped!);
+        return AggregateRequestDto.decode(wrapped!);
       case 36:
-        return DeleteRecordsByTimeRangeRequestDto.decode(wrapped!);
+        return DeleteRecordsByIdsRequestDto.decode(wrapped!);
       case 37:
-        return ReadRecordRequestDto.decode(wrapped!);
+        return DeleteRecordsByTimeRangeRequestDto.decode(wrapped!);
       case 38:
-        return ReadRecordsRequestDto.decode(wrapped!);
+        return ReadRecordRequestDto.decode(wrapped!);
       case 39:
-        return ReadRecordsResponseDto.decode(wrapped!);
+        return ReadRecordsRequestDto.decode(wrapped!);
       case 40:
-        return HealthConnectorExceptionDto.decode(wrapped!);
+        return ReadRecordsResponseDto.decode(wrapped!);
       case 41:
-        return HealthConnectorLogDto.decode(wrapped!);
+        return HealthConnectorExceptionDto.decode(wrapped!);
       case 42:
-        return PeripheralPerfusionIndexRecordDto.decode(wrapped!);
+        return HealthConnectorLogDto.decode(wrapped!);
       case 43:
-        return PersistentIntermenstrualBleedingEventRecordDto.decode(wrapped!);
+        return PeripheralPerfusionIndexRecordDto.decode(wrapped!);
       case 44:
-        return ProlongedMenstrualPeriodEventRecordDto.decode(wrapped!);
+        return PersistentIntermenstrualBleedingEventRecordDto.decode(wrapped!);
       case 45:
-        return AtrialFibrillationBurdenRecordDto.decode(wrapped!);
+        return ProlongedMenstrualPeriodEventRecordDto.decode(wrapped!);
       case 46:
+        return AtrialFibrillationBurdenRecordDto.decode(wrapped!);
+      case 47:
         return NumberOfTimesFallenRecordDto.decode(wrapped!);
+      case 48:
+        return AppleStandHourRecordDto.decode(wrapped!);
     }
     return null;
   }
@@ -11732,604 +11828,618 @@ class _PigeonCodec extends StandardMessageCodec {
     } else if (value is HealthConnectorLogLevelDto) {
       buffer.putUint8(163);
       writeValue(buffer, value.index);
-    } else if (value is HealthConnectorConfigDto) {
+    } else if (value is AppleStandHourStatusDto) {
       buffer.putUint8(164);
-      writeValue(buffer, value.encode());
-    } else if (value is OperatingSystemInfoDto) {
+      writeValue(buffer, value.index);
+    } else if (value is HealthConnectorConfigDto) {
       buffer.putUint8(165);
       writeValue(buffer, value.encode());
-    } else if (value is MetadataDto) {
+    } else if (value is OperatingSystemInfoDto) {
       buffer.putUint8(166);
       writeValue(buffer, value.encode());
-    } else if (value is RestingHeartRateRecordDto) {
+    } else if (value is MetadataDto) {
       buffer.putUint8(167);
       writeValue(buffer, value.encode());
-    } else if (value is WalkingHeartRateAverageRecordDto) {
+    } else if (value is RestingHeartRateRecordDto) {
       buffer.putUint8(168);
       writeValue(buffer, value.encode());
-    } else if (value is LowCardioFitnessEventRecordDto) {
+    } else if (value is WalkingHeartRateAverageRecordDto) {
       buffer.putUint8(169);
       writeValue(buffer, value.encode());
-    } else if (value is EnvironmentalAudioExposureEventRecordDto) {
+    } else if (value is LowCardioFitnessEventRecordDto) {
       buffer.putUint8(170);
       writeValue(buffer, value.encode());
-    } else if (value is HeadphoneAudioExposureEventRecordDto) {
+    } else if (value is EnvironmentalAudioExposureEventRecordDto) {
       buffer.putUint8(171);
       writeValue(buffer, value.encode());
-    } else if (value is EnvironmentalAudioExposureRecordDto) {
+    } else if (value is HeadphoneAudioExposureEventRecordDto) {
       buffer.putUint8(172);
       writeValue(buffer, value.encode());
-    } else if (value is HeadphoneAudioExposureRecordDto) {
+    } else if (value is EnvironmentalAudioExposureRecordDto) {
       buffer.putUint8(173);
       writeValue(buffer, value.encode());
-    } else if (value is LowHeartRateEventRecordDto) {
+    } else if (value is HeadphoneAudioExposureRecordDto) {
       buffer.putUint8(174);
       writeValue(buffer, value.encode());
-    } else if (value is HighHeartRateEventRecordDto) {
+    } else if (value is LowHeartRateEventRecordDto) {
       buffer.putUint8(175);
       writeValue(buffer, value.encode());
-    } else if (value is IrregularMenstrualCycleEventRecordDto) {
+    } else if (value is HighHeartRateEventRecordDto) {
       buffer.putUint8(176);
       writeValue(buffer, value.encode());
-    } else if (value is InfrequentMenstrualCycleEventRecordDto) {
+    } else if (value is IrregularMenstrualCycleEventRecordDto) {
       buffer.putUint8(177);
       writeValue(buffer, value.encode());
-    } else if (value is IrregularHeartRhythmEventRecordDto) {
+    } else if (value is InfrequentMenstrualCycleEventRecordDto) {
       buffer.putUint8(178);
       writeValue(buffer, value.encode());
-    } else if (value is WalkingSteadinessEventRecordDto) {
+    } else if (value is IrregularHeartRhythmEventRecordDto) {
       buffer.putUint8(179);
       writeValue(buffer, value.encode());
-    } else if (value is Vo2MaxRecordDto) {
+    } else if (value is WalkingSteadinessEventRecordDto) {
       buffer.putUint8(180);
       writeValue(buffer, value.encode());
-    } else if (value is ForcedVitalCapacityRecordDto) {
+    } else if (value is Vo2MaxRecordDto) {
       buffer.putUint8(181);
       writeValue(buffer, value.encode());
-    } else if (value is ForcedExpiratoryVolumeRecordDto) {
+    } else if (value is ForcedVitalCapacityRecordDto) {
       buffer.putUint8(182);
       writeValue(buffer, value.encode());
-    } else if (value is PeakExpiratoryFlowRateRecordDto) {
+    } else if (value is ForcedExpiratoryVolumeRecordDto) {
       buffer.putUint8(183);
       writeValue(buffer, value.encode());
-    } else if (value is BodyMassIndexRecordDto) {
+    } else if (value is PeakExpiratoryFlowRateRecordDto) {
       buffer.putUint8(184);
       writeValue(buffer, value.encode());
-    } else if (value is WaistCircumferenceRecordDto) {
+    } else if (value is BodyMassIndexRecordDto) {
       buffer.putUint8(185);
       writeValue(buffer, value.encode());
-    } else if (value is HeartRateVariabilitySDNNRecordDto) {
+    } else if (value is WaistCircumferenceRecordDto) {
       buffer.putUint8(186);
       writeValue(buffer, value.encode());
-    } else if (value is BloodGlucoseRecordDto) {
+    } else if (value is HeartRateVariabilitySDNNRecordDto) {
       buffer.putUint8(187);
       writeValue(buffer, value.encode());
-    } else if (value is ExerciseSessionStateTransitionEventDto) {
+    } else if (value is BloodGlucoseRecordDto) {
       buffer.putUint8(188);
       writeValue(buffer, value.encode());
-    } else if (value is ExerciseSessionMarkerEventDto) {
+    } else if (value is ExerciseSessionStateTransitionEventDto) {
       buffer.putUint8(189);
       writeValue(buffer, value.encode());
-    } else if (value is ExerciseSessionLapEventDto) {
+    } else if (value is ExerciseSessionMarkerEventDto) {
       buffer.putUint8(190);
       writeValue(buffer, value.encode());
-    } else if (value is ExerciseSessionSegmentEventDto) {
+    } else if (value is ExerciseSessionLapEventDto) {
       buffer.putUint8(191);
       writeValue(buffer, value.encode());
-    } else if (value is ExerciseRouteLocationDto) {
+    } else if (value is ExerciseSessionSegmentEventDto) {
       buffer.putUint8(192);
       writeValue(buffer, value.encode());
-    } else if (value is ExerciseRouteDto) {
+    } else if (value is ExerciseRouteLocationDto) {
       buffer.putUint8(193);
       writeValue(buffer, value.encode());
-    } else if (value is ExerciseSessionRecordDto) {
+    } else if (value is ExerciseRouteDto) {
       buffer.putUint8(194);
       writeValue(buffer, value.encode());
-    } else if (value is MindfulnessSessionRecordDto) {
+    } else if (value is ExerciseSessionRecordDto) {
       buffer.putUint8(195);
       writeValue(buffer, value.encode());
-    } else if (value is ActiveEnergyBurnedRecordDto) {
+    } else if (value is MindfulnessSessionRecordDto) {
       buffer.putUint8(196);
       writeValue(buffer, value.encode());
-    } else if (value is AlcoholicBeveragesRecordDto) {
+    } else if (value is ActiveEnergyBurnedRecordDto) {
       buffer.putUint8(197);
       writeValue(buffer, value.encode());
-    } else if (value is ExerciseTimeRecordDto) {
+    } else if (value is AlcoholicBeveragesRecordDto) {
       buffer.putUint8(198);
       writeValue(buffer, value.encode());
-    } else if (value is MoveTimeRecordDto) {
+    } else if (value is ExerciseTimeRecordDto) {
       buffer.putUint8(199);
       writeValue(buffer, value.encode());
-    } else if (value is StandTimeRecordDto) {
+    } else if (value is MoveTimeRecordDto) {
       buffer.putUint8(200);
       writeValue(buffer, value.encode());
-    } else if (value is WalkingSteadinessRecordDto) {
+    } else if (value is StandTimeRecordDto) {
       buffer.putUint8(201);
       writeValue(buffer, value.encode());
-    } else if (value is WalkingAsymmetryPercentageRecordDto) {
+    } else if (value is WalkingSteadinessRecordDto) {
       buffer.putUint8(202);
       writeValue(buffer, value.encode());
-    } else if (value is WalkingDoubleSupportPercentageRecordDto) {
+    } else if (value is WalkingAsymmetryPercentageRecordDto) {
       buffer.putUint8(203);
       writeValue(buffer, value.encode());
-    } else if (value is WalkingStepLengthRecordDto) {
+    } else if (value is WalkingDoubleSupportPercentageRecordDto) {
       buffer.putUint8(204);
       writeValue(buffer, value.encode());
-    } else if (value is RunningGroundContactTimeRecordDto) {
+    } else if (value is WalkingStepLengthRecordDto) {
       buffer.putUint8(205);
       writeValue(buffer, value.encode());
-    } else if (value is RunningStrideLengthRecordDto) {
+    } else if (value is RunningGroundContactTimeRecordDto) {
       buffer.putUint8(206);
       writeValue(buffer, value.encode());
-    } else if (value is DistanceActivityRecordDto) {
+    } else if (value is RunningStrideLengthRecordDto) {
       buffer.putUint8(207);
       writeValue(buffer, value.encode());
-    } else if (value is SpeedActivityRecordDto) {
+    } else if (value is DistanceActivityRecordDto) {
       buffer.putUint8(208);
       writeValue(buffer, value.encode());
-    } else if (value is FloorsClimbedRecordDto) {
+    } else if (value is SpeedActivityRecordDto) {
       buffer.putUint8(209);
       writeValue(buffer, value.encode());
-    } else if (value is WheelchairPushesRecordDto) {
+    } else if (value is FloorsClimbedRecordDto) {
       buffer.putUint8(210);
       writeValue(buffer, value.encode());
-    } else if (value is StepsRecordDto) {
+    } else if (value is WheelchairPushesRecordDto) {
       buffer.putUint8(211);
       writeValue(buffer, value.encode());
-    } else if (value is SwimmingStrokesRecordDto) {
+    } else if (value is StepsRecordDto) {
       buffer.putUint8(212);
       writeValue(buffer, value.encode());
-    } else if (value is WeightRecordDto) {
+    } else if (value is SwimmingStrokesRecordDto) {
       buffer.putUint8(213);
       writeValue(buffer, value.encode());
-    } else if (value is BloodPressureRecordDto) {
+    } else if (value is WeightRecordDto) {
       buffer.putUint8(214);
       writeValue(buffer, value.encode());
-    } else if (value is SystolicBloodPressureRecordDto) {
+    } else if (value is BloodPressureRecordDto) {
       buffer.putUint8(215);
       writeValue(buffer, value.encode());
-    } else if (value is DiastolicBloodPressureRecordDto) {
+    } else if (value is SystolicBloodPressureRecordDto) {
       buffer.putUint8(216);
       writeValue(buffer, value.encode());
-    } else if (value is LeanBodyMassRecordDto) {
+    } else if (value is DiastolicBloodPressureRecordDto) {
       buffer.putUint8(217);
       writeValue(buffer, value.encode());
-    } else if (value is HeightRecordDto) {
+    } else if (value is LeanBodyMassRecordDto) {
       buffer.putUint8(218);
       writeValue(buffer, value.encode());
-    } else if (value is BloodAlcoholContentRecordDto) {
+    } else if (value is HeightRecordDto) {
       buffer.putUint8(219);
       writeValue(buffer, value.encode());
-    } else if (value is BodyFatPercentageRecordDto) {
+    } else if (value is BloodAlcoholContentRecordDto) {
       buffer.putUint8(220);
       writeValue(buffer, value.encode());
-    } else if (value is BodyTemperatureRecordDto) {
+    } else if (value is BodyFatPercentageRecordDto) {
       buffer.putUint8(221);
       writeValue(buffer, value.encode());
-    } else if (value is BasalBodyTemperatureRecordDto) {
+    } else if (value is BodyTemperatureRecordDto) {
       buffer.putUint8(222);
       writeValue(buffer, value.encode());
-    } else if (value is SleepingWristTemperatureRecordDto) {
+    } else if (value is BasalBodyTemperatureRecordDto) {
       buffer.putUint8(223);
       writeValue(buffer, value.encode());
-    } else if (value is CervicalMucusRecordDto) {
+    } else if (value is SleepingWristTemperatureRecordDto) {
       buffer.putUint8(224);
       writeValue(buffer, value.encode());
-    } else if (value is CyclingPowerRecordDto) {
+    } else if (value is CervicalMucusRecordDto) {
       buffer.putUint8(225);
       writeValue(buffer, value.encode());
-    } else if (value is RunningPowerRecordDto) {
+    } else if (value is CyclingPowerRecordDto) {
       buffer.putUint8(226);
       writeValue(buffer, value.encode());
-    } else if (value is OxygenSaturationRecordDto) {
+    } else if (value is RunningPowerRecordDto) {
       buffer.putUint8(227);
       writeValue(buffer, value.encode());
-    } else if (value is OvulationTestRecordDto) {
+    } else if (value is OxygenSaturationRecordDto) {
       buffer.putUint8(228);
       writeValue(buffer, value.encode());
-    } else if (value is PregnancyTestRecordDto) {
+    } else if (value is OvulationTestRecordDto) {
       buffer.putUint8(229);
       writeValue(buffer, value.encode());
-    } else if (value is PregnancyRecordDto) {
+    } else if (value is PregnancyTestRecordDto) {
       buffer.putUint8(230);
       writeValue(buffer, value.encode());
-    } else if (value is ContraceptiveRecordDto) {
+    } else if (value is PregnancyRecordDto) {
       buffer.putUint8(231);
       writeValue(buffer, value.encode());
-    } else if (value is ProgesteroneTestRecordDto) {
+    } else if (value is ContraceptiveRecordDto) {
       buffer.putUint8(232);
       writeValue(buffer, value.encode());
-    } else if (value is IntermenstrualBleedingRecordDto) {
+    } else if (value is ProgesteroneTestRecordDto) {
       buffer.putUint8(233);
       writeValue(buffer, value.encode());
-    } else if (value is MenstrualFlowRecordDto) {
+    } else if (value is IntermenstrualBleedingRecordDto) {
       buffer.putUint8(234);
       writeValue(buffer, value.encode());
-    } else if (value is RespiratoryRateRecordDto) {
+    } else if (value is MenstrualFlowRecordDto) {
       buffer.putUint8(235);
       writeValue(buffer, value.encode());
-    } else if (value is ElectrodermalActivityRecordDto) {
+    } else if (value is RespiratoryRateRecordDto) {
       buffer.putUint8(236);
       writeValue(buffer, value.encode());
-    } else if (value is HydrationRecordDto) {
+    } else if (value is ElectrodermalActivityRecordDto) {
       buffer.putUint8(237);
       writeValue(buffer, value.encode());
-    } else if (value is InsulinDeliveryRecordDto) {
+    } else if (value is HydrationRecordDto) {
       buffer.putUint8(238);
       writeValue(buffer, value.encode());
-    } else if (value is InhalerUsageRecordDto) {
+    } else if (value is InsulinDeliveryRecordDto) {
       buffer.putUint8(239);
       writeValue(buffer, value.encode());
-    } else if (value is HeartRateMeasurementDto) {
+    } else if (value is InhalerUsageRecordDto) {
       buffer.putUint8(240);
       writeValue(buffer, value.encode());
-    } else if (value is HeartRateRecordDto) {
+    } else if (value is HeartRateMeasurementDto) {
       buffer.putUint8(241);
       writeValue(buffer, value.encode());
-    } else if (value is CyclingPedalingCadenceRecordDto) {
+    } else if (value is HeartRateRecordDto) {
       buffer.putUint8(242);
       writeValue(buffer, value.encode());
-    } else if (value is HeartRateRecoveryOneMinuteRecordDto) {
+    } else if (value is CyclingPedalingCadenceRecordDto) {
       buffer.putUint8(243);
       writeValue(buffer, value.encode());
-    } else if (value is SleepStageRecordDto) {
+    } else if (value is HeartRateRecoveryOneMinuteRecordDto) {
       buffer.putUint8(244);
       writeValue(buffer, value.encode());
-    } else if (value is SexualActivityRecordDto) {
+    } else if (value is SleepStageRecordDto) {
       buffer.putUint8(245);
       writeValue(buffer, value.encode());
-    } else if (value is DietaryEnergyConsumedRecordDto) {
+    } else if (value is SexualActivityRecordDto) {
       buffer.putUint8(246);
       writeValue(buffer, value.encode());
-    } else if (value is DietaryCaffeineRecordDto) {
+    } else if (value is DietaryEnergyConsumedRecordDto) {
       buffer.putUint8(247);
       writeValue(buffer, value.encode());
-    } else if (value is DietaryProteinRecordDto) {
+    } else if (value is DietaryCaffeineRecordDto) {
       buffer.putUint8(248);
       writeValue(buffer, value.encode());
-    } else if (value is DietaryTotalCarbohydrateRecordDto) {
+    } else if (value is DietaryProteinRecordDto) {
       buffer.putUint8(249);
       writeValue(buffer, value.encode());
-    } else if (value is DietaryTotalFatRecordDto) {
+    } else if (value is DietaryTotalCarbohydrateRecordDto) {
       buffer.putUint8(250);
       writeValue(buffer, value.encode());
-    } else if (value is DietarySaturatedFatRecordDto) {
+    } else if (value is DietaryTotalFatRecordDto) {
       buffer.putUint8(251);
       writeValue(buffer, value.encode());
-    } else if (value is DietaryMonounsaturatedFatRecordDto) {
+    } else if (value is DietarySaturatedFatRecordDto) {
       buffer.putUint8(252);
       writeValue(buffer, value.encode());
-    } else if (value is DietaryPolyunsaturatedFatRecordDto) {
+    } else if (value is DietaryMonounsaturatedFatRecordDto) {
       buffer.putUint8(253);
       writeValue(buffer, value.encode());
-    } else if (value is DietaryCholesterolRecordDto) {
+    } else if (value is DietaryPolyunsaturatedFatRecordDto) {
       buffer.putUint8(254);
       writeValue(buffer, value.encode());
-    } else if (value is DietaryFiberRecordDto) {
+    } else if (value is DietaryCholesterolRecordDto) {
       final _PigeonCodecOverflow wrap = _PigeonCodecOverflow(
         type: 0,
         wrapped: value.encode(),
       );
       buffer.putUint8(255);
       writeValue(buffer, wrap.encode());
-    } else if (value is DietarySugarRecordDto) {
+    } else if (value is DietaryFiberRecordDto) {
       final _PigeonCodecOverflow wrap = _PigeonCodecOverflow(
         type: 1,
         wrapped: value.encode(),
       );
       buffer.putUint8(255);
       writeValue(buffer, wrap.encode());
-    } else if (value is DietaryVitaminARecordDto) {
+    } else if (value is DietarySugarRecordDto) {
       final _PigeonCodecOverflow wrap = _PigeonCodecOverflow(
         type: 2,
         wrapped: value.encode(),
       );
       buffer.putUint8(255);
       writeValue(buffer, wrap.encode());
-    } else if (value is DietaryVitaminB6RecordDto) {
+    } else if (value is DietaryVitaminARecordDto) {
       final _PigeonCodecOverflow wrap = _PigeonCodecOverflow(
         type: 3,
         wrapped: value.encode(),
       );
       buffer.putUint8(255);
       writeValue(buffer, wrap.encode());
-    } else if (value is DietaryVitaminB12RecordDto) {
+    } else if (value is DietaryVitaminB6RecordDto) {
       final _PigeonCodecOverflow wrap = _PigeonCodecOverflow(
         type: 4,
         wrapped: value.encode(),
       );
       buffer.putUint8(255);
       writeValue(buffer, wrap.encode());
-    } else if (value is DietaryVitaminCRecordDto) {
+    } else if (value is DietaryVitaminB12RecordDto) {
       final _PigeonCodecOverflow wrap = _PigeonCodecOverflow(
         type: 5,
         wrapped: value.encode(),
       );
       buffer.putUint8(255);
       writeValue(buffer, wrap.encode());
-    } else if (value is DietaryVitaminDRecordDto) {
+    } else if (value is DietaryVitaminCRecordDto) {
       final _PigeonCodecOverflow wrap = _PigeonCodecOverflow(
         type: 6,
         wrapped: value.encode(),
       );
       buffer.putUint8(255);
       writeValue(buffer, wrap.encode());
-    } else if (value is DietaryVitaminERecordDto) {
+    } else if (value is DietaryVitaminDRecordDto) {
       final _PigeonCodecOverflow wrap = _PigeonCodecOverflow(
         type: 7,
         wrapped: value.encode(),
       );
       buffer.putUint8(255);
       writeValue(buffer, wrap.encode());
-    } else if (value is LactationRecordDto) {
+    } else if (value is DietaryVitaminERecordDto) {
       final _PigeonCodecOverflow wrap = _PigeonCodecOverflow(
         type: 8,
         wrapped: value.encode(),
       );
       buffer.putUint8(255);
       writeValue(buffer, wrap.encode());
-    } else if (value is DietaryVitaminKRecordDto) {
+    } else if (value is LactationRecordDto) {
       final _PigeonCodecOverflow wrap = _PigeonCodecOverflow(
         type: 9,
         wrapped: value.encode(),
       );
       buffer.putUint8(255);
       writeValue(buffer, wrap.encode());
-    } else if (value is DietaryThiaminRecordDto) {
+    } else if (value is DietaryVitaminKRecordDto) {
       final _PigeonCodecOverflow wrap = _PigeonCodecOverflow(
         type: 10,
         wrapped: value.encode(),
       );
       buffer.putUint8(255);
       writeValue(buffer, wrap.encode());
-    } else if (value is DietaryRiboflavinRecordDto) {
+    } else if (value is DietaryThiaminRecordDto) {
       final _PigeonCodecOverflow wrap = _PigeonCodecOverflow(
         type: 11,
         wrapped: value.encode(),
       );
       buffer.putUint8(255);
       writeValue(buffer, wrap.encode());
-    } else if (value is DietaryNiacinRecordDto) {
+    } else if (value is DietaryRiboflavinRecordDto) {
       final _PigeonCodecOverflow wrap = _PigeonCodecOverflow(
         type: 12,
         wrapped: value.encode(),
       );
       buffer.putUint8(255);
       writeValue(buffer, wrap.encode());
-    } else if (value is DietaryFolateRecordDto) {
+    } else if (value is DietaryNiacinRecordDto) {
       final _PigeonCodecOverflow wrap = _PigeonCodecOverflow(
         type: 13,
         wrapped: value.encode(),
       );
       buffer.putUint8(255);
       writeValue(buffer, wrap.encode());
-    } else if (value is DietaryBiotinRecordDto) {
+    } else if (value is DietaryFolateRecordDto) {
       final _PigeonCodecOverflow wrap = _PigeonCodecOverflow(
         type: 14,
         wrapped: value.encode(),
       );
       buffer.putUint8(255);
       writeValue(buffer, wrap.encode());
-    } else if (value is DietaryPantothenicAcidRecordDto) {
+    } else if (value is DietaryBiotinRecordDto) {
       final _PigeonCodecOverflow wrap = _PigeonCodecOverflow(
         type: 15,
         wrapped: value.encode(),
       );
       buffer.putUint8(255);
       writeValue(buffer, wrap.encode());
-    } else if (value is DietaryCalciumRecordDto) {
+    } else if (value is DietaryPantothenicAcidRecordDto) {
       final _PigeonCodecOverflow wrap = _PigeonCodecOverflow(
         type: 16,
         wrapped: value.encode(),
       );
       buffer.putUint8(255);
       writeValue(buffer, wrap.encode());
-    } else if (value is DietaryIronRecordDto) {
+    } else if (value is DietaryCalciumRecordDto) {
       final _PigeonCodecOverflow wrap = _PigeonCodecOverflow(
         type: 17,
         wrapped: value.encode(),
       );
       buffer.putUint8(255);
       writeValue(buffer, wrap.encode());
-    } else if (value is DietaryMagnesiumRecordDto) {
+    } else if (value is DietaryIronRecordDto) {
       final _PigeonCodecOverflow wrap = _PigeonCodecOverflow(
         type: 18,
         wrapped: value.encode(),
       );
       buffer.putUint8(255);
       writeValue(buffer, wrap.encode());
-    } else if (value is DietaryManganeseRecordDto) {
+    } else if (value is DietaryMagnesiumRecordDto) {
       final _PigeonCodecOverflow wrap = _PigeonCodecOverflow(
         type: 19,
         wrapped: value.encode(),
       );
       buffer.putUint8(255);
       writeValue(buffer, wrap.encode());
-    } else if (value is DietaryPhosphorusRecordDto) {
+    } else if (value is DietaryManganeseRecordDto) {
       final _PigeonCodecOverflow wrap = _PigeonCodecOverflow(
         type: 20,
         wrapped: value.encode(),
       );
       buffer.putUint8(255);
       writeValue(buffer, wrap.encode());
-    } else if (value is DietaryPotassiumRecordDto) {
+    } else if (value is DietaryPhosphorusRecordDto) {
       final _PigeonCodecOverflow wrap = _PigeonCodecOverflow(
         type: 21,
         wrapped: value.encode(),
       );
       buffer.putUint8(255);
       writeValue(buffer, wrap.encode());
-    } else if (value is DietarySeleniumRecordDto) {
+    } else if (value is DietaryPotassiumRecordDto) {
       final _PigeonCodecOverflow wrap = _PigeonCodecOverflow(
         type: 22,
         wrapped: value.encode(),
       );
       buffer.putUint8(255);
       writeValue(buffer, wrap.encode());
-    } else if (value is DietarySodiumRecordDto) {
+    } else if (value is DietarySeleniumRecordDto) {
       final _PigeonCodecOverflow wrap = _PigeonCodecOverflow(
         type: 23,
         wrapped: value.encode(),
       );
       buffer.putUint8(255);
       writeValue(buffer, wrap.encode());
-    } else if (value is DietaryZincRecordDto) {
+    } else if (value is DietarySodiumRecordDto) {
       final _PigeonCodecOverflow wrap = _PigeonCodecOverflow(
         type: 24,
         wrapped: value.encode(),
       );
       buffer.putUint8(255);
       writeValue(buffer, wrap.encode());
-    } else if (value is NutritionRecordDto) {
+    } else if (value is DietaryZincRecordDto) {
       final _PigeonCodecOverflow wrap = _PigeonCodecOverflow(
         type: 25,
         wrapped: value.encode(),
       );
       buffer.putUint8(255);
       writeValue(buffer, wrap.encode());
-    } else if (value is BasalEnergyBurnedRecordDto) {
+    } else if (value is NutritionRecordDto) {
       final _PigeonCodecOverflow wrap = _PigeonCodecOverflow(
         type: 26,
         wrapped: value.encode(),
       );
       buffer.putUint8(255);
       writeValue(buffer, wrap.encode());
-    } else if (value is HealthDataSyncTokenDto) {
+    } else if (value is BasalEnergyBurnedRecordDto) {
       final _PigeonCodecOverflow wrap = _PigeonCodecOverflow(
         type: 27,
         wrapped: value.encode(),
       );
       buffer.putUint8(255);
       writeValue(buffer, wrap.encode());
-    } else if (value is HealthDataSyncResultDto) {
+    } else if (value is HealthDataSyncTokenDto) {
       final _PigeonCodecOverflow wrap = _PigeonCodecOverflow(
         type: 28,
         wrapped: value.encode(),
       );
       buffer.putUint8(255);
       writeValue(buffer, wrap.encode());
-    } else if (value is HealthDataPermissionRequestDto) {
+    } else if (value is HealthDataSyncResultDto) {
       final _PigeonCodecOverflow wrap = _PigeonCodecOverflow(
         type: 29,
         wrapped: value.encode(),
       );
       buffer.putUint8(255);
       writeValue(buffer, wrap.encode());
-    } else if (value is ExerciseRoutePermissionRequestDto) {
+    } else if (value is HealthDataPermissionRequestDto) {
       final _PigeonCodecOverflow wrap = _PigeonCodecOverflow(
         type: 30,
         wrapped: value.encode(),
       );
       buffer.putUint8(255);
       writeValue(buffer, wrap.encode());
-    } else if (value is PermissionsRequestDto) {
+    } else if (value is ExerciseRoutePermissionRequestDto) {
       final _PigeonCodecOverflow wrap = _PigeonCodecOverflow(
         type: 31,
         wrapped: value.encode(),
       );
       buffer.putUint8(255);
       writeValue(buffer, wrap.encode());
-    } else if (value is HealthDataPermissionRequestResultDto) {
+    } else if (value is PermissionsRequestDto) {
       final _PigeonCodecOverflow wrap = _PigeonCodecOverflow(
         type: 32,
         wrapped: value.encode(),
       );
       buffer.putUint8(255);
       writeValue(buffer, wrap.encode());
-    } else if (value is ExerciseRoutePermissionRequestResultDto) {
+    } else if (value is HealthDataPermissionRequestResultDto) {
       final _PigeonCodecOverflow wrap = _PigeonCodecOverflow(
         type: 33,
         wrapped: value.encode(),
       );
       buffer.putUint8(255);
       writeValue(buffer, wrap.encode());
-    } else if (value is AggregateRequestDto) {
+    } else if (value is ExerciseRoutePermissionRequestResultDto) {
       final _PigeonCodecOverflow wrap = _PigeonCodecOverflow(
         type: 34,
         wrapped: value.encode(),
       );
       buffer.putUint8(255);
       writeValue(buffer, wrap.encode());
-    } else if (value is DeleteRecordsByIdsRequestDto) {
+    } else if (value is AggregateRequestDto) {
       final _PigeonCodecOverflow wrap = _PigeonCodecOverflow(
         type: 35,
         wrapped: value.encode(),
       );
       buffer.putUint8(255);
       writeValue(buffer, wrap.encode());
-    } else if (value is DeleteRecordsByTimeRangeRequestDto) {
+    } else if (value is DeleteRecordsByIdsRequestDto) {
       final _PigeonCodecOverflow wrap = _PigeonCodecOverflow(
         type: 36,
         wrapped: value.encode(),
       );
       buffer.putUint8(255);
       writeValue(buffer, wrap.encode());
-    } else if (value is ReadRecordRequestDto) {
+    } else if (value is DeleteRecordsByTimeRangeRequestDto) {
       final _PigeonCodecOverflow wrap = _PigeonCodecOverflow(
         type: 37,
         wrapped: value.encode(),
       );
       buffer.putUint8(255);
       writeValue(buffer, wrap.encode());
-    } else if (value is ReadRecordsRequestDto) {
+    } else if (value is ReadRecordRequestDto) {
       final _PigeonCodecOverflow wrap = _PigeonCodecOverflow(
         type: 38,
         wrapped: value.encode(),
       );
       buffer.putUint8(255);
       writeValue(buffer, wrap.encode());
-    } else if (value is ReadRecordsResponseDto) {
+    } else if (value is ReadRecordsRequestDto) {
       final _PigeonCodecOverflow wrap = _PigeonCodecOverflow(
         type: 39,
         wrapped: value.encode(),
       );
       buffer.putUint8(255);
       writeValue(buffer, wrap.encode());
-    } else if (value is HealthConnectorExceptionDto) {
+    } else if (value is ReadRecordsResponseDto) {
       final _PigeonCodecOverflow wrap = _PigeonCodecOverflow(
         type: 40,
         wrapped: value.encode(),
       );
       buffer.putUint8(255);
       writeValue(buffer, wrap.encode());
-    } else if (value is HealthConnectorLogDto) {
+    } else if (value is HealthConnectorExceptionDto) {
       final _PigeonCodecOverflow wrap = _PigeonCodecOverflow(
         type: 41,
         wrapped: value.encode(),
       );
       buffer.putUint8(255);
       writeValue(buffer, wrap.encode());
-    } else if (value is PeripheralPerfusionIndexRecordDto) {
+    } else if (value is HealthConnectorLogDto) {
       final _PigeonCodecOverflow wrap = _PigeonCodecOverflow(
         type: 42,
         wrapped: value.encode(),
       );
       buffer.putUint8(255);
       writeValue(buffer, wrap.encode());
-    } else if (value is PersistentIntermenstrualBleedingEventRecordDto) {
+    } else if (value is PeripheralPerfusionIndexRecordDto) {
       final _PigeonCodecOverflow wrap = _PigeonCodecOverflow(
         type: 43,
         wrapped: value.encode(),
       );
       buffer.putUint8(255);
       writeValue(buffer, wrap.encode());
-    } else if (value is ProlongedMenstrualPeriodEventRecordDto) {
+    } else if (value is PersistentIntermenstrualBleedingEventRecordDto) {
       final _PigeonCodecOverflow wrap = _PigeonCodecOverflow(
         type: 44,
         wrapped: value.encode(),
       );
       buffer.putUint8(255);
       writeValue(buffer, wrap.encode());
-    } else if (value is AtrialFibrillationBurdenRecordDto) {
+    } else if (value is ProlongedMenstrualPeriodEventRecordDto) {
       final _PigeonCodecOverflow wrap = _PigeonCodecOverflow(
         type: 45,
         wrapped: value.encode(),
       );
       buffer.putUint8(255);
       writeValue(buffer, wrap.encode());
-    } else if (value is NumberOfTimesFallenRecordDto) {
+    } else if (value is AtrialFibrillationBurdenRecordDto) {
       final _PigeonCodecOverflow wrap = _PigeonCodecOverflow(
         type: 46,
+        wrapped: value.encode(),
+      );
+      buffer.putUint8(255);
+      writeValue(buffer, wrap.encode());
+    } else if (value is NumberOfTimesFallenRecordDto) {
+      final _PigeonCodecOverflow wrap = _PigeonCodecOverflow(
+        type: 47,
+        wrapped: value.encode(),
+      );
+      buffer.putUint8(255);
+      writeValue(buffer, wrap.encode());
+    } else if (value is AppleStandHourRecordDto) {
+      final _PigeonCodecOverflow wrap = _PigeonCodecOverflow(
+        type: 48,
         wrapped: value.encode(),
       );
       buffer.putUint8(255);
@@ -12458,195 +12568,196 @@ class _PigeonCodec extends StandardMessageCodec {
         final int? value = readValue(buffer) as int?;
         return value == null ? null : HealthConnectorLogLevelDto.values[value];
       case 164:
-        return HealthConnectorConfigDto.decode(readValue(buffer)!);
+        final int? value = readValue(buffer) as int?;
+        return value == null ? null : AppleStandHourStatusDto.values[value];
       case 165:
-        return OperatingSystemInfoDto.decode(readValue(buffer)!);
+        return HealthConnectorConfigDto.decode(readValue(buffer)!);
       case 166:
-        return MetadataDto.decode(readValue(buffer)!);
+        return OperatingSystemInfoDto.decode(readValue(buffer)!);
       case 167:
-        return RestingHeartRateRecordDto.decode(readValue(buffer)!);
+        return MetadataDto.decode(readValue(buffer)!);
       case 168:
-        return WalkingHeartRateAverageRecordDto.decode(readValue(buffer)!);
+        return RestingHeartRateRecordDto.decode(readValue(buffer)!);
       case 169:
-        return LowCardioFitnessEventRecordDto.decode(readValue(buffer)!);
+        return WalkingHeartRateAverageRecordDto.decode(readValue(buffer)!);
       case 170:
+        return LowCardioFitnessEventRecordDto.decode(readValue(buffer)!);
+      case 171:
         return EnvironmentalAudioExposureEventRecordDto.decode(
           readValue(buffer)!,
         );
-      case 171:
-        return HeadphoneAudioExposureEventRecordDto.decode(readValue(buffer)!);
       case 172:
-        return EnvironmentalAudioExposureRecordDto.decode(readValue(buffer)!);
+        return HeadphoneAudioExposureEventRecordDto.decode(readValue(buffer)!);
       case 173:
-        return HeadphoneAudioExposureRecordDto.decode(readValue(buffer)!);
+        return EnvironmentalAudioExposureRecordDto.decode(readValue(buffer)!);
       case 174:
-        return LowHeartRateEventRecordDto.decode(readValue(buffer)!);
+        return HeadphoneAudioExposureRecordDto.decode(readValue(buffer)!);
       case 175:
-        return HighHeartRateEventRecordDto.decode(readValue(buffer)!);
+        return LowHeartRateEventRecordDto.decode(readValue(buffer)!);
       case 176:
-        return IrregularMenstrualCycleEventRecordDto.decode(readValue(buffer)!);
+        return HighHeartRateEventRecordDto.decode(readValue(buffer)!);
       case 177:
+        return IrregularMenstrualCycleEventRecordDto.decode(readValue(buffer)!);
+      case 178:
         return InfrequentMenstrualCycleEventRecordDto.decode(
           readValue(buffer)!,
         );
-      case 178:
-        return IrregularHeartRhythmEventRecordDto.decode(readValue(buffer)!);
       case 179:
-        return WalkingSteadinessEventRecordDto.decode(readValue(buffer)!);
+        return IrregularHeartRhythmEventRecordDto.decode(readValue(buffer)!);
       case 180:
-        return Vo2MaxRecordDto.decode(readValue(buffer)!);
+        return WalkingSteadinessEventRecordDto.decode(readValue(buffer)!);
       case 181:
-        return ForcedVitalCapacityRecordDto.decode(readValue(buffer)!);
+        return Vo2MaxRecordDto.decode(readValue(buffer)!);
       case 182:
-        return ForcedExpiratoryVolumeRecordDto.decode(readValue(buffer)!);
+        return ForcedVitalCapacityRecordDto.decode(readValue(buffer)!);
       case 183:
-        return PeakExpiratoryFlowRateRecordDto.decode(readValue(buffer)!);
+        return ForcedExpiratoryVolumeRecordDto.decode(readValue(buffer)!);
       case 184:
-        return BodyMassIndexRecordDto.decode(readValue(buffer)!);
+        return PeakExpiratoryFlowRateRecordDto.decode(readValue(buffer)!);
       case 185:
-        return WaistCircumferenceRecordDto.decode(readValue(buffer)!);
+        return BodyMassIndexRecordDto.decode(readValue(buffer)!);
       case 186:
-        return HeartRateVariabilitySDNNRecordDto.decode(readValue(buffer)!);
+        return WaistCircumferenceRecordDto.decode(readValue(buffer)!);
       case 187:
-        return BloodGlucoseRecordDto.decode(readValue(buffer)!);
+        return HeartRateVariabilitySDNNRecordDto.decode(readValue(buffer)!);
       case 188:
+        return BloodGlucoseRecordDto.decode(readValue(buffer)!);
+      case 189:
         return ExerciseSessionStateTransitionEventDto.decode(
           readValue(buffer)!,
         );
-      case 189:
-        return ExerciseSessionMarkerEventDto.decode(readValue(buffer)!);
       case 190:
-        return ExerciseSessionLapEventDto.decode(readValue(buffer)!);
+        return ExerciseSessionMarkerEventDto.decode(readValue(buffer)!);
       case 191:
-        return ExerciseSessionSegmentEventDto.decode(readValue(buffer)!);
+        return ExerciseSessionLapEventDto.decode(readValue(buffer)!);
       case 192:
-        return ExerciseRouteLocationDto.decode(readValue(buffer)!);
+        return ExerciseSessionSegmentEventDto.decode(readValue(buffer)!);
       case 193:
-        return ExerciseRouteDto.decode(readValue(buffer)!);
+        return ExerciseRouteLocationDto.decode(readValue(buffer)!);
       case 194:
-        return ExerciseSessionRecordDto.decode(readValue(buffer)!);
+        return ExerciseRouteDto.decode(readValue(buffer)!);
       case 195:
-        return MindfulnessSessionRecordDto.decode(readValue(buffer)!);
+        return ExerciseSessionRecordDto.decode(readValue(buffer)!);
       case 196:
-        return ActiveEnergyBurnedRecordDto.decode(readValue(buffer)!);
+        return MindfulnessSessionRecordDto.decode(readValue(buffer)!);
       case 197:
-        return AlcoholicBeveragesRecordDto.decode(readValue(buffer)!);
+        return ActiveEnergyBurnedRecordDto.decode(readValue(buffer)!);
       case 198:
-        return ExerciseTimeRecordDto.decode(readValue(buffer)!);
+        return AlcoholicBeveragesRecordDto.decode(readValue(buffer)!);
       case 199:
-        return MoveTimeRecordDto.decode(readValue(buffer)!);
+        return ExerciseTimeRecordDto.decode(readValue(buffer)!);
       case 200:
-        return StandTimeRecordDto.decode(readValue(buffer)!);
+        return MoveTimeRecordDto.decode(readValue(buffer)!);
       case 201:
-        return WalkingSteadinessRecordDto.decode(readValue(buffer)!);
+        return StandTimeRecordDto.decode(readValue(buffer)!);
       case 202:
-        return WalkingAsymmetryPercentageRecordDto.decode(readValue(buffer)!);
+        return WalkingSteadinessRecordDto.decode(readValue(buffer)!);
       case 203:
+        return WalkingAsymmetryPercentageRecordDto.decode(readValue(buffer)!);
+      case 204:
         return WalkingDoubleSupportPercentageRecordDto.decode(
           readValue(buffer)!,
         );
-      case 204:
-        return WalkingStepLengthRecordDto.decode(readValue(buffer)!);
       case 205:
-        return RunningGroundContactTimeRecordDto.decode(readValue(buffer)!);
+        return WalkingStepLengthRecordDto.decode(readValue(buffer)!);
       case 206:
-        return RunningStrideLengthRecordDto.decode(readValue(buffer)!);
+        return RunningGroundContactTimeRecordDto.decode(readValue(buffer)!);
       case 207:
-        return DistanceActivityRecordDto.decode(readValue(buffer)!);
+        return RunningStrideLengthRecordDto.decode(readValue(buffer)!);
       case 208:
-        return SpeedActivityRecordDto.decode(readValue(buffer)!);
+        return DistanceActivityRecordDto.decode(readValue(buffer)!);
       case 209:
-        return FloorsClimbedRecordDto.decode(readValue(buffer)!);
+        return SpeedActivityRecordDto.decode(readValue(buffer)!);
       case 210:
-        return WheelchairPushesRecordDto.decode(readValue(buffer)!);
+        return FloorsClimbedRecordDto.decode(readValue(buffer)!);
       case 211:
-        return StepsRecordDto.decode(readValue(buffer)!);
+        return WheelchairPushesRecordDto.decode(readValue(buffer)!);
       case 212:
-        return SwimmingStrokesRecordDto.decode(readValue(buffer)!);
+        return StepsRecordDto.decode(readValue(buffer)!);
       case 213:
-        return WeightRecordDto.decode(readValue(buffer)!);
+        return SwimmingStrokesRecordDto.decode(readValue(buffer)!);
       case 214:
-        return BloodPressureRecordDto.decode(readValue(buffer)!);
+        return WeightRecordDto.decode(readValue(buffer)!);
       case 215:
-        return SystolicBloodPressureRecordDto.decode(readValue(buffer)!);
+        return BloodPressureRecordDto.decode(readValue(buffer)!);
       case 216:
-        return DiastolicBloodPressureRecordDto.decode(readValue(buffer)!);
+        return SystolicBloodPressureRecordDto.decode(readValue(buffer)!);
       case 217:
-        return LeanBodyMassRecordDto.decode(readValue(buffer)!);
+        return DiastolicBloodPressureRecordDto.decode(readValue(buffer)!);
       case 218:
-        return HeightRecordDto.decode(readValue(buffer)!);
+        return LeanBodyMassRecordDto.decode(readValue(buffer)!);
       case 219:
-        return BloodAlcoholContentRecordDto.decode(readValue(buffer)!);
+        return HeightRecordDto.decode(readValue(buffer)!);
       case 220:
-        return BodyFatPercentageRecordDto.decode(readValue(buffer)!);
+        return BloodAlcoholContentRecordDto.decode(readValue(buffer)!);
       case 221:
-        return BodyTemperatureRecordDto.decode(readValue(buffer)!);
+        return BodyFatPercentageRecordDto.decode(readValue(buffer)!);
       case 222:
-        return BasalBodyTemperatureRecordDto.decode(readValue(buffer)!);
+        return BodyTemperatureRecordDto.decode(readValue(buffer)!);
       case 223:
-        return SleepingWristTemperatureRecordDto.decode(readValue(buffer)!);
+        return BasalBodyTemperatureRecordDto.decode(readValue(buffer)!);
       case 224:
-        return CervicalMucusRecordDto.decode(readValue(buffer)!);
+        return SleepingWristTemperatureRecordDto.decode(readValue(buffer)!);
       case 225:
-        return CyclingPowerRecordDto.decode(readValue(buffer)!);
+        return CervicalMucusRecordDto.decode(readValue(buffer)!);
       case 226:
-        return RunningPowerRecordDto.decode(readValue(buffer)!);
+        return CyclingPowerRecordDto.decode(readValue(buffer)!);
       case 227:
-        return OxygenSaturationRecordDto.decode(readValue(buffer)!);
+        return RunningPowerRecordDto.decode(readValue(buffer)!);
       case 228:
-        return OvulationTestRecordDto.decode(readValue(buffer)!);
+        return OxygenSaturationRecordDto.decode(readValue(buffer)!);
       case 229:
-        return PregnancyTestRecordDto.decode(readValue(buffer)!);
+        return OvulationTestRecordDto.decode(readValue(buffer)!);
       case 230:
-        return PregnancyRecordDto.decode(readValue(buffer)!);
+        return PregnancyTestRecordDto.decode(readValue(buffer)!);
       case 231:
-        return ContraceptiveRecordDto.decode(readValue(buffer)!);
+        return PregnancyRecordDto.decode(readValue(buffer)!);
       case 232:
-        return ProgesteroneTestRecordDto.decode(readValue(buffer)!);
+        return ContraceptiveRecordDto.decode(readValue(buffer)!);
       case 233:
-        return IntermenstrualBleedingRecordDto.decode(readValue(buffer)!);
+        return ProgesteroneTestRecordDto.decode(readValue(buffer)!);
       case 234:
-        return MenstrualFlowRecordDto.decode(readValue(buffer)!);
+        return IntermenstrualBleedingRecordDto.decode(readValue(buffer)!);
       case 235:
-        return RespiratoryRateRecordDto.decode(readValue(buffer)!);
+        return MenstrualFlowRecordDto.decode(readValue(buffer)!);
       case 236:
-        return ElectrodermalActivityRecordDto.decode(readValue(buffer)!);
+        return RespiratoryRateRecordDto.decode(readValue(buffer)!);
       case 237:
-        return HydrationRecordDto.decode(readValue(buffer)!);
+        return ElectrodermalActivityRecordDto.decode(readValue(buffer)!);
       case 238:
-        return InsulinDeliveryRecordDto.decode(readValue(buffer)!);
+        return HydrationRecordDto.decode(readValue(buffer)!);
       case 239:
-        return InhalerUsageRecordDto.decode(readValue(buffer)!);
+        return InsulinDeliveryRecordDto.decode(readValue(buffer)!);
       case 240:
-        return HeartRateMeasurementDto.decode(readValue(buffer)!);
+        return InhalerUsageRecordDto.decode(readValue(buffer)!);
       case 241:
-        return HeartRateRecordDto.decode(readValue(buffer)!);
+        return HeartRateMeasurementDto.decode(readValue(buffer)!);
       case 242:
-        return CyclingPedalingCadenceRecordDto.decode(readValue(buffer)!);
+        return HeartRateRecordDto.decode(readValue(buffer)!);
       case 243:
-        return HeartRateRecoveryOneMinuteRecordDto.decode(readValue(buffer)!);
+        return CyclingPedalingCadenceRecordDto.decode(readValue(buffer)!);
       case 244:
-        return SleepStageRecordDto.decode(readValue(buffer)!);
+        return HeartRateRecoveryOneMinuteRecordDto.decode(readValue(buffer)!);
       case 245:
-        return SexualActivityRecordDto.decode(readValue(buffer)!);
+        return SleepStageRecordDto.decode(readValue(buffer)!);
       case 246:
-        return DietaryEnergyConsumedRecordDto.decode(readValue(buffer)!);
+        return SexualActivityRecordDto.decode(readValue(buffer)!);
       case 247:
-        return DietaryCaffeineRecordDto.decode(readValue(buffer)!);
+        return DietaryEnergyConsumedRecordDto.decode(readValue(buffer)!);
       case 248:
-        return DietaryProteinRecordDto.decode(readValue(buffer)!);
+        return DietaryCaffeineRecordDto.decode(readValue(buffer)!);
       case 249:
-        return DietaryTotalCarbohydrateRecordDto.decode(readValue(buffer)!);
+        return DietaryProteinRecordDto.decode(readValue(buffer)!);
       case 250:
-        return DietaryTotalFatRecordDto.decode(readValue(buffer)!);
+        return DietaryTotalCarbohydrateRecordDto.decode(readValue(buffer)!);
       case 251:
-        return DietarySaturatedFatRecordDto.decode(readValue(buffer)!);
+        return DietaryTotalFatRecordDto.decode(readValue(buffer)!);
       case 252:
-        return DietaryMonounsaturatedFatRecordDto.decode(readValue(buffer)!);
+        return DietarySaturatedFatRecordDto.decode(readValue(buffer)!);
       case 253:
-        return DietaryPolyunsaturatedFatRecordDto.decode(readValue(buffer)!);
+        return DietaryMonounsaturatedFatRecordDto.decode(readValue(buffer)!);
       case 254:
-        return DietaryCholesterolRecordDto.decode(readValue(buffer)!);
+        return DietaryPolyunsaturatedFatRecordDto.decode(readValue(buffer)!);
       case 255:
         final _PigeonCodecOverflow wrapper = _PigeonCodecOverflow.decode(
           readValue(buffer)!,

--- a/packages/health_connector_hk_ios/pigeon/health_connector_hk_ios_api.dart
+++ b/packages/health_connector_hk_ios/pigeon/health_connector_hk_ios_api.dart
@@ -1149,6 +1149,9 @@ enum HealthDataTypeDto {
 
   /// Headphone audio exposure event data.
   headphoneAudioExposureEvent,
+
+  /// Apple Stand Hour data.
+  appleStandHour,
 }
 
 /// Sealed class for all health record DTOs.
@@ -5223,6 +5226,50 @@ class NumberOfTimesFallenRecordDto extends HealthRecordDto {
 
   /// The number of times fallen (count).
   final double count;
+
+  /// Timezone offset in seconds for start time.
+  final int? startZoneOffsetSeconds;
+
+  /// Timezone offset in seconds for end time.
+  final int? endZoneOffsetSeconds;
+}
+
+/// Whether the user completed the Stand or Roll goal during an hour.
+enum AppleStandHourStatusDto {
+  /// The user stood or rolled and moved for at least one continuous minute.
+  stood,
+
+  /// The user did not stand or roll and move for at least one continuous
+  /// minute.
+  idle,
+}
+
+/// Represents an Apple Stand Hour record for platform transfer.
+class AppleStandHourRecordDto extends HealthRecordDto {
+  AppleStandHourRecordDto({
+    required this.id,
+    required this.startTime,
+    required this.endTime,
+    required this.metadata,
+    required this.status,
+    this.startZoneOffsetSeconds,
+    this.endZoneOffsetSeconds,
+  });
+
+  /// Platform-assigned unique identifier.
+  final String? id;
+
+  /// Start time in milliseconds since epoch (UTC).
+  final int startTime;
+
+  /// End time in milliseconds since epoch (UTC).
+  final int endTime;
+
+  /// Metadata about this record.
+  final MetadataDto metadata;
+
+  /// Whether the Stand or Roll goal was completed during this hour.
+  final AppleStandHourStatusDto status;
 
   /// Timezone offset in seconds for start time.
   final int? startZoneOffsetSeconds;

--- a/packages/health_connector_hk_ios/test/unit_tests/src/mappers/health_data_type_mapper_test.dart
+++ b/packages/health_connector_hk_ios/test/unit_tests/src/mappers/health_data_type_mapper_test.dart
@@ -27,6 +27,10 @@ void main() {
                 HealthDataType.walkingRunningDistance,
               ],
               [HealthDataTypeDto.floorsClimbed, HealthDataType.floorsClimbed],
+              [
+                HealthDataTypeDto.appleStandHour,
+                HealthDataType.appleStandHour,
+              ],
               [HealthDataTypeDto.height, HealthDataType.height],
               [HealthDataTypeDto.hydration, HealthDataType.hydration],
               [HealthDataTypeDto.leanBodyMass, HealthDataType.leanBodyMass],
@@ -238,6 +242,10 @@ void main() {
                 HealthDataTypeDto.walkingRunningDistance,
               ],
               [HealthDataType.floorsClimbed, HealthDataTypeDto.floorsClimbed],
+              [
+                HealthDataType.appleStandHour,
+                HealthDataTypeDto.appleStandHour,
+              ],
               [HealthDataType.height, HealthDataTypeDto.height],
               [HealthDataType.hydration, HealthDataTypeDto.hydration],
               [HealthDataType.leanBodyMass, HealthDataTypeDto.leanBodyMass],

--- a/packages/health_connector_hk_ios/test/unit_tests/src/mappers/health_record_mappers/activity/apple_stand_hour_record_mapper_test.dart
+++ b/packages/health_connector_hk_ios/test/unit_tests/src/mappers/health_record_mappers/activity/apple_stand_hour_record_mapper_test.dart
@@ -1,0 +1,50 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:health_connector_core/health_connector_core.dart';
+import 'package:health_connector_hk_ios/src/mappers/health_record_mappers/activity/apple_stand_hour_record_mapper.dart';
+import 'package:health_connector_hk_ios/src/pigeon/health_connector_hk_ios_api.g.dart';
+import 'package:parameterized_test/parameterized_test.dart';
+
+import '../../../../utils/fake_data.dart';
+
+void main() {
+  group('AppleStandHourRecordDtoToDomain', () {
+    parameterizedTest(
+      'maps every stand-hour status',
+      [
+        [AppleStandHourStatusDto.stood, AppleStandHourStatus.stood],
+        [AppleStandHourStatusDto.idle, AppleStandHourStatus.idle],
+      ],
+      (AppleStandHourStatusDto dtoStatus, AppleStandHourStatus domainStatus) {
+        // Given
+        final dto = AppleStandHourRecordDto(
+          id: FakeData.fakeId,
+          startTime: FakeData.fakeStartTime.millisecondsSinceEpoch,
+          endTime: FakeData.fakeEndTime.millisecondsSinceEpoch,
+          metadata: MetadataDto(
+            dataOrigin: FakeData.fakeDataOrigin,
+            recordingMethod: RecordingMethodDto.automaticallyRecorded,
+            deviceType: DeviceTypeDto.watch,
+          ),
+          status: dtoStatus,
+          startZoneOffsetSeconds: 7200,
+          endZoneOffsetSeconds: 7200,
+        );
+
+        // When
+        final record = dto.toDomain();
+
+        // Then
+        expect(record.id.value, FakeData.fakeId);
+        expect(record.startTime, FakeData.fakeStartTime);
+        expect(record.endTime, FakeData.fakeEndTime);
+        expect(record.status, domainStatus);
+        expect(record.startZoneOffsetSeconds, 7200);
+        expect(record.endZoneOffsetSeconds, 7200);
+        expect(
+          record.metadata.dataOrigin?.packageName,
+          FakeData.fakeDataOrigin,
+        );
+      },
+    );
+  });
+}

--- a/webapp/SUPPORTED_HEALTH_DATA_TYPES.yml
+++ b/webapp/SUPPORTED_HEALTH_DATA_TYPES.yml
@@ -224,6 +224,18 @@
     url: https://developer.apple.com/documentation/healthkit/hkquantitytypeidentifier/applestandtime
   category: Activity
   group: General Activity
+- name: Apple Stand Hour
+  description: Hourly status indicating whether the Stand or Roll goal was met
+  constant: HealthDataType.appleStandHour
+  aggregations:
+  - Sum
+  android: false
+  ios: true
+  iosApi:
+    label: HKCategoryTypeIdentifier.appleStandHour
+    url: https://developer.apple.com/documentation/healthkit/hkcategorytypeidentifier/applestandhour
+  category: Activity
+  group: General Activity
 - name: Distance (generic)
   description: Generic distance traveled
   constant: HealthDataType.distance


### PR DESCRIPTION
## Summary

- add `HealthDataType.appleStandHour` and the read-only record/status model
- map Apple Stand Hour permissions and reads through Pigeon and HealthKit
- support sum aggregation of achieved Stand or Roll hours
- add explicit Android unsupported handling, toolbox UI, tests, and documentation
- keep HealthKit diagnostic context free of user dates and category values

Closes #217

## Validation

- `melos run test:dart --no-select`
- `melos run analyze:dart --no-select`
- `melos run format:dart:check --no-select`
- `melos run format:swift:check`
- `melos run analyze:swift` (0 violations; baseline unchanged)
- `xcodebuild test -workspace Runner.xcworkspace -scheme Runner -destination 'platform=iOS Simulator,id=C202E40E-462A-4960-BC02-4EF1BCF25D8F' CODE_SIGNING_ALLOWED=NO` (6 passed)
- `fvm flutter build ios --simulator --debug --no-codesign`
- parsed `webapp/SUPPORTED_HEALTH_DATA_TYPES.yml`

## Known check gaps

- `melos run analyze:dart:strict --no-select` reports five existing info-level findings in `health_connector_core` under the system Dart SDK.
- `melos run analyze:md` could not run because `markdownlint` is not installed.
